### PR TITLE
Change draft's unit tests and field name

### DIFF
--- a/db/migrations/20181203235900_create_audio_draft_table.js
+++ b/db/migrations/20181203235900_create_audio_draft_table.js
@@ -10,7 +10,7 @@ exports.up = function(knex, Promise) {
       .unsigned()
       .notNullable()
     t.string('title').notNullable()
-    t.string('s3_path').notNullable()
+    t.string('path').notNullable()
     t.timestamp('created_at').defaultTo(knex.fn.now())
     t.timestamp('updated_at').defaultTo(knex.fn.now())
 

--- a/db/seeds/13_audio_draft.js
+++ b/db/seeds/13_audio_draft.js
@@ -9,19 +9,19 @@ exports.seed = function(knex, Promise) {
           uuid: '00000000-0000-0000-0000-000000000001',
           author_id: '1',
           title: 'Audio 1',
-          s3_path: 'S3 path'
+          path: 'S3 path'
         },
         {
           uuid: '00000000-0000-0000-0000-000000000002',
           author_id: '2',
           title: 'Audio 2',
-          s3_path: 'S3 path'
+          path: 'S3 path'
         },
         {
           uuid: '00000000-0000-0000-0000-000000000003',
           author_id: '3',
           title: 'Audio 3',
-          s3_path: 'S3 path'
+          path: 'S3 path'
         }
       ])
     })

--- a/schema.graphql
+++ b/schema.graphql
@@ -76,7 +76,7 @@ type AudioDraft {
   title: String
   mimetype: String!
   encoding: String!
-  s3Path: String!
+  path: String!
   createdAt: DateTime!
   updatedAt: DateTime!
 }

--- a/src/connectors/__test__/draftService.test.ts
+++ b/src/connectors/__test__/draftService.test.ts
@@ -1,5 +1,28 @@
 import { DraftService } from '../draftService'
 
+const draftValidation = {
+  id: expect.any(String),
+  uuid: expect.any(String),
+  authorId: expect.any(String),
+  upstreamId: null,
+  title: expect.any(String),
+  cover: expect.any(String),
+  abstract: expect.any(String),
+  content: expect.any(String),
+  createdAt: expect.any(Date),
+  updatedAt: expect.any(Date)
+}
+
+const audioValidation = {
+  id: expect.any(String),
+  uuid: expect.any(String),
+  authorId: expect.any(String),
+  title: expect.any(String),
+  path: expect.any(String),
+  createdAt: expect.any(Date),
+  updatedAt: expect.any(Date)
+}
+
 const service = new DraftService()
 
 test('countByAuthor', async () => {
@@ -10,34 +33,29 @@ test('countByAuthor', async () => {
 test('findByAuthor', async () => {
   const drafts = await service.findByAuthor(1)
   expect(drafts.length).toBe(1)
-
-  // TODO: Add object property validation
+  expect(drafts[0]).toEqual(expect.objectContaining(draftValidation))
 })
 
 test('findByAuthorInBatch', async () => {
   const drafts = await service.findByAuthorInBatch(1, 0)
   expect(drafts.length).toBe(1)
-
-  // TODO: Add object property validation
+  expect(drafts[0]).toEqual(expect.objectContaining(draftValidation))
 })
 
 test('findAudioDraft', async () => {
   const audios = await service.findAudioDraft(1)
   expect(audios.length).toBe(1)
-
-  // TODO: Add object property validation
+  expect(audios[0]).toEqual(expect.objectContaining(audioValidation))
 })
 
 test('findAudioDraftsByAuthor', async () => {
   const audios = await service.findAudioDraftsByAuthor(1)
   expect(audios.length).toBe(1)
-
-  // TODO: Add object property validation
+  expect(audios[0]).toEqual(expect.objectContaining(audioValidation))
 })
 
 test('findAudioDraftsByAuthorInBatch', async () => {
   const audios = await service.findAudioDraftsByAuthorInBatch(1, 0)
   expect(audios.length).toBe(1)
-
-  // TODO: Add object property validation
+  expect(audios[0]).toEqual(expect.objectContaining(audioValidation))
 })

--- a/src/mutations/draft/createOrEditAudioDraft.ts
+++ b/src/mutations/draft/createOrEditAudioDraft.ts
@@ -13,7 +13,7 @@ const resolver: Resolver = async (
   const data: ItemData = {
     authorId: viewer.id,
     title,
-    s3Path: path
+    path
   }
 
   // Edit an audo draft item

--- a/src/types/draft.ts
+++ b/src/types/draft.ts
@@ -29,7 +29,7 @@ export default /* GraphQL */ `
     uuid: UUID!
     authorId: Int!
     title: String
-    s3Path: String!
+    path: String!
     createdAt: DateTime!
     updatedAt: DateTime!
   }


### PR DESCRIPTION
### Changes: ###

- Add validations for draft unit tests
- Alter field name `s3_path` to `path`