### PR TITLE
Alter recommendation

### DIFF
--- a/src/connectors/articleService.ts
+++ b/src/connectors/articleService.ts
@@ -370,8 +370,8 @@ export class ArticleService extends BaseService {
     limit?: number
     offset?: number
     where?: { [key: string]: any }
-  }) => {
-    const today = await this.knex('article')
+  }) =>
+    this.knex('article')
       .select(
         'article.*',
         'c.updated_at as chose_at',
@@ -384,15 +384,6 @@ export class ArticleService extends BaseService {
       .where(where)
       .offset(offset)
       .limit(limit)
-      .first()
-
-    return {
-      ...today,
-      cover: today.ossCover || today.cover,
-      title: today.ossTitle || today.title,
-      summary: today.ossSummary || today.summary
-    }
-  }
 
   recommendIcymi = async ({
     limit = BATCH_SIZE,

--- a/src/queries/user/recommendation.ts
+++ b/src/queries/user/recommendation.ts
@@ -101,11 +101,18 @@ const resolvers: GQLRecommendationTypeResolver = {
     )
   },
   today: async (_, __, { dataSources: { articleService } }) => {
-    const article = await articleService.recommendToday({
+    const [article] = await articleService.recommendToday({
       offset: 0,
       limit: 1
     })
     return article
+      ? {
+          ...article,
+          cover: article.ossCover || article.cover,
+          title: article.ossTitle || article.title,
+          summary: article.ossSummary || article.summary
+        }
+      : article
   },
   icymi: async ({ id }, { input }, { dataSources: { articleService } }) => {
     const where = id


### PR DESCRIPTION
Method `articleService.recommendToday` is used by FE and OSS, and the use cases are quite different. OSS needs it return data in array otherwise it will break down, but FE only needs one data object. Thus, I pull the FE logic out of the method. 

@guoliu please make sure these changes fit your original design.  ：）

### Changes ###
- Revert `articleService.recommendToday` to previous version
- Pull the FE logic and place it into resolver