### PR TITLE
Allow query all comments

### DIFF
--- a/src/queries/comment/article/comments.ts
+++ b/src/queries/comment/article/comments.ts
@@ -12,9 +12,9 @@ const resolver: ArticleToCommentsResolver = async (
   // resolve sort to order
   const order = sort === 'oldest' ? 'asc' : 'desc'
 
-  // set default for first in forward pagination
+  // set default for first in forward pagination. use 0 for query all.
   // TODO: use "last" for backward pagination
-  if (!rest.before && typeof(first) !== 'number') {
+  if (!rest.before && typeof first !== 'number') {
     first = 10
   }
 


### PR DESCRIPTION
@guoliu 
Since `before` and `after` are being used for specific purposes, let's use first = 0 for query all.