### PR TITLE
Skip trigger a notice if replyToComment is the same as parentComment

### DIFF
--- a/src/mutations/comment/putComment.ts
+++ b/src/mutations/comment/putComment.ts
@@ -193,7 +193,7 @@ const resolver: MutationToPutCommentResolver = async (
     }
 
     // notify the author of replyTo's comment
-    if (replyToComment) {
+    if (replyToComment && replyToComment.id !== parentComment.id) {
       notificationService.trigger({
         event: 'comment_new_reply',
         actorId: viewer.id,


### PR DESCRIPTION
This is a hotfix and merged now for testing.