### PR TITLE
enable `calculateHttpHeaders` for CloudFront caching

### DIFF
--- a/src/routes/graphql.ts
+++ b/src/routes/graphql.ts
@@ -110,7 +110,7 @@ const server = new ProtectedApolloServer({
     cache: redisCache
   },
   cacheControl: {
-    calculateHttpHeaders: false,
+    calculateHttpHeaders: true,
     defaultMaxAge: CACHE_TTL.DEFAULT,
     stripFormattedExtensions: isProd
   },


### PR DESCRIPTION
I merge it now for CDN testing