### PR TITLE
Change asset's structure of path and name.

### DIFF
--- a/src/connectors/aws/index.ts
+++ b/src/connectors/aws/index.ts
@@ -109,8 +109,7 @@ export class AWSService {
 
     const extension =
       mime.extension(mimetype) || upload.filename.split('.').pop()
-    const filename = `asset-${randomString(4)}`
-    const key = `${folder}/${uuid}/${filename}.${extension}`
+    const key = `${folder}/${uuid}.${extension}`
     const result = await this.s3
       .upload({
         Body: buffer,


### PR DESCRIPTION
### Changes
- Alter url structure, and the new url will be `type/uuid.extension`.
- It looks like we already applied removing EXIF from JP(E)G while compressing. Default compress process won't copy any metadata (see [this](https://github.com/imagemin/imagemin-jpegtran/blob/master/index.js#L17)). 🤙