### PR TITLE
Fix OAuth potential bug

### DIFF
--- a/src/connectors/oauthService.ts
+++ b/src/connectors/oauthService.ts
@@ -88,13 +88,14 @@ export class OAuthService extends BaseService {
       .select()
       .where({ token: accessToken })
       .first()
-    const client = (await this.getClientById(token.clientId)) as OAuthClient
-    const userService = new UserService()
-    const user = (await userService.dataloader.load(token.userId)) as User
 
     if (!token) {
       return
     }
+
+    const client = (await this.getClientById(token.clientId)) as OAuthClient
+    const userService = new UserService()
+    const user = (await userService.dataloader.load(token.userId)) as User
 
     return {
       accessToken: token.token,


### PR DESCRIPTION
### Changes ###
- The logic of this code snippet has potential bug. Should first check if `token` exists or not, and then uses `token.clientId` or `token.userId` in the following context. 