### PR TITLE
Update LikeCoin APIs

### DIFF
--- a/src/connectors/likecoin/index.ts
+++ b/src/connectors/likecoin/index.ts
@@ -328,6 +328,7 @@ export class LikeCoin extends BaseService {
     step: number
     userIds?: string[]
   }) => {
+    const MAT_TO_LIKE_RATE = 10
     const userService = new UserService()
     const users = await userService.findNoPendingLIKEUsers({
       limit: step,
@@ -337,7 +338,7 @@ export class LikeCoin extends BaseService {
     // normalize users for request body
     const normalizedUsers = users.map(({ mat: MAT, likerId }) => ({
       likerId,
-      pendingLIKE: MAT
+      pendingLIKE: MAT * MAT_TO_LIKE_RATE
     }))
 
     if (normalizedUsers.length <= 0) {

--- a/src/connectors/userService.ts
+++ b/src/connectors/userService.ts
@@ -1017,9 +1017,8 @@ export class UserService extends BaseService {
     // check
     const likerId = await this.likecoin.check({ user: userName })
 
-    const oAuthService = new OAuthService()
-
     // register
+    const oAuthService = new OAuthService()
     const tokens = await oAuthService.generateTokenForLikeCoin({ userId })
     const { accessToken, refreshToken, scope } = await this.likecoin.register({
       user: likerId,
@@ -1037,11 +1036,20 @@ export class UserService extends BaseService {
     })
   }
 
-  claimLikerId = async ({ liker }: { liker: UserOAuthLikeCoin }) => {
+  claimLikerId = async ({
+    userId,
+    liker
+  }: {
+    userId: string
+    liker: UserOAuthLikeCoin
+  }) => {
+    const oAuthService = new OAuthService()
+    const tokens = await oAuthService.generateTokenForLikeCoin({ userId })
+
     await this.likecoin.edit({
       user: liker.likerId,
       action: 'claim',
-      payload: { token: liker.accessToken }
+      payload: { token: tokens.accessToken }
     })
 
     return await this.knex('user_oauth_likecoin')

--- a/src/mutations/user/generateLikerId.ts
+++ b/src/mutations/user/generateLikerId.ts
@@ -27,6 +27,7 @@ const resolver: MutationToGenerateLikerIdResolver = async (
     }
 
     await userService.claimLikerId({
+      userId: viewer.id,
       liker
     })
   }


### PR DESCRIPTION
* Update MAT to LIKE rate (1:10);
* In Claim API, we should use Matters issue's access token instead of like.co issue's