### PR TITLE
Pass URL as like referrer instead of encoded URL (ask by LikeCoin team).

### DIFF
--- a/src/connectors/likecoin/index.ts
+++ b/src/connectors/likecoin/index.ts
@@ -394,7 +394,7 @@ export class LikeCoin {
         method: 'POST',
         liker,
         data: {
-          referrer: encodeURIComponent(url)
+          referrer: url
         }
       })
       const data = _.get(result, 'data')


### PR DESCRIPTION
As tile.