### PR TITLE
Public "liker.civicLiker" and "liker.rateUSD"

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -722,7 +722,7 @@ type LIKE {
 
 type Liker {
   """Liker ID of LikeCoin"""
-  id: String
+  likerId: String
 
   """Whether liker is a civic liker"""
   civicLiker: Boolean!

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -378,7 +378,7 @@ export interface GQLLiker {
   /**
    * Liker ID of LikeCoin
    */
-  id?: string
+  likerId?: string
 
   /**
    * Whether liker is a civic liker
@@ -3481,13 +3481,13 @@ export interface UserToNoticesResolver<TParent = any, TResult = any> {
 }
 
 export interface GQLLikerTypeResolver<TParent = any> {
-  id?: LikerToIdResolver<TParent>
+  likerId?: LikerToLikerIdResolver<TParent>
   civicLiker?: LikerToCivicLikerResolver<TParent>
   total?: LikerToTotalResolver<TParent>
   rateUSD?: LikerToRateUSDResolver<TParent>
 }
 
-export interface LikerToIdResolver<TParent = any, TResult = any> {
+export interface LikerToLikerIdResolver<TParent = any, TResult = any> {
   (
     parent: TParent,
     args: {},

--- a/src/queries/user/liker/index.ts
+++ b/src/queries/user/liker/index.ts
@@ -4,7 +4,7 @@ import rateUSD from './rateUSD'
 import total from './total'
 
 export default {
-  id: likerId,
+  likerId,
   civicLiker,
   total,
   rateUSD

--- a/src/queries/user/liker/likerId.ts
+++ b/src/queries/user/liker/likerId.ts
@@ -1,7 +1,7 @@
 import { environment } from 'common/environment'
-import { LikerToIdResolver } from 'definitions'
+import { LikerToLikerIdResolver } from 'definitions'
 
-const resolver: LikerToIdResolver = async (
+const resolver: LikerToLikerIdResolver = async (
   { likerId },
   _,
   { viewer, dataSources: { userService } }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -264,7 +264,7 @@ export default /* GraphQL */ `
 
   type Liker {
     "Liker ID of LikeCoin"
-    id: String @scope
+    likerId: String @scope
 
     "Whether liker is a civic liker"
     civicLiker: Boolean!


### PR DESCRIPTION
* Public "liker.civicLiker" and "liker.rateUSD"
* Rename "liker.id" to "liker.likerId" due to `id` will automatically as cache key in Apollo Client