### PR TITLE
Use proper create and update time instead of default value.

### DIFF
--- a/db/migrations/20200220061530_migrate_article_read.js
+++ b/db/migrations/20200220061530_migrate_article_read.js
@@ -4,7 +4,7 @@ const uuid = require('uuid')
 const source = 'article_read'
 const target = 'article_read_count'
 
-const size = 300
+const size = 500
 
 exports.up = async knex => {
   const querySource = knex(source)


### PR DESCRIPTION
### Changes

- Size up the batch size
- Replace default date time with proper create and update time from `article_read`