### PR TITLE
Fix typo when sending migration success email.

### DIFF
--- a/src/connectors/notificationService/mail.ts
+++ b/src/connectors/notificationService/mail.ts
@@ -360,7 +360,7 @@ class Mail {
           // @ts-ignore
           dynamic_template_data: {
             subject: trans.migration(language, {}),
-            siteDomin: environment.siteDomain,
+            siteDomain: environment.siteDomain,
             recipient
           }
         }


### PR DESCRIPTION
As title.