### PR TITLE
Add segment snippet to html on ipfs

### DIFF
--- a/src/connectors/ipfs/index.ts
+++ b/src/connectors/ipfs/index.ts
@@ -85,13 +85,9 @@ export class IPFS {
     })
 
     // add segment
-    $('head').append(`
-    <script>
-      !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
-      analytics.load("Q61o0JYbkuY6xmL5x6ViRThCrLaDEUpL");
-      analytics.page();
-      }}();
-    </script>`)
+    $('head').append(
+      `<script type="text/javascript" src="//static.matters.news/analytics.js"></script>`
+    )
 
     const assets = await Promise.all(assetsPromises)
 


### PR DESCRIPTION
Updated 03/18:

Analytic script is moved to s3 under bucket `matters-public-files`, with domain `static.matters.news`. 


----
As title.

Note: 

The segment token used here is generated for IPFS, and different from matters.news. I think we can hard code it and share between test and production environment, instead of storing it in environment variables. Page view data will have some numbers from testing environment, but minimal and won't affect analytics much, since this data is also secondary. We also don't have any need of changing segment token, so storing it in environment variables seems redundant.