### PR TITLE
[hotfix - master] Fix `findLost` for type = `new-register`

### DIFF
--- a/src/connectors/userService.ts
+++ b/src/connectors/userService.ts
@@ -1514,16 +1514,8 @@ export class UserService extends BaseService {
           '>=',
           this.knex.raw(`now() -  interval '30 days'`)
         )
+        .where('last_read', '<', this.knex.raw(`now() -  interval '7 days'`))
         .whereNotIn('user.state', [USER_STATE.archived, USER_STATE.banned])
-        .where((builder) =>
-          builder
-            .whereNull('last_read')
-            .orWhere(
-              'last_read',
-              '<',
-              this.knex.raw(`now() -  interval '7 days'`)
-            )
-        )
         .whereNull('sent_record.type')
     }
 


### PR DESCRIPTION
Based on the definition of churn users:

> 對象定義：註冊一個月內，連續七天沒有閱讀文章記錄的用戶，會在第八天收到這封召回信。每位用戶只發送一次，該用戶就算有第二個「七天未閱讀文章」的記錄，也不發送第二次。

The query result shouldn't contain users that haven't read any article.