### PR TITLE
Hotfix: add input to translation

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -136,6 +136,9 @@ type Article implements Node {
   """Content of this article."""
   content: String!
 
+  """Original language of content"""
+  language: String
+
   """List of articles which added this article into their collections."""
   collectedBy(input: ConnectionArgs!): ArticleConnection!
 
@@ -172,7 +175,7 @@ type Article implements Node {
   sticky: Boolean!
 
   """Translation of article title and content."""
-  translation: ArticleTranslation
+  translation(input: TranslationArgs): ArticleTranslation
 
   """Transactions history of this article."""
   transactionsReceivedBy(input: TransactionsReceivedByArgs!): UserConnection!
@@ -438,8 +441,9 @@ type ArticleTagHasBeenUnselectedNotice implements Notice {
   tag: Tag
 }
 
+"""@objectCache(maxAge: 864000)"""
 type ArticleTranslation {
-  originalLanguage: String!
+  originalLanguage: String! @deprecated(reason: "Use `Article.language` instead")
   title: String!
   content: String!
 }
@@ -1934,6 +1938,10 @@ enum TransactionState {
 }
 
 union TransactionTarget = Article | Transaction
+
+input TranslationArgs {
+  language: UserLanguage!
+}
 
 input UnpinCommentInput {
   id: ID!

--- a/src/connectors/gcp/index.ts
+++ b/src/connectors/gcp/index.ts
@@ -12,10 +12,14 @@ class GCP {
   translateAPI: TranslateAPI.Translate
 
   constructor() {
-    this.translateAPI = new TranslateAPI.Translate({
-      projectId: environment.gcpProjectId,
-      keyFilename: environment.translateCertPath,
-    })
+    try {
+      this.translateAPI = new TranslateAPI.Translate({
+        projectId: environment.gcpProjectId,
+        keyFilename: environment.translateCertPath,
+      })
+    } catch (err) {
+      logger.error(err)
+    }
   }
 
   // map to internal language

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -117,6 +117,11 @@ export interface GQLArticle extends GQLNode {
   content: string
 
   /**
+   * Original language of content
+   */
+  language?: string
+
+  /**
    * List of articles which added this article into their collections.
    */
   collectedBy: GQLArticleConnection
@@ -1382,7 +1387,18 @@ export interface GQLStripeAccount {
   loginUrl: GQLURL
 }
 
+export interface GQLTranslationArgs {
+  language: GQLUserLanguage
+}
+
+/**
+ * @objectCache(maxAge: 864000)
+ */
 export interface GQLArticleTranslation {
+  /**
+   *
+   * @deprecated Use `Article.language` instead
+   */
   originalLanguage: string
   title: string
   content: string
@@ -3338,6 +3354,7 @@ export interface GQLArticleTypeResolver<TParent = any> {
   dataHash?: ArticleToDataHashResolver<TParent>
   mediaHash?: ArticleToMediaHashResolver<TParent>
   content?: ArticleToContentResolver<TParent>
+  language?: ArticleToLanguageResolver<TParent>
   collectedBy?: ArticleToCollectedByResolver<TParent>
   collection?: ArticleToCollectionResolver<TParent>
   relatedArticles?: ArticleToRelatedArticlesResolver<TParent>
@@ -3509,6 +3526,15 @@ export interface ArticleToContentResolver<TParent = any, TResult = any> {
   ): TResult
 }
 
+export interface ArticleToLanguageResolver<TParent = any, TResult = any> {
+  (
+    parent: TParent,
+    args: {},
+    context: Context,
+    info: GraphQLResolveInfo
+  ): TResult
+}
+
 export interface ArticleToCollectedByArgs {
   input: GQLConnectionArgs
 }
@@ -3635,10 +3661,13 @@ export interface ArticleToStickyResolver<TParent = any, TResult = any> {
   ): TResult
 }
 
+export interface ArticleToTranslationArgs {
+  input?: GQLTranslationArgs
+}
 export interface ArticleToTranslationResolver<TParent = any, TResult = any> {
   (
     parent: TParent,
-    args: {},
+    args: ArticleToTranslationArgs,
     context: Context,
     info: GraphQLResolveInfo
   ): TResult

--- a/src/queries/article/index.ts
+++ b/src/queries/article/index.ts
@@ -12,6 +12,7 @@ import collection from './collection'
 import content from './content'
 import articleCover from './cover'
 import hasAppreciate from './hasAppreciate'
+import language from './language'
 import * as articleOSS from './oss'
 import relatedArticles from './relatedArticles'
 import rootArticle from './rootArticle'
@@ -22,7 +23,7 @@ import * as tagOSS from './tag/oss'
 import tagSelected from './tag/selected'
 import tags from './tags'
 import transactionsReceivedBy from './transactionsReceivedBy'
-import ArticleTranslation from './translation'
+import translation from './translation'
 import userArticles from './user/articles'
 
 export default {
@@ -44,6 +45,7 @@ export default {
     collectedBy,
     id: ({ id }: { id: string }) => toGlobalId({ type: 'Article', id }),
     hasAppreciate,
+    language,
     oss: (root: any) => root,
     relatedArticles,
     slug: ({ slug, title }: { slug: string; title: string }) =>
@@ -58,12 +60,11 @@ export default {
       content: string
     }) => makeSummary(articleContent, cover ? 110 : 140),
     tags,
-    translation: (root: any) => root,
+    translation,
     topicScore: ({ topicScore }: { topicScore: number }) =>
       topicScore ? Math.round(topicScore) : null,
     transactionsReceivedBy,
   },
-  ArticleTranslation,
   Tag: {
     id: ({ id }: { id: string }) => toGlobalId({ type: 'Tag', id }),
     articles: tagArticles,

--- a/src/queries/article/language.ts
+++ b/src/queries/article/language.ts
@@ -1,0 +1,9 @@
+import { ArticleToLanguageResolver } from 'definitions'
+
+const resolver: ArticleToLanguageResolver = (
+  { content },
+  _,
+  { dataSources: { articleService } }
+) => articleService.detectLanguage(content)
+
+export default resolver

--- a/src/queries/article/translation.ts
+++ b/src/queries/article/translation.ts
@@ -1,23 +1,24 @@
-import { GQLArticleTranslationTypeResolver } from 'definitions'
+import { ArticleToTranslationResolver } from 'definitions'
 
-const resolver: GQLArticleTranslationTypeResolver = {
-  originalLanguage: async (
-    { content },
-    _,
-    { dataSources: { articleService } }
-  ) => articleService.detectLanguage(content),
+const resolver: ArticleToTranslationResolver = (
+  { content, title },
+  { input },
+  { dataSources: { articleService }, viewer }
+) => ({
+  // deprecated
+  originalLanguage: () => articleService.detectLanguage(content),
 
-  title: async (
-    { title },
-    _,
-    { dataSources: { articleService }, viewer: { language } }
-  ) => articleService.translate({ content: title, target: language }),
+  title: () =>
+    articleService.translate({
+      content: title,
+      target: input ? input.language : viewer.language,
+    }),
 
-  content: async (
-    { content },
-    _,
-    { dataSources: { articleService }, viewer: { language } }
-  ) => articleService.translate({ content, target: language }),
-}
+  content: () =>
+    articleService.translate({
+      content,
+      target: input ? input.language : viewer.language,
+    }),
+})
 
 export default resolver

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -119,6 +119,9 @@ export default /* GraphQL */ `
     "Content of this article."
     content: String!
 
+    "Original language of content"
+    language: String # @objectCache(maxAge: ${CACHE_TTL.STATIC})
+
     "List of articles which added this article into their collections."
     collectedBy(input: ConnectionArgs!): ArticleConnection!
 
@@ -153,7 +156,7 @@ export default /* GraphQL */ `
     sticky: Boolean!
 
     "Translation of article title and content."
-    translation: ArticleTranslation
+    translation(input: TranslationArgs): ArticleTranslation
 
     "Transactions history of this article."
     transactionsReceivedBy(input: TransactionsReceivedByArgs!): UserConnection!
@@ -203,8 +206,9 @@ export default /* GraphQL */ `
     inRecommendNewest: Boolean! @authorize
   }
 
-  type ArticleTranslation @objectCache(maxAge: ${CACHE_TTL.STATIC}) {
-    originalLanguage: String!
+# @objectCache(maxAge: ${CACHE_TTL.STATIC})
+  type ArticleTranslation  {
+    originalLanguage: String! @deprecated(reason: "Use \`Article.language\` instead")
     title: String!
     content: String!
   }
@@ -354,6 +358,10 @@ export default /* GraphQL */ `
     after: String
     first: Int
     purpose: TransactionPurpose!
+  }
+
+  input TranslationArgs {
+    language: UserLanguage!
   }
 
   "Enums for an article state."

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,6 +13,7 @@ const Root = /* GraphQL */ `
   type Query
   type Mutation
   type Subscription
+
   schema {
     query: Query
     mutation: Mutation


### PR DESCRIPTION
Currently we use user language setting internally to determine what translation we should return. However, APQ layer couldn't differentiate among different languages and result in wrong cache. This PR adds language as argument for translation, so APQ layer can cache different language separately. 