### PR TITLE
ci(deployment): skip waiting for eb deployment in dev env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -152,6 +152,7 @@ jobs:
           region: ap-southeast-1
           deployment_package: deploy.zip
           use_existing_version_if_available: true
+          wait_for_deployment: false
       # === [END] `develop` branch ===
 
       # === `master` branch ===


### PR DESCRIPTION
This change could save some runner minutes.