### PR TITLE
feat(upload): remove support for SVG file

### DIFF
--- a/src/common/enums.ts
+++ b/src/common/enums.ts
@@ -486,7 +486,6 @@ export const ACCEPTED_UPLOAD_IMAGE_TYPES: string[] = [
   'image/gif',
   'image/png',
   'image/jpeg',
-  'image/svg+xml',
   'image/webp',
 ]
 


### PR DESCRIPTION
SVG file can't be correctly processed by `thematters/serverless-file-post-processing`