### PR TITLE
fix(cache): make `Draft.id` uncacheable

### DIFF
--- a/src/types/draft.ts
+++ b/src/types/draft.ts
@@ -14,7 +14,7 @@ export default /* GraphQL */ `
   """
   type Draft implements Node @cacheControl(maxAge: ${CACHE_TTL.INSTANT}) {
     "Unique ID of this draft."
-    id: ID!
+    id: ID! @cacheControl(maxAge: ${CACHE_TTL.INSTANT})
 
     "Collection list of this draft."
     collection(input: ConnectionArgs!): ArticleConnection!


### PR DESCRIPTION
Since our web client will query from `node`, previous [changes](https://github.com/thematters/matters-server/commit/77e1cc9fe10c48a8567ab02d2bfac7f3589bbc4c#diff-c5622d8b010cdd90a490ee874366ba6dR15) won't work as expected. 