### PR TITLE
feat(error): add one more error type for forbidden error

### DIFF
--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -82,6 +82,14 @@ export class ForbiddenError extends ApolloError {
   }
 }
 
+export class ForbiddenByStateError extends ApolloError {
+  constructor(message: string) {
+    super(message, 'FORBIDDEN_BY_STATE')
+
+    Object.defineProperty(this, 'name', { value: 'ForbiddenByStateError' })
+  }
+}
+
 export class TokenInvalidError extends ApolloError {
   constructor(message: string) {
     super(message, 'TOKEN_INVALID')


### PR DESCRIPTION
Currently, we has one `ForbiddenError` that covers various forbidden situations. For example: visitor and banned users are based on different permission types, but we always return `ForbiddenError` if they are not permitted to do something. Besides, front-end catch it and toast message with login button (a bit weird to a registered user). Therefore, add one more forbidden error to distinguish the differences.