### PR TITLE
Fix article-draft relationship

### DIFF
--- a/db/migrations/20200924152927_fix_article_draft_relationship.js
+++ b/db/migrations/20200924152927_fix_article_draft_relationship.js
@@ -7,7 +7,7 @@ const article_tag_table = 'article_tag'
 const tag_table = 'tag'
 const collection_table = 'collection'
 
-const CHUNK_SIZE = 50
+const CHUNK_SIZE = 10
 const REMARK = '{20200924152927_fix_article_draft_relationship,}'
 
 exports.up = async (knex) => {

--- a/db/migrations/20200924152927_fix_article_draft_relationship.js
+++ b/db/migrations/20200924152927_fix_article_draft_relationship.js
@@ -50,7 +50,6 @@ exports.up = async (knex) => {
           .insert({
             uuid: uuidv4(),
             author_id: item.author_id,
-            upstream_id: item.upstream_id,
             title: item.title,
             cover: item.cover,
             summary: item.summary,

--- a/db/migrations/20200924152927_fix_article_draft_relationship.js
+++ b/db/migrations/20200924152927_fix_article_draft_relationship.js
@@ -1,0 +1,78 @@
+const chunk = require('lodash/chunk')
+const { v4: uuidv4 } = require('uuid')
+
+const article_table = 'article'
+const draft_table = 'draft'
+const article_tag_table = 'article_tag'
+const tag_table = 'tag'
+const collection_table = 'collection'
+
+const CHUNK_SIZE = 50
+const REMARK = '{20200924152927_fix_article_draft_relationship,}'
+
+exports.up = async (knex) => {
+  // Gather articles without `draft_id`
+  const articles = await knex(article_table).select('id').whereNull('draft_id')
+  const chunks = chunk(articles, CHUNK_SIZE)
+
+  for (const ids of chunks) {
+    // Gather articles with all fields
+    const items = await knex(article_table)
+      .select()
+      .whereIn(
+        'id',
+        ids.map(({ id }) => id)
+      )
+
+    // Create a draft based on the article, then update `draft_id`
+    await Promise.all(
+      items.map(async (item) => {
+        // gather tags
+        const tagIds = (
+          await knex(article_tag_table)
+            .select('tag_id')
+            .where({ article_id: item.id })
+        ).map(({ tag_id }) => tag_id)
+        const tags = (
+          await knex(tag_table).select('content').whereIn('id', tagIds)
+        ).map(({ content }) => content)
+
+        // gather collection
+        const collection = (
+          await knex(collection_table)
+            .select('article_id')
+            .where({ entrance_id: item.id })
+            .orderBy('order')
+        ).map(({ articleId }) => articleId)
+
+        // create draft
+        const [draft] = await knex(draft_table)
+          .insert({
+            uuid: uuidv4(),
+            author_id: item.author_id,
+            upstream_id: item.upstream_id,
+            title: item.title,
+            cover: item.cover,
+            summary: item.summary,
+            content: item.content,
+            created_at: item.created_at,
+            updated_at: item.created_at, // use created_at
+            archived: false,
+            publish_state: 'published',
+            tags: tags.length > 0 ? tags : null,
+            collection: collection.length > 0 ? collection : null,
+          })
+          .returning(['id'])
+        console.log(`draft: ${draft.id}, inserted`)
+
+        // update article
+        await knex(article_table)
+          .where({ id: item.id })
+          .update({ draft_id: draft.id, remark: REMARK })
+        console.log(`article: ${item.id}, updated`)
+      })
+    )
+  }
+}
+
+exports.down = async (knex) => {}

--- a/src/connectors/articleService.ts
+++ b/src/connectors/articleService.ts
@@ -60,19 +60,6 @@ export class ArticleService extends BaseService {
   }
 
   /**
-   * Create a new article item.
-   */
-  create = async (articleData: ItemData & { content: string }) => {
-    // craete article
-    const article = await this.baseCreate({
-      uuid: v4(),
-      wordCount: countWords(articleData.content),
-      ...articleData,
-    })
-    return article
-  }
-
-  /**
    * Publish an article to IPFS
    */
   publish = async ({
@@ -87,6 +74,7 @@ export class ArticleService extends BaseService {
   }) => {
     const userService = new UserService()
     const systemService = new SystemService()
+
     // prepare metadata
     const author = await userService.dataloader.load(authorId)
     const now = new Date()
@@ -142,11 +130,13 @@ export class ArticleService extends BaseService {
     })
     const mediaHash = cid.toBaseEncodedString()
 
-    // edit db record
-    const article = await this.create({
+    // craete article
+    const article = await this.baseCreate({
+      uuid: v4(),
       authorId,
       title,
       slug: slugify(title),
+      wordCount: countWords(content),
       summary,
       content,
       cover,

--- a/src/connectors/draftService.ts
+++ b/src/connectors/draftService.ts
@@ -1,5 +1,6 @@
 import DataLoader from 'dataloader'
 
+import { PUBLISH_STATE } from 'common/enums'
 import { BaseService } from 'connectors'
 
 export class DraftService extends BaseService {
@@ -47,13 +48,12 @@ export class DraftService extends BaseService {
     })
 
   /**
-   * Find or Delete drafts that aren't linked to articles by a given author id (user).
+   * Find unpublished drafts by a given author id (user).
    */
-  findUnlinkedDraftsByAuthor = (authorId: string) =>
+  findUnpublishedByAuthor = (authorId: string) =>
     this.knex
-      .select('draft.*', 'article.draft_id')
+      .select()
       .from(this.table)
-      .leftOuterJoin('article', 'article.draft_id', 'draft.id')
-      .whereNull('draft_id')
-      .andWhere({ 'draft.author_id': authorId })
+      .where({ authorId })
+      .andWhereNot({ publishState: PUBLISH_STATE.published })
 }

--- a/src/connectors/queue/user.ts
+++ b/src/connectors/queue/user.ts
@@ -81,7 +81,7 @@ class UserQueue extends BaseQueue {
       const { userId } = job.data as ArchiveUserData
 
       // delete unlinked drafts
-      await this.deleteUnlinkedDrafts(userId)
+      await this.deleteUnpublishedDrafts(userId)
       job.progress(50)
 
       // delete assets
@@ -95,10 +95,10 @@ class UserQueue extends BaseQueue {
   }
 
   /**
-   * Delete drafts that aren't linked to articles
+   * Delete unpublished drafts
    */
-  private deleteUnlinkedDrafts = async (authorId: string) => {
-    const drafts = await this.draftService.findUnlinkedDraftsByAuthor(authorId)
+  private deleteUnpublishedDrafts = async (authorId: string) => {
+    const drafts = await this.draftService.findUnpublishedByAuthor(authorId)
     const {
       id: draftEntityTypeId,
     } = await this.systemService.baseFindEntityTypeId('draft')


### PR DESCRIPTION
* Add migration script to fix article-draft relationship [1]
* Delete unpublished instead of unlinked drafts on archive user


**[1]** copy the article without `draft_id` to draft:
Article | Draft | Remark
-- | -- | --
id | id |  
uuid | uuid | generated by `v4()`
author_id | author_id |  
upstream_id | upstream_id | leave it blank, will be dropped
title | title |  
slug |   |  
cover | cover |  
summary | summary |  
word_count |   |  
dash_hash |   |  
media_hash |   |  
content | content |  
state |   |  
public |   |  
live |   |  
created_at | created_at | set to `created_at` of article
updated_at | updated_at | set to `created_at` of article
draft_id |   |  
remark |   |  
sticky |   |  
language |   |  
  | archived | set to `false`
  | publish_state | set to `published`
  | tags | gather from `tag` & `article_tag` tables
  | scheduled_at | set to `null`
  | collection | gather from `collection` table

