### PR TITLE
feat(search api): add `record` boolean to input

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1552,6 +1552,9 @@ input SearchInput {
   after: String
   first: Int
   filter: SearchFilter
+
+  """whether this search operation should be recorded in search history"""
+  record: Boolean
   oss: Boolean
 }
 

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -1554,6 +1554,11 @@ export interface GQLSearchInput {
   after?: string
   first?: number
   filter?: GQLSearchFilter
+
+  /**
+   * whether this search operation should be recorded in search history
+   */
+  record?: boolean
   oss?: boolean
 }
 

--- a/src/queries/system/search.ts
+++ b/src/queries/system/search.ts
@@ -22,7 +22,7 @@ const resolver: QueryToSearchResolver = async (
       : input.key.slice(0, SEARCH_KEY_TRUNCATE_LENGTH)
   }
 
-  if (input.type !== 'User' && input.key) {
+  if (input.key && input.record) {
     systemService.baseCreate(
       { userId: viewer ? viewer.id : null, searchKey: input.key },
       'search_history'

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -152,6 +152,8 @@ export default /* GraphQL */ `
     after: String
     first: Int
     filter: SearchFilter
+    "whether this search operation should be recorded in search history"
+    record: Boolean
     oss: Boolean
   }
 


### PR DESCRIPTION
Add `record` boolean to search input to determine if search key needs to be stored.