### PR TITLE
fix(notice): add await for sending delete article tag notices to avoid duplicate insertion keys

### DIFF
--- a/src/mutations/article/deleteArticlesTags.ts
+++ b/src/mutations/article/deleteArticlesTags.ts
@@ -67,7 +67,7 @@ const resolver: MutationToDeleteArticlesTagsResolver = async (
   // trigger notification for deleting article tag
   deleteIds.forEach(async (articleId: string) => {
     const article = await articleService.baseFindById(articleId)
-    notificationService.trigger({
+    await notificationService.trigger({
       event: 'article_tag_has_been_removed',
       recipientId: article.authorId,
       actorId: viewer.id,


### PR DESCRIPTION
As title.