### PR TITLE
fix(asset): permission checking inside resolver instead of using `@auth`

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -112,7 +112,7 @@ type Article implements Node {
   """Article cover's link."""
   cover: URL
 
-  """List of asstets are belonged to this article."""
+  """List of assets are belonged to this article."""
   assets: [Asset!]!
 
   """A short summary for this article."""
@@ -774,7 +774,7 @@ type Draft implements Node {
   """State of draft during publihsing."""
   publishState: PublishState!
 
-  """List of asstets are belonged to this draft."""
+  """List of assets are belonged to this draft."""
   assets: [Asset!]!
 
   """Published article"""

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -83,7 +83,7 @@ export interface GQLArticle extends GQLNode {
   cover?: GQLURL
 
   /**
-   * List of asstets are belonged to this article.
+   * List of assets are belonged to this article.
    */
   assets: Array<GQLAsset>
 
@@ -1024,7 +1024,7 @@ export interface GQLDraft extends GQLNode {
   publishState: GQLPublishState
 
   /**
-   * List of asstets are belonged to this draft.
+   * List of assets are belonged to this draft.
    */
   assets: Array<GQLAsset>
 

--- a/src/queries/article/assets.ts
+++ b/src/queries/article/assets.ts
@@ -1,10 +1,17 @@
 import { ArticleToAssetsResolver } from 'definitions'
 
 const resolver: ArticleToAssetsResolver = async (
-  { id, articleId },
+  { id, authorId, articleId },
   _,
-  { dataSources: { systemService } }
+  { viewer, dataSources: { systemService } }
 ) => {
+  // Check inside resolver instead of `@auth(mode: "${AUTH_MODE.oauth}")`
+  // since `@auth` now only supports scope starting with `viewer`.
+  const isAuthor = authorId === viewer.id
+  if (!isAuthor) {
+    return []
+  }
+
   // assets belonged to this article
   const { id: articleEntityTypeId } = await systemService.baseFindEntityTypeId(
     'article'

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -91,8 +91,8 @@ export default /* GraphQL */ `
     "Article cover's link."
     cover: URL
 
-    "List of asstets are belonged to this article."
-    assets: [Asset!]! @auth(mode: "${AUTH_MODE.oauth}") @cacheControl(maxAge: ${CACHE_TTL.INSTANT})
+    "List of assets are belonged to this article."
+    assets: [Asset!]! @cacheControl(maxAge: ${CACHE_TTL.INSTANT})
 
     "A short summary for this article."
     summary: String!

--- a/src/types/draft.ts
+++ b/src/types/draft.ts
@@ -49,7 +49,7 @@ export default /* GraphQL */ `
     "State of draft during publihsing."
     publishState: PublishState!
 
-    "List of asstets are belonged to this draft."
+    "List of assets are belonged to this draft."
     assets: [Asset!]!
 
     "Published article"


### PR DESCRIPTION
Check permission inside resolver instead of `@auth(mode: "${AUTH_MODE.oauth}")` since `@auth` now only supports scope starting with `viewer`, which means the root type of the resolver is `User` and `Article.assets` [can't match](https://github.com/thematters/matters-server/blob/develop/src/types/directives/auth.ts#L22).