### PR TITLE
refactor(service): inject knex into context and make a lighter service

### DIFF
--- a/src/common/utils/makeContext.ts
+++ b/src/common/utils/makeContext.ts
@@ -3,6 +3,7 @@ import { Request, Response } from 'express'
 import { cloneDeep } from 'lodash'
 
 import { getViewerFromReq, toGlobalId } from 'common/utils'
+import { knex } from 'connectors'
 import { RequestContext } from 'definitions'
 
 const purgeSentryData = (req?: Request): any => {
@@ -60,5 +61,6 @@ export const makeContext = async ({
     viewer,
     req,
     res,
+    knex,
   }
 }

--- a/src/connectors/atomService.ts
+++ b/src/connectors/atomService.ts
@@ -3,6 +3,7 @@ import DataLoader from 'dataloader'
 import Knex from 'knex'
 
 import { EntityNotFoundError } from 'common/errors'
+import logger from 'common/logger'
 import { aws, es, knex } from 'connectors'
 import { Item, TableName } from 'definitions'
 
@@ -22,21 +23,29 @@ interface UpdateInput {
   data: Record<string, any>
 }
 
+interface DeleteManyInput {
+  table: TableName
+  where?: Record<string, any>
+  whereIn?: [string, string[]]
+}
+
 /**
  * This object is a container for data loaders or system wide services.
  */
 export class AtomService extends DataSource {
+  es: typeof es
   knex: Knex
 
   constructor() {
     super()
+    this.es = es
     this.knex = knex
   }
 
   /**
    * Find an unique record.
    *
-   * A Prisma like query for retrieving a record by specified id.
+   * A Prisma like method for retrieving a record by specified id.
    */
   findUnique = async ({ table, where }: FindInput) =>
     this.knex.select().from(table).where(where).first()
@@ -44,7 +53,7 @@ export class AtomService extends DataSource {
   /**
    * Update an unique record.
    *
-   * A Prisma like operation for updating a record by specified id.
+   * A Prisma like method for updating a record by specified id.
    */
   update = async ({ table, where, data }: UpdateInput) => {
     const [record] = await this.knex
@@ -53,5 +62,33 @@ export class AtomService extends DataSource {
       .into(table)
       .returning('*')
     return record
+  }
+
+  /**
+   * Delete records.
+   *
+   * A Prisma like method for deleting multiple records.
+   */
+  deleteMany = async ({ table, where, whereIn }: DeleteManyInput) => {
+    const action = this.knex(table)
+    if (where) {
+      action.where(where)
+    }
+    if (whereIn) {
+      action.whereIn(...whereIn)
+    }
+    await action.del()
+  }
+
+  /**
+   * Delete data stored in elastic search.
+   */
+  deleteSearch = async ({ table, id }: { table: TableName; id: any }) => {
+    try {
+      const result = await this.es.client.delete({ index: table, id })
+      return result
+    } catch (error) {
+      logger.error(error)
+    }
   }
 }

--- a/src/connectors/atomService.ts
+++ b/src/connectors/atomService.ts
@@ -1,0 +1,57 @@
+import { DataSource } from 'apollo-datasource'
+import DataLoader from 'dataloader'
+import Knex from 'knex'
+
+import { EntityNotFoundError } from 'common/errors'
+import { aws, es, knex } from 'connectors'
+import { Item, TableName } from 'definitions'
+
+interface InitLoaderInput {
+  table: TableName
+  mode: 'id' | 'uuid'
+}
+
+interface FindInput {
+  table: TableName
+  where: { id: string }
+}
+
+interface UpdateInput {
+  table: TableName
+  where: { id: string }
+  data: Record<string, any>
+}
+
+/**
+ * This object is a container for data loaders or system wide services.
+ */
+export class AtomService extends DataSource {
+  knex: Knex
+
+  constructor() {
+    super()
+    this.knex = knex
+  }
+
+  /**
+   * Find an unique record.
+   *
+   * A Prisma like query for retrieving a record by specified id.
+   */
+  findUnique = async ({ table, where }: FindInput) =>
+    this.knex.select().from(table).where(where).first()
+
+  /**
+   * Update an unique record.
+   *
+   * A Prisma like operation for updating a record by specified id.
+   */
+  update = async ({ table, where, data }: UpdateInput) => {
+    const [record] = await this.knex
+      .where(where)
+      .update(data)
+      .into(table)
+      .returning('*')
+    return record
+  }
+}

--- a/src/connectors/draftService.ts
+++ b/src/connectors/draftService.ts
@@ -15,9 +15,6 @@ export class DraftService extends BaseService {
    *             Draft             *
    *                               *
    *********************************/
-  archive = async (id: string) =>
-    this.baseUpdate(id, { archived: true, updatedAt: new Date() })
-
   /**
    * Count user's drafts by a given author id (user).
    */

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -10,6 +10,7 @@ export * from './gcp'
 
 export * from './baseService'
 export * from './articleService'
+export * from './atomService'
 export * from './commentService'
 export * from './draftService'
 export * from './systemService'

--- a/src/connectors/tagService.ts
+++ b/src/connectors/tagService.ts
@@ -393,18 +393,6 @@ export class TagService extends BaseService {
     }
   }
 
-  deleteSearch = async ({ id }: { [key: string]: any }) => {
-    try {
-      const result = await this.es.client.delete({
-        index: this.table,
-        id,
-      })
-      return result
-    } catch (error) {
-      logger.error(error)
-    }
-  }
-
   search = async ({
     key,
     first = 20,
@@ -761,20 +749,6 @@ export class TagService extends BaseService {
    *              OSS              *
    *                               *
    *********************************/
-  deleteTags = async (tagIds: string[]) => {
-    // delete article tags
-    await this.knex('article_tag').whereIn('tag_id', tagIds).del()
-
-    // delete action tag
-    await this.knex('action_tag')
-      .whereIn('target_id', tagIds)
-      .andWhere('action', 'follow')
-      .del()
-
-    // delete tags
-    await this.baseBatchDelete(tagIds)
-  }
-
   renameTag = async ({ tagId, content }: { tagId: string; content: string }) =>
     this.baseUpdate(tagId, { content, updatedAt: new Date() })
 
@@ -824,8 +798,6 @@ export class TagService extends BaseService {
 
     // delete tags
     await this.baseBatchDelete(tagIds)
-
-    await Promise.all(tagIds.map((id: string) => this.deleteSearch({ id })))
 
     return newTag
   }

--- a/src/definitions/index.d.ts
+++ b/src/definitions/index.d.ts
@@ -1,16 +1,18 @@
 import { RedisCache } from 'apollo-server-cache-redis'
 import { Request, Response } from 'express'
+import Knex from 'knex'
 
 import {
-  UserService,
   ArticleService,
+  AtomService,
   CommentService,
   DraftService,
-  SystemService,
-  TagService,
   NotificationService,
   OAuthService,
   PaymentService,
+  SystemService,
+  TagService,
+  UserService,
 } from 'connectors'
 
 export * from './schema'
@@ -69,9 +71,11 @@ export type RequestContext = {
   viewer: Viewer
   req: Request
   res: Response
+  knex: Knex
 }
 
 export type DataSources = {
+  atomService: InstanceType<typeof AtomService>
   articleService: InstanceType<typeof ArticleService>
   commentService: InstanceType<typeof CommentService>
   draftService: InstanceType<typeof DraftService>

--- a/src/mutations/draft/deleteDraft.ts
+++ b/src/mutations/draft/deleteDraft.ts
@@ -9,14 +9,18 @@ import { MutationToDeleteDraftResolver } from 'definitions'
 const resolver: MutationToDeleteDraftResolver = async (
   _,
   { input: { id } },
-  { viewer, dataSources: { draftService } }
+  { viewer, dataSources: { atomService } }
 ) => {
   if (!viewer.id) {
     throw new AuthenticationError('visitor has no permission')
   }
 
   const { id: dbId } = fromGlobalId(id)
-  const draft = await draftService.dataloader.load(dbId)
+  const draft = await atomService.findUnique({
+    table: 'draft',
+    where: { id: dbId },
+  })
+
   if (!draft || draft.archived) {
     throw new DraftNotFoundError('target draft does not exist')
   }
@@ -24,7 +28,11 @@ const resolver: MutationToDeleteDraftResolver = async (
     throw new ForbiddenError('viewer has no permission')
   }
 
-  await draftService.archive(draft.id)
+  await atomService.update({
+    table: 'draft',
+    where: { id: draft.id },
+    data: { archived: true, updatedAt: new Date() },
+  })
 
   return true
 }

--- a/src/routes/graphql.ts
+++ b/src/routes/graphql.ts
@@ -22,6 +22,7 @@ import logger from 'common/logger'
 import { initSubscriptions, makeContext } from 'common/utils'
 import {
   ArticleService,
+  AtomService,
   CommentService,
   DraftService,
   NotificationService,
@@ -88,6 +89,9 @@ const server = new ProtectedApolloServer({
   },
   subscriptions: initSubscriptions(),
   dataSources: () => ({
+    atomService: new AtomService(),
+
+    // below services will be deprecated
     userService: new UserService(),
     articleService: new ArticleService(),
     commentService: new CommentService(),

--- a/src/types/__test__/utils.ts
+++ b/src/types/__test__/utils.ts
@@ -5,6 +5,7 @@ import { Request } from 'express'
 import { authModes, roleAccess } from 'common/utils'
 import {
   ArticleService,
+  AtomService,
   CommentService,
   DraftService,
   NotificationService,
@@ -121,6 +122,7 @@ export const testClient = async (
       return { req, ..._context }
     },
     dataSources: (): DataSources => ({
+      atomService: new AtomService(),
       userService: new UserService(),
       articleService: new ArticleService(),
       commentService: new CommentService(),


### PR DESCRIPTION
- Inject `knex` instance into context
- Make a new service gathering reusable methods to replace old services
- Make query and update methods looks like Prisma like.