### PR TITLE
feat(circle): add `discussionCount` and `discussionThreadCount`

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -483,6 +483,12 @@ type Circle implements Node {
 
   """Comments made by Circle member."""
   discussion(input: ConnectionArgs!): CommentConnection!
+
+  """Discussion (exclude replies) count of this circle."""
+  discussionThreadCount: Int!
+
+  """Discussion (include replies) count of this circle."""
+  discussionCount: Int!
 }
 
 type CircleConnection implements Connection {

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -1130,6 +1130,16 @@ export interface GQLCircle extends GQLNode {
    * Comments made by Circle member.
    */
   discussion: GQLCommentConnection
+
+  /**
+   * Discussion (exclude replies) count of this circle.
+   */
+  discussionThreadCount: number
+
+  /**
+   * Discussion (include replies) count of this circle.
+   */
+  discussionCount: number
 }
 
 export interface GQLPrice {
@@ -5890,6 +5900,8 @@ export interface GQLCircleTypeResolver<TParent = any> {
   broadcast?: CircleToBroadcastResolver<TParent>
   pinnedBroadcast?: CircleToPinnedBroadcastResolver<TParent>
   discussion?: CircleToDiscussionResolver<TParent>
+  discussionThreadCount?: CircleToDiscussionThreadCountResolver<TParent>
+  discussionCount?: CircleToDiscussionCountResolver<TParent>
 }
 
 export interface CircleToIdResolver<TParent = any, TResult = any> {
@@ -6082,6 +6094,27 @@ export interface CircleToDiscussionResolver<TParent = any, TResult = any> {
   (
     parent: TParent,
     args: CircleToDiscussionArgs,
+    context: Context,
+    info: GraphQLResolveInfo
+  ): TResult
+}
+
+export interface CircleToDiscussionThreadCountResolver<
+  TParent = any,
+  TResult = any
+> {
+  (
+    parent: TParent,
+    args: {},
+    context: Context,
+    info: GraphQLResolveInfo
+  ): TResult
+}
+
+export interface CircleToDiscussionCountResolver<TParent = any, TResult = any> {
+  (
+    parent: TParent,
+    args: {},
     context: Context,
     info: GraphQLResolveInfo
   ): TResult

--- a/src/queries/comment/circle/discussionCount.ts
+++ b/src/queries/comment/circle/discussionCount.ts
@@ -1,0 +1,21 @@
+import { COMMENT_STATE, COMMENT_TYPE } from 'common/enums'
+import { CircleToDiscussionCountResolver } from 'definitions'
+
+const resolver: CircleToDiscussionCountResolver = async (
+  { id },
+  _,
+  { dataSources: { atomService } }
+) => {
+  const count = await atomService.count({
+    table: 'comment',
+    where: {
+      state: COMMENT_STATE.active,
+      targetId: id,
+      type: COMMENT_TYPE.circleDiscussion,
+    },
+  })
+
+  return count
+}
+
+export default resolver

--- a/src/queries/comment/circle/discussionThreadCount.ts
+++ b/src/queries/comment/circle/discussionThreadCount.ts
@@ -1,0 +1,22 @@
+import { COMMENT_STATE, COMMENT_TYPE } from 'common/enums'
+import { CircleToDiscussionThreadCountResolver } from 'definitions'
+
+const resolver: CircleToDiscussionThreadCountResolver = async (
+  { id },
+  _,
+  { dataSources: { atomService } }
+) => {
+  const count = await atomService.count({
+    table: 'comment',
+    where: {
+      state: COMMENT_STATE.active,
+      parentCommentId: null,
+      targetId: id,
+      type: COMMENT_TYPE.circleDiscussion,
+    },
+  })
+
+  return count
+}
+
+export default resolver

--- a/src/queries/comment/index.ts
+++ b/src/queries/comment/index.ts
@@ -9,6 +9,8 @@ import articlePinnedComments from './article/pinnedComments'
 import author from './author'
 import circleBroadcast from './circle/broadcast'
 import circleDiscussion from './circle/discussion'
+import circleDiscussionCount from './circle/discussionCount'
+import circleDiscussionThreadCount from './circle/discussionThreadCount'
 import circlePinnedBroadcast from './circle/pinnedBroadcast'
 import comments from './comments'
 import content from './content'
@@ -50,5 +52,7 @@ export default {
     broadcast: circleBroadcast,
     pinnedBroadcast: circlePinnedBroadcast,
     discussion: circleDiscussion,
+    discussionCount: circleDiscussionCount,
+    discussionThreadCount: circleDiscussionThreadCount,
   },
 }

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -109,6 +109,12 @@ export default /* GraphQL */ `
 
     "Comments made by Circle member."
     discussion(input: ConnectionArgs!): CommentConnection!
+
+    "Discussion (exclude replies) count of this circle."
+    discussionThreadCount: Int!
+
+    "Discussion (include replies) count of this circle."
+    discussionCount: Int!
   }
 
   type CommentConnection implements Connection {


### PR DESCRIPTION
Since circle discussion are protected and `discussion.totalCount` returns `0` on public query, we add `discussionCount` and `discussionThreadCount` to fulfill the stats needs.