### PR TITLE
Matters as subscription provider

### DIFF
--- a/src/common/enums/payment.ts
+++ b/src/common/enums/payment.ts
@@ -175,3 +175,8 @@ export enum METADATA_KEY {
   CIRCLE_ID = 'db_circle_id',
   CIRCLE_PRICE_ID = 'db_circle_price_id',
 }
+
+export enum SUBSCRIPTION_ITEM_REMARK {
+  trial_end = 'trial_end',
+  trial_cancel = 'trial_cancel',
+}

--- a/src/connectors/paymentService.ts
+++ b/src/connectors/paymentService.ts
@@ -706,8 +706,8 @@ export class PaymentService extends BaseService {
       // Create to DB
       const [mattersDBSub] = await this.knex('circle_subscription')
         .insert({
-          providerSubscriptionId: null,
           provider: PAYMENT_PROVIDER.matters,
+          providerSubscriptionId: v4(),
           state: SUBSCRIPTION_STATE.trialing,
           userId,
         })
@@ -718,7 +718,7 @@ export class PaymentService extends BaseService {
           userId,
           priceId,
           provider: PAYMENT_PROVIDER.matters,
-          providerSubscriptionItemId: null,
+          providerSubscriptionItemId: v4(),
         })
         .returning('*')
 
@@ -792,7 +792,7 @@ export class PaymentService extends BaseService {
           userId,
           priceId,
           provider: PAYMENT_PROVIDER.matters,
-          providerSubscriptionItemId: null,
+          providerSubscriptionItemId: v4(),
         })
         .returning('*')
 

--- a/src/connectors/paymentService.ts
+++ b/src/connectors/paymentService.ts
@@ -699,7 +699,7 @@ export class PaymentService extends BaseService {
     /**
      * Create Matters subscription if it's with trial invitation
      */
-    // If any discount coupon invitation
+    // If any discount invitation
     const ivt = await this.findPendingInvitation({ userId, priceId })
 
     if (ivt) {
@@ -722,8 +722,8 @@ export class PaymentService extends BaseService {
         })
         .returning('*')
 
-      // Mark coupon invitation as accepted
-      await this.acceptCouponInvitation(ivt.id, mattersDBSubItem.id)
+      // Mark invitation as accepted
+      await this.acceptInvitation(ivt.id, mattersDBSubItem.id)
     }
 
     /**
@@ -781,7 +781,7 @@ export class PaymentService extends BaseService {
     /**
      * Create Matters subscription item if it's with trial invitation
      */
-    // If any discount coupon invitation
+    // If any discount invitation
     const ivt = await this.findPendingInvitation({ userId, priceId })
 
     if (ivt) {
@@ -796,8 +796,8 @@ export class PaymentService extends BaseService {
         })
         .returning('*')
 
-      // Mark coupon invitation as accepted
-      await this.acceptCouponInvitation(ivt.id, mattersDBSubItem.id)
+      // Mark invitation as accepted
+      await this.acceptInvitation(ivt.id, mattersDBSubItem.id)
     }
 
     /**
@@ -827,11 +827,11 @@ export class PaymentService extends BaseService {
 
   /*********************************
    *                               *
-   *            Coupon             *
+   *           Invitation          *
    *                               *
    *********************************/
   /**
-   * Find coupons applicable to a user for a cirlce
+   * Find invitation applicable to a user for a cirlce
    */
   findPendingInvitation = async (params: {
     userId: string
@@ -843,10 +843,9 @@ export class PaymentService extends BaseService {
       .where({ id: params.userId })
       .first()
     const records = await this.knex
-      .select('ci.id', 'cc.provider_coupon_id')
+      .select('ci.id')
       .from('circle_invitation as ci')
       .join('circle_price as cp', 'cp.circle_id', 'ci.circle_id')
-      .join('circle_coupon as cc', 'cc.id', 'ci.coupon_id')
       .where({
         'cp.id': params.priceId,
         accepted: false,
@@ -860,12 +859,9 @@ export class PaymentService extends BaseService {
   }
 
   /**
-   * Accept coupon invitation
+   * Accept invitation
    */
-  acceptCouponInvitation = async (
-    ivtId: string,
-    subscriptionItemId: string
-  ) => {
+  acceptInvitation = async (ivtId: string, subscriptionItemId: string) => {
     await this.knex('circle_invitation')
       .where('id', ivtId)
       .update({

--- a/src/connectors/stripe/index.ts
+++ b/src/connectors/stripe/index.ts
@@ -1,6 +1,5 @@
 import { last } from 'lodash'
 import Stripe from 'stripe'
-import { isUndefined } from 'util'
 
 import {
   DAY,
@@ -283,11 +282,9 @@ class StripeService {
   createSubscription = async ({
     customer,
     price,
-    coupon,
   }: {
     customer: string
     price: string
-    coupon?: string
   }) => {
     try {
       const trialEndAt =
@@ -298,7 +295,6 @@ class StripeService {
         customer,
         items: [{ price }],
         proration_behavior: 'none',
-        coupon,
       })
     } catch (error) {
       this.handleError(error)
@@ -316,19 +312,11 @@ class StripeService {
   createSubscriptionItem = async ({
     price,
     subscription,
-    coupon,
   }: {
     price: string
     subscription: string
-    coupon?: string
   }) => {
     try {
-      if (!isUndefined(coupon)) {
-        // Apply coupon discount to subscription
-        await this.stripeAPI.subscriptions.update(subscription, {
-          coupon,
-        })
-      }
       return await this.stripeAPI.subscriptionItems.create({
         price,
         proration_behavior: 'none',
@@ -412,33 +400,6 @@ class StripeService {
         cursor = last(events)?.id
       }
       return events
-    } catch (error) {
-      this.handleError(error)
-    }
-  }
-
-  /**
-   * Create a coupon for a specific product.
-   */
-  createCoupon = async ({
-    months,
-    percentOff,
-    productId,
-  }: {
-    months: number
-    percentOff: number
-    productId: string
-  }) => {
-    try {
-      return await this.stripeAPI.coupons.create({
-        applies_to: {
-          products: [productId],
-        },
-        duration: 'repeating',
-        duration_in_months: months,
-        name: `${productId}-${months}months-coupon`,
-        percent_off: percentOff,
-      })
     } catch (error) {
       this.handleError(error)
     }

--- a/src/connectors/stripe/index.ts
+++ b/src/connectors/stripe/index.ts
@@ -292,22 +292,14 @@ class StripeService {
     try {
       const trialEndAt =
         (isProd ? getUTC8NextMonthDayOne() : getUTC8NextMonday()) / 1000
-      if (isUndefined(coupon)) {
-        return this.stripeAPI.subscriptions.create({
-          trial_end: trialEndAt,
-          customer,
-          items: [{ price }],
-          proration_behavior: 'none',
-        })
-      } else {
-        return this.stripeAPI.subscriptions.create({
-          trial_end: trialEndAt,
-          customer,
-          items: [{ price }],
-          proration_behavior: 'none',
-          coupon,
-        })
-      }
+
+      return this.stripeAPI.subscriptions.create({
+        trial_end: trialEndAt,
+        customer,
+        items: [{ price }],
+        proration_behavior: 'none',
+        coupon,
+      })
     } catch (error) {
       this.handleError(error)
     }

--- a/src/definitions/index.d.ts
+++ b/src/definitions/index.d.ts
@@ -141,7 +141,6 @@ export type BasicTableName =
   | 'punish_record'
   | 'entity_type'
   | 'circle'
-  | 'circle_coupon'
   | 'circle_invitation'
   | 'circle_price'
   | 'circle_subscription'

--- a/src/mutations/circle/invite.ts
+++ b/src/mutations/circle/invite.ts
@@ -13,7 +13,6 @@ import {
   EntityNotFoundError,
   ForbiddenByStateError,
   ForbiddenError,
-  ServerError,
   UserInputError,
 } from 'common/errors'
 import {
@@ -24,7 +23,7 @@ import {
 import { CacheService } from 'connectors'
 import { MutationToInviteResolver } from 'definitions'
 
-const months = [1, 3, 6, 12]
+const VALID_INVITATION_MONTHS = [1, 3, 6, 12]
 
 const resolver: MutationToInviteResolver = async (
   root,
@@ -43,6 +42,7 @@ const resolver: MutationToInviteResolver = async (
     throw new AuthenticationError('visitor has no permisson')
   }
 
+  // check viewer state
   if (
     [USER_STATE.archived, USER_STATE.banned, USER_STATE.frozen].includes(
       viewer.state
@@ -51,14 +51,22 @@ const resolver: MutationToInviteResolver = async (
     throw new ForbiddenByStateError(`${viewer.state} user has no permission`)
   }
 
+  // check inputs
   if (!invitees || invitees.length === 0) {
     throw new UserInputError('invitees are required')
   }
 
-  if (!months.includes(freePeriod)) {
-    throw new UserInputError('free period is invalid')
+  if (!VALID_INVITATION_MONTHS.includes(freePeriod)) {
+    throw new UserInputError(
+      `free period is invalid, should be one of [${VALID_INVITATION_MONTHS.join(
+        ', '
+      )}]`
+    )
   }
+  // TODO: alter `freePeriod` input as day unit
+  const durationInDays = freePeriod * 30
 
+  // check circle
   const circleDbId = fromGlobalId(circleId).id
   const circle = await atomService.findFirst({
     table: 'circle',
@@ -68,43 +76,11 @@ const resolver: MutationToInviteResolver = async (
   if (!circle) {
     throw new EntityNotFoundError('circle not found')
   }
-
   if (circle.owner !== viewer.id) {
     throw new ForbiddenError('operation not allowed')
   }
 
-  let coupon = await atomService.findFirst({
-    table: 'circle_coupon',
-    where: { circleId: circleDbId, durationInMonths: freePeriod },
-  })
-
-  // check coupon is existed, if not create Stripe and matters coupon
-  if (!coupon) {
-    const stripeCoupon = await paymentService.stripe.createCoupon({
-      months: freePeriod,
-      percentOff: 100,
-      productId: circle.providerProductId,
-    })
-
-    if (!stripeCoupon) {
-      throw new ServerError('failed to create stripe coupon')
-    }
-
-    coupon = await atomService.create({
-      table: 'circle_coupon',
-      data: {
-        circleId: circle.id,
-        durationInMonths: freePeriod,
-        providerCouponId: stripeCoupon.id,
-      },
-    })
-
-    if (!coupon) {
-      throw new ServerError('failed to create matters coupon')
-    }
-  }
-
-  // process invitations
+  // create invitations
   const invitations = []
   for (const invitee of invitees) {
     const { id, email } = invitee
@@ -155,24 +131,19 @@ const resolver: MutationToInviteResolver = async (
         table: 'circle_invitation',
         data: {
           circleId: circle.id,
-          couponId: coupon.id,
           email,
           inviter: viewer.id,
           userId,
+          durationInDays,
         },
       })
-    } else {
-      // if existed, then update sentAt and possible couponId
-      const isFreePeriodChanged = invitation.couponId !== coupon.id
-      const updateData = {
-        sentAt: new Date(),
-        ...(isFreePeriodChanged ? { couponId: coupon.id } : {}),
-      }
-
+    }
+    // if existed, then update sentAt
+    else {
       invitation = await atomService.update({
         table: 'circle_invitation',
         where: { circleId: circle.id, email, userId },
-        data: updateData,
+        data: { sentAt: new Date() },
       })
     }
 

--- a/src/mutations/circle/subscribeCircle.ts
+++ b/src/mutations/circle/subscribeCircle.ts
@@ -92,27 +92,23 @@ const resolver: MutationToSubscribeCircleResolver = async (
     userId: circle.owner,
     targetId: viewer.id,
   })
-
   if (isBlocked) {
     throw new ForbiddenError('viewer has no permission')
   }
-
-  const provider = PAYMENT_PROVIDER.stripe
 
   // retrieve or create a Customer
   let customer = (await atomService.findFirst({
     table: 'customer',
     where: {
       userId: viewer.id,
-      provider,
+      provider: PAYMENT_PROVIDER.stripe,
       archived: false,
     },
   })) as Customer
-
   if (!customer) {
     customer = (await paymentService.createCustomer({
       user: viewer,
-      provider,
+      provider: PAYMENT_PROVIDER.stripe,
     })) as Customer
   }
 

--- a/src/mutations/circle/subscribeCircle.ts
+++ b/src/mutations/circle/subscribeCircle.ts
@@ -121,10 +121,7 @@ const resolver: MutationToSubscribeCircleResolver = async (
     subscriptions && subscriptions.length > 0
       ? await atomService.findMany({
           table: 'circle_subscription_item',
-          where: {
-            priceId: price.id,
-            archived: false,
-          },
+          where: { priceId: price.id, archived: false },
           whereIn: ['subscription_id', subscriptions.map((sub) => sub.id)],
         })
       : null

--- a/src/mutations/circle/unsubscribeCircle.ts
+++ b/src/mutations/circle/unsubscribeCircle.ts
@@ -112,10 +112,7 @@ const resolver: MutationToUnsubscribeCircleResolver = async (
       await atomService.update({
         table: 'circle_subscription_item',
         where: { id: targetItem.id },
-        data: {
-          archived: true,
-          updatedAt: new Date(),
-        },
+        data: { archived: true, updatedAt: new Date() },
       })
     })
   )

--- a/src/mutations/circle/unsubscribeCircle.ts
+++ b/src/mutations/circle/unsubscribeCircle.ts
@@ -3,7 +3,10 @@ import {
   CIRCLE_STATE,
   DB_NOTICE_TYPE,
   NODE_TYPES,
+  PAYMENT_PROVIDER,
   PRICE_STATE,
+  SUBSCRIPTION_ITEM_REMARK,
+  SUBSCRIPTION_STATE,
 } from 'common/enums'
 import {
   AuthenticationError,
@@ -41,6 +44,7 @@ const resolver: MutationToUnsubscribeCircleResolver = async (
     throw new ForbiddenError('viewer has no permission')
   }
 
+  // check circle
   const { id: circleId } = fromGlobalId(id || '')
   const [circle, price] = await Promise.all([
     atomService.findFirst({
@@ -60,59 +64,79 @@ const resolver: MutationToUnsubscribeCircleResolver = async (
     throw new EntityNotFoundError(`price of circle ${id} not found`)
   }
 
+  // loop subscriptions
   const subscriptions = await paymentService.findSubscriptions({
     userId: viewer.id,
   })
 
+  const cancelSubscription = async (sub: any) => {
+    let state
+    let canceledAt
+
+    // cancel stripe subscription
+    if (sub.provider === PAYMENT_PROVIDER.stripe) {
+      const stripeSub = await paymentService.stripe.cancelSubscription(
+        sub.providerSubscriptionId
+      )
+      state = stripeSub?.status
+      canceledAt = stripeSub?.canceled_at
+        ? stripeSub?.canceled_at * 1000
+        : undefined
+    }
+
+    // update db
+    await atomService.update({
+      table: 'circle_subscription',
+      where: { id: sub.id },
+      data: {
+        state: state || SUBSCRIPTION_STATE.canceled,
+        canceledAt: canceledAt || new Date(),
+        updatedAt: new Date(),
+      },
+    })
+  }
+
   await Promise.all(
-    subscriptions.map(async (subscription) => {
-      const items = subscription
+    subscriptions.map(async (sub) => {
+      const isStripeSub = sub.provider === PAYMENT_PROVIDER.stripe
+      const isMattersSub = sub.provider === PAYMENT_PROVIDER.matters
+
+      const subItems = sub
         ? await atomService.findMany({
             table: 'circle_subscription_item',
-            where: {
-              subscriptionId: subscription.id,
-              archived: false,
-            },
+            where: { subscriptionId: sub.id, archived: false },
           })
         : []
-      const targetItem = items.find((item) => item.priceId === price.id)
+      const targetSubItem = subItems.find((item) => item.priceId === price.id)
 
-      if (!targetItem) {
+      if (!targetSubItem) {
         return circle
       }
 
-      if (items.length <= 1) {
-        // cancel stripe subscription
-        const stripeSubscription = await paymentService.stripe.cancelSubscription(
-          subscription.providerSubscriptionId
-        )
-
-        // update db subscription
-        if (stripeSubscription) {
-          await atomService.update({
-            table: 'circle_subscription',
-            where: { id: subscription.id },
-            data: {
-              state: stripeSubscription.status,
-              canceledAt: stripeSubscription.canceled_at
-                ? new Date(stripeSubscription.canceled_at * 1000)
-                : undefined,
-              updatedAt: new Date(),
-            },
-          })
+      // cancel the subscription if only one subscription item left
+      if (subItems.length <= 1) {
+        await cancelSubscription(sub)
+      }
+      // remove subscription item from Stripe
+      else {
+        if (isStripeSub) {
+          await paymentService.stripe.deleteSubscriptionItem(
+            targetSubItem.providerSubscriptionItemId
+          )
         }
-      } else {
-        // remove stripe subscription item
-        await paymentService.stripe.deleteSubscriptionItem(
-          targetItem.providerSubscriptionItemId
-        )
       }
 
       // archive subscription item
       await atomService.update({
         table: 'circle_subscription_item',
-        where: { id: targetItem.id },
-        data: { archived: true, updatedAt: new Date() },
+        where: { id: targetSubItem.id },
+        data: {
+          archived: true,
+          updatedAt: new Date(),
+          ...(isMattersSub
+            ? { remark: SUBSCRIPTION_ITEM_REMARK.trial_cancel }
+            : {}),
+        },
       })
     })
   )

--- a/src/queries/circle/invitation/freePeriod.ts
+++ b/src/queries/circle/invitation/freePeriod.ts
@@ -1,15 +1,16 @@
 import { InvitationToFreePeriodResolver } from 'definitions'
 
 const resolver: InvitationToFreePeriodResolver = async (
-  { couponId },
+  { durationInDays },
   _,
   { dataSources: { atomService } }
 ) => {
-  const coupon = await atomService.findUnique({
-    table: 'circle_coupon',
-    where: { id: couponId },
-  })
-  return coupon.durationInMonths
+  // TODO: alter `freePeriod` input as day unit
+  if (durationInDays && durationInDays >= 0) {
+    return durationInDays / 30
+  }
+
+  return null
 }
 
 export default resolver

--- a/src/routes/pay/stripe/circle.ts
+++ b/src/routes/pay/stripe/circle.ts
@@ -174,12 +174,12 @@ export const updateSubscription = async ({
     type: event.type,
   }
 
-  const dbSubscription = await atomService.findFirst({
+  const dbSub = await atomService.findFirst({
     table: 'circle_subscription',
     where: { providerSubscriptionId: subscription.id },
   })
 
-  if (!dbSubscription) {
+  if (!dbSub) {
     slack.sendStripeAlert({
       data: slackEventData,
       message: `can't find subscription ${subscription.id}.`,
@@ -187,12 +187,12 @@ export const updateSubscription = async ({
     return
   }
 
-  if (dbSubscription.state === subscription.status) {
+  if (dbSub.state === subscription.status) {
     return
   }
 
-  const userId = dbSubscription.userId
-  const subscriptionId = dbSubscription.id
+  const userId = dbSub.userId
+  const subscriptionId = dbSub.id
 
   /**
    * subscription
@@ -200,7 +200,7 @@ export const updateSubscription = async ({
   try {
     await atomService.update({
       table: 'circle_subscription',
-      where: { id: dbSubscription.id },
+      where: { id: dbSub.id },
       data: {
         state: subscription.status,
         canceledAt: subscription.canceled_at
@@ -297,7 +297,7 @@ export const updateSubscription = async ({
       whereIn: ['id', [...addedPriceIds, ...removedPriceIds]],
     })
     invalidateFQC({
-      node: { type: NODE_TYPES.User, id: dbSubscription.userId },
+      node: { type: NODE_TYPES.User, id: dbSub.userId },
       redis: cacheService.redis,
     })
     dbDiffPrices.map((price) => {


### PR DESCRIPTION
In this PR, we add support for creating subscription and subscription items with `provider=matters`, which currently used by trial invitation.

**Notes:**
* Matters subscription items also count in the limitation that up to 20;
* `freePeriod` should be altered from month to day unit by the next deployment (June 1);