### PR TITLE
fix(cookie): set samesite to `none` if it's local request

### DIFF
--- a/src/common/utils/cookie.ts
+++ b/src/common/utils/cookie.ts
@@ -32,7 +32,7 @@ const getCookieOption = ({
     httpOnly,
     secure: req.protocol === 'https',
     domain,
-    sameSite: isLocalDev ? undefined : sameSite,
+    sameSite: isLocalDev ? 'none' : sameSite,
   } as CookieOptions
 }
 


### PR DESCRIPTION
Chrome 91 may change the default behavior of cookie `SameSite`, we need to set it to `none` explicitly.