### PR TITLE
Fix/xss sanity check

### DIFF
--- a/src/common/utils/__test__/xss.test.ts
+++ b/src/common/utils/__test__/xss.test.ts
@@ -37,6 +37,10 @@ test('valid contents', async () => {
       content:
         '<figure class="embed-code"><div class="iframe-container"><iframe src="https://jsfiddle.net/yokev33205/efcd46mb/embedded/" frameborder="0" allowfullscreen="false" sandbox="allow-scripts allow-same-origin allow-popups"></iframe></div><figcaption><span></span></figcaption></figure>',
     },
+    {
+      content:
+        '<pre class="ql-syntax" spellcheck="false">Pre1\n</pre><p>Para2</p><p>Para3</p>',
+    },
   ]
 
   htmls.forEach(({ content }) => {

--- a/src/common/utils/xss.ts
+++ b/src/common/utils/xss.ts
@@ -3,6 +3,7 @@ import * as xss from 'xss'
 const CUSTOM_WHITELIST = {
   source: ['src', 'type'],
   iframe: ['src', 'frameborder', 'allowfullscreen', 'sandbox'],
+  pre: ['spellcheck'],
 }
 
 const IFRAME_SANDBOX_WHITELIST = [


### PR DESCRIPTION
- make unittest for server side for sure not to touch the pre code-block … 0341e8f
  part of reason for thematters/matters-web#2114 is server not saving exactly same pre code-block, as

  ```html
  <pre class="ql-syntax" spellcheck="false">Pre1\n</pre><p>next paragraph...
  ```

  server side is always dropping the `spellcheck="false"`, then next time when editor is loading
the incomplete pre code-block, it triggers `clipboard.convert` to parse again, and in MattersArticleEditor
the `mentionContainer` reference is causing ReactQuill to re-initialize twice every time, caused
converting between `HTML <=> Delta` happening 6 or even more times, and eventually caused wrong parsing

- sanitize xss filter whitelist pre: ['spellcheck'] 3c9fccc