### PR TITLE
fix the ipfs/go-ipfs:latest not working

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
         ports:
           - 9200:9200
       ipfs:
-        image: ipfs/go-ipfs:latest
+        image: ipfs/go-ipfs:v0.9.1
         ports:
           - 5001:5001
       stripe:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         ports:
           - 9200:9200
       ipfs:
-        image: ipfs/go-ipfs:latest
+        image: ipfs/go-ipfs:v0.9.1
         ports:
           - 5001:5001
       stripe:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - '4569:4569'
   ipfs:
     container_name: ipfs
-    image: ipfs/go-ipfs:latest
+    image: ipfs/go-ipfs:v0.9.1
     ports:
       - '8080:8080'
       - '4001:4001'


### PR DESCRIPTION
from last good deployment
https://github.com/thematters/matters-server/runs/3756298109?check_suite_focus=true#step:2:225

the latest good image is `Digest: sha256:f7e30972e35a839ea8ce00c060412face29aa31624fd2dc87a5e696f99835a91`
it's werid can't find a tagged version from https://hub.docker.com/r/ipfs/go-ipfs/tags?page=1&ordering=last_updated
some latest tagged versions there are tested not working either; might be a major version change incompatibility