### PR TITLE
make sure a anchor tag be able to save rel attribute

### DIFF
--- a/src/common/utils/__test__/xss.test.ts
+++ b/src/common/utils/__test__/xss.test.ts
@@ -5,7 +5,7 @@ test('valid contents', async () => {
     // link:mention
     {
       content:
-        '<a class="mention" href="/@hi176" target="_blank" data-display-name="Matty" data-user-name="hi176" data-id="VXNlcjoxNDk0OQ"><span>@Matty</span></a>',
+        '<a class="mention" href="/@hi176" rel="noopener noreferrer" target="_blank" data-display-name="Matty" data-user-name="hi176" data-id="VXNlcjoxNDk0OQ"><span>@Matty</span></a>',
     },
     // link:embed
     {

--- a/src/common/utils/xss.ts
+++ b/src/common/utils/xss.ts
@@ -4,6 +4,7 @@ const CUSTOM_WHITELIST = {
   source: ['src', 'type'],
   iframe: ['src', 'frameborder', 'allowfullscreen', 'sandbox'],
   pre: ['spellcheck'],
+  a: ['target', 'href', 'title', 'rel'],
 }
 
 const IFRAME_SANDBOX_WHITELIST = [


### PR DESCRIPTION
after #2282 merged and deployed, now thematters/matters-web#2114 is parted fixed, only for cases like

    '<pre class="ql-syntax" spellcheck="false">Pre1\n</pre><p>Para2</p><p>Para3</p>'

it's now showing correctly not wrapping any paragraphs,

but if the content includes more complex format, like

    '<pre class="ql-syntax" spellcheck="false">Pre1\n</pre><p>Para2</p><p>Para3 <a href="...">link</a></p>'

thematters/matters-web#2114 is then still reproducing, the real reason is our server side is not always saving exactly same HTML generated from the editor, in this case Quill editor is appending `rel="noopener noreferrer"` to `a` tag, but `rel` attribute is stripped by the server (the `xss`); then at next time Editor initialization time, `ReactQuill` is loading this server saved HTML into Quill editor, and compare with editor output HTML (the version with `rel=...`), if not the same, it's trying to load the HTML again, and again, till editor output HTML is same as input

the loading again logic is triggering the Quill problem described here: https://github.com/thematters/matters-web/issues/2114#issuecomment-933096516