### PR TITLE
fix(deps): move rover installation to CI

### DIFF
--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -36,7 +36,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Install Dependencies
-        run: npm ci
+        run: npm ci && npm i @apollo/rover
 
       - name: Push Schema (develop)
         if: github.base_ref == 'develop'

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "xss": "^1.0.9"
   },
   "devDependencies": {
-    "@apollo/rover": "^0.1.9",
     "@types/bcrypt": "^5.0.0",
     "@types/bull": "^3.15.2",
     "@types/cookie": "^0.4.1",


### PR DESCRIPTION
As title, M1 (arm) machine cannot install rover in local, move it CI since it's only used by CI.