### PR TITLE
fix: avoid the scenario where current folder does not exist

### DIFF
--- a/.ebextensions/private-files.config
+++ b/.ebextensions/private-files.config
@@ -48,4 +48,4 @@ files:
 
 container_commands:
   01_private_files:
-    command: cp -r /tmp/.ebextensions/. /var/app/current/.ebextensions
+    command: cp -r /tmp/.ebextensions/. /var/app/.ebextensions

--- a/.platform/nginx/conf.d/00_client_max_body_size.conf
+++ b/.platform/nginx/conf.d/00_client_max_body_size.conf
@@ -1,0 +1,1 @@
+client_max_body_size 100m;

--- a/.platform/nginx/conf.d/01_increase_timeout.conf
+++ b/.platform/nginx/conf.d/01_increase_timeout.conf
@@ -1,0 +1,4 @@
+
+send_timeout       300;
+proxy_send_timeout 300;
+proxy_read_timeout 300;

--- a/docker/Dockerrun.aws.json.example
+++ b/docker/Dockerrun.aws.json.example
@@ -43,7 +43,7 @@
       "ContainerDirectory": "/var/app/tslint.json"
     },
     {
-      "HostDirectory": "/var/app/current/.ebextensions",
+      "HostDirectory": "/var/app/.ebextensions",
       "ContainerDirectory": "/var/app/.ebextensions"
     }
   ],


### PR DESCRIPTION
Fix the following:

- In new EB env, the `current` folder maybe absent during initialization, e.g. when `clone` an environment;
- In new EB env, `nginx.conf` in `.ebextension` does not work. 