### PR TITLE
error message: why ip undefined could run `.split`?

### DIFF
--- a/src/common/utils/getViewer.ts
+++ b/src/common/utils/getViewer.ts
@@ -44,7 +44,7 @@ export const getUserGroup = ({
       num = parseInt(last, 10) || 0
     }
   } catch (error) {
-    logger.error(error)
+    logger.error("ERROR:", error, { id, ip })
   }
   return num % 2 === 0 ? 'a' : 'b'
 }


### PR DESCRIPTION
```console
2021-12-08 07:26:56 error: "Cannot read properties of undefined (reading 'split')"
2021-12-08 07:26:56 error: "Cannot read properties of undefined (reading 'split')"
2021-12-08 07:26:56 error: "Cannot read properties of undefined (reading 'split')"
2021-12-08 07:26:56 error: "Cannot read properties of undefined (reading 'split')"
2021-12-08 07:26:56 error: "Cannot read properties of undefined (reading 'split')"
```