### PR TITLE
fix/crypto_wallet: fake a table entry if has eth_address linked in us…

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -2528,7 +2528,6 @@ type Following {
 type CryptoWallet {
   id: ID!
   address: String!
-  createdAt: DateTime!
 
   """ does this address own any Travelogger NFTs? this value is cached at most 1day, and refreshed at next `nfts` query 
   """

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -3489,7 +3489,6 @@ export interface GQLFollowing {
 export interface GQLCryptoWallet {
   id: string
   address: string
-  createdAt: GQLDateTime
 
   /**
    *  does this address own any Travelogger NFTs? this value is cached at most 1day, and refreshed at next `nfts` query
@@ -11715,7 +11714,6 @@ export interface FollowingToUsersResolver<TParent = any, TResult = any> {
 export interface GQLCryptoWalletTypeResolver<TParent = any> {
   id?: CryptoWalletToIdResolver<TParent>
   address?: CryptoWalletToAddressResolver<TParent>
-  createdAt?: CryptoWalletToCreatedAtResolver<TParent>
   hasNFTs?: CryptoWalletToHasNFTsResolver<TParent>
   nfts?: CryptoWalletToNftsResolver<TParent>
 }
@@ -11730,15 +11728,6 @@ export interface CryptoWalletToIdResolver<TParent = any, TResult = any> {
 }
 
 export interface CryptoWalletToAddressResolver<TParent = any, TResult = any> {
-  (
-    parent: TParent,
-    args: {},
-    context: Context,
-    info: GraphQLResolveInfo
-  ): TResult
-}
-
-export interface CryptoWalletToCreatedAtResolver<TParent = any, TResult = any> {
   (
     parent: TParent,
     args: {},

--- a/src/queries/user/cryptoWallet.ts
+++ b/src/queries/user/cryptoWallet.ts
@@ -3,10 +3,16 @@ import { UserInfoToCryptoWalletResolver } from 'definitions'
 const resolver: UserInfoToCryptoWalletResolver = async (
   { id },
   _,
-  { dataSources: { atomService } }
+  { dataSources: { userService, atomService } }
 ) => {
   if (id === undefined) {
     return null
+  }
+
+  const user = await userService.baseFindById(id)
+  if (user.ethAddress) {
+    // fake a crypto_wallet
+    return { address: user.ethAddress }
   }
 
   const wallet = await atomService.findFirst({

--- a/src/queries/user/index.ts
+++ b/src/queries/user/index.ts
@@ -173,7 +173,7 @@ const user: {
     id: ({ id }) =>
       id ? toGlobalId({ type: NODE_TYPES.CryptoWallet, id }) : '',
     address: ({ address }) => address,
-    createdAt: ({ createdAt }) => createdAt,
+    // createdAt: ({ createdAt }) => createdAt,
 
     hasNFTs,
     nfts,

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -540,7 +540,7 @@ export default /* GraphQL */ `
   type CryptoWallet {
     id: ID!
     address: String!
-    createdAt: DateTime!
+    # createdAt: DateTime!
 
     """ does this address own any Travelogger NFTs? this value is cached at most 1day, and refreshed at next \`nfts\` query """
     hasNFTs: Boolean! @objectCache(maxAge: ${CACHE_TTL.LONG})


### PR DESCRIPTION
…er table

supplements #2429

the old crypto_wallet table could potentially support multiple wallet for single user,
but new model is strictly 1-to-1 mapping;

the `crypto_wallet` table will eventually be deprecated