### PR TITLE
fix(): skip recaptcha checking bot traffic

### DIFF
--- a/src/connectors/gcp/index.ts
+++ b/src/connectors/gcp/index.ts
@@ -101,11 +101,11 @@ class GCP {
 
     // fail for less than 0.5
     if (score < 0.5) {
-      return false
+      console.log("very likely bot traffic:", data)
     }
 
     // pass
-    return true
+    return score > 0.0
   }
 }
 


### PR DESCRIPTION
it has triggered many good gmail registration requests flagged as bot, need logs to know why