### PR TITLE
hot-release/4.1.1 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matters-server",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "matters-server",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/elasticsearch": "^7.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matters-server",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Matters Server",
   "author": "Matters <hi@matters.news>",
   "main": "build/index.js",

--- a/src/connectors/tagService.ts
+++ b/src/connectors/tagService.ts
@@ -532,7 +532,9 @@ export class TagService extends BaseService {
         )
         .from(TAGS_VIEW)
         .whereIn('id', Array.from(ids))
-        .orderByRaw('content = ? DESC NULLS LAST', [key]) // always show exact match at first
+        .orderByRaw('content = ? DESC', [key]) // always show exact match at first
+        .orderByRaw('content ~* ? DESC', [key]) // then show inclusive match, by regular expression, case insensitive
+        .orderBy('num_authors', 'desc')
         .orderBy('num_articles', 'desc')
         .orderBy('created_at', 'asc')
 

--- a/src/connectors/tagService.ts
+++ b/src/connectors/tagService.ts
@@ -468,6 +468,7 @@ export class TagService extends BaseService {
     const body = bodybuilder()
       .query('match', 'content', key)
       .sort([
+        { _score: 'desc' },
         { numArticles: 'desc' },
         { numAuthors: 'desc' },
         { createdAt: 'asc' }, // prefer earlier created one if same number of articles
@@ -504,7 +505,7 @@ export class TagService extends BaseService {
         // ids.push(...res2.map(({ tagId }) => tagId))
         res.forEach(({ id }) => ids.add(id))
         res2.forEach(({ tagId }) => ids.add(tagId))
-        console.log(new Date(), 'author tags:', res, res2, 'merged:', ids)
+        // console.log(new Date(), 'author tags:', res, res2, 'merged:', ids)
       }
 
       if (key) {
@@ -513,13 +514,13 @@ export class TagService extends BaseService {
           body,
         })
 
-        console.log(
+        /* console.log(
           'ES search of:',
           body,
           'result:',
           result.body?.hits?.hits,
           result
-        )
+        ) */
         const { hits } = result.body
 
         // ids.push(...hits.hits.map(({ _id }: { _id: any }) => _id))
@@ -550,7 +551,7 @@ export class TagService extends BaseService {
         take,
         skip,
       })
-      console.log('found:', ids, 'search from lasts:', tags)
+      // console.log('found:', ids, 'search from lasts:', tags)
 
       return {
         // /** tslint:disable-next-line:prefer-object-spread */
@@ -559,7 +560,7 @@ export class TagService extends BaseService {
       }
     } catch (err) {
       logger.error(err)
-      console.error(new Date(), 'ERROR:', err)
+      // console.error(new Date(), 'ERROR:', err)
       throw new ServerError('tag search failed')
     }
   }

--- a/src/connectors/tagService.ts
+++ b/src/connectors/tagService.ts
@@ -9,6 +9,7 @@ import {
   TAG_ACTION,
   VIEW,
 } from 'common/enums'
+import { isProd } from 'common/environment'
 import { ServerError } from 'common/errors'
 import logger from 'common/logger'
 import { tagSlugify } from 'common/utils'
@@ -546,7 +547,9 @@ export class TagService extends BaseService {
       }
 
       const tags = await queryTags
-      console.log('found:', ids, 'search from lasts:', tags)
+      if (!isProd) {
+        console.log('found:', ids, 'search from lasts:', tags)
+      }
 
       return {
         // /** tslint:disable-next-line:prefer-object-spread */


### PR DESCRIPTION
hot-release/4.1.1 

changed tags search results order:
1. categories of `exact match`, `partial match`, and `everything else`
2. within each category, sort by num_articles descending
