### PR TITLE
feat(tag): add fallback query for numArticles and numAuthors

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -544,8 +544,8 @@ type Tag implements Node {
   isOfficial: Boolean
 
   """Counts of this tag."""
-  numArticles: Int
-  numAuthors: Int
+  numArticles: Int!
+  numAuthors: Int!
 
   """
   #############

--- a/src/connectors/tagService.ts
+++ b/src/connectors/tagService.ts
@@ -913,7 +913,7 @@ export class TagService extends BaseService {
       .returning('*')
 
   /**
-   * Count tags by a given tag text.
+   * Count articles by a given tag id.
    */
   countArticles = async ({
     id: tagId,
@@ -951,6 +951,23 @@ export class TagService extends BaseService {
     })
 
     // console.log('countArticles:', { sql: query.toString(), tagId })
+
+    const result = await query
+    return parseInt(result ? (result.count as string) : '0', 10)
+  }
+
+  /**
+   * Count article authors by a given tag id.
+   */
+  countAuthors = async ({ id: tagId }: { id: string }) => {
+    const query = this.knex('article_tag')
+      .join('article', 'article_id', 'article.id')
+      .countDistinct('author_id')
+      .first()
+
+    query.andWhere({
+      state: ARTICLE_STATE.active,
+    })
 
     const result = await query
     return parseInt(result ? (result.count as string) : '0', 10)

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -808,8 +808,8 @@ export interface GQLTag extends GQLNode {
   /**
    * Counts of this tag.
    */
-  numArticles?: number
-  numAuthors?: number
+  numArticles: number
+  numAuthors: number
 
   /**
    * #############

--- a/src/queries/article/index.ts
+++ b/src/queries/article/index.ts
@@ -45,6 +45,8 @@ import tagEditors from './tag/editors'
 import tagFollowers from './tag/followers'
 import tagIsFollower from './tag/isFollower'
 import tagIsOfficial from './tag/isOfficial'
+import tagNumArticles from './tag/numArticles'
+import tagNumAuthors from './tag/numAuthors'
 import * as tagOSS from './tag/oss'
 import tagOwner from './tag/owner'
 import tagParticipants from './tag/participants'
@@ -122,6 +124,8 @@ export default {
     owner: tagOwner,
     isFollower: tagIsFollower,
     isOfficial: tagIsOfficial,
+    numArticles: tagNumArticles,
+    numAuthors: tagNumAuthors,
     followers: tagFollowers,
     oss: (root: any) => root,
     cover: tagCover,

--- a/src/queries/article/tag/numArticles.ts
+++ b/src/queries/article/tag/numArticles.ts
@@ -1,0 +1,15 @@
+import { TagToNumArticlesResolver } from 'definitions'
+
+const resolver: TagToNumArticlesResolver = async (
+  { id, numAuthors },
+  _,
+  { dataSources: { tagService } }
+) => {
+  if (numAuthors) {
+    return numAuthors
+  }
+
+  return tagService.countArticles({ id })
+}
+
+export default resolver

--- a/src/queries/article/tag/numAuthors.ts
+++ b/src/queries/article/tag/numAuthors.ts
@@ -1,0 +1,15 @@
+import { TagToNumAuthorsResolver } from 'definitions'
+
+const resolver: TagToNumAuthorsResolver = async (
+  { id, numAuthors },
+  _,
+  { dataSources: { tagService } }
+) => {
+  if (numAuthors) {
+    return numAuthors
+  }
+
+  return tagService.countAuthors({ id })
+}
+
+export default resolver

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -317,8 +317,8 @@ export default /* GraphQL */ `
     isOfficial: Boolean
 
     "Counts of this tag."
-    numArticles: Int
-    numAuthors: Int
+    numArticles: Int!
+    numAuthors: Int!
     ## numArticlesR3m: Int
     ## numAuthorsR3m: Int
 


### PR DESCRIPTION
* fallback to query the main DB directly if `numArticles` and `numAuthors` is not from the recommendation DB;
* make `numArticles` and `numAuthors` required;