### PR TITLE
fix(article-id): for the case when not duck'ing a Draft to Article

### DIFF
--- a/src/queries/article/index.ts
+++ b/src/queries/article/index.ts
@@ -76,6 +76,10 @@ export default {
     topics: userTopics,
   },
   Article: {
+    // when the Article is duck'ing from a Draft it has articleId,
+    // otherwise when articleId is undefined, it's a native Article, just use 'id'
+    id: ({ articleId, id }: { articleId: string; id: string }) =>
+      toGlobalId({ type: NODE_TYPES.Article, id: articleId ?? id }),
     content,
     summary,
     appreciationsReceived,
@@ -87,8 +91,6 @@ export default {
     assets,
     collection,
     collectedBy,
-    id: ({ articleId }: { articleId: string }) =>
-      toGlobalId({ type: NODE_TYPES.Article, id: articleId }),
     hasAppreciate,
     canSuperLike,
     language,


### PR DESCRIPTION
    // when the Article is duck'ing from a Draft it has articleId,
    // otherwise when articleId is undefined, it's a native Article, just use 'id'

this should resolve thematters/matters-web#2578 without need to change front-end