### PR TITLE
feat(tag): tag validation pattern for new tag naming rules

### DIFF
--- a/src/connectors/baseService.ts
+++ b/src/connectors/baseService.ts
@@ -212,17 +212,23 @@ export class BaseService extends DataSource {
     where,
     data,
     table,
+    columns = ['*'],
+    modifier,
+    skipCreate = false,
   }: {
     where: { [key: string]: any }
     data: ItemData
     table?: TableName
+    columns?: string[]
+    modifier?: (builder: Knex.QueryBuilder) => void
+    skipCreate?: boolean
   }) => {
     const tableName = table || this.table
-    const item = await this.knex(tableName).select().where(where).first()
+    const item = await this.knex(tableName).select(columns).where(where).first()
 
     // create
-    if (!item) {
-      return this.baseCreate(data, tableName)
+    if (!item && !skipCreate) {
+      return this.baseCreate(data, tableName, columns, modifier)
     }
 
     // find

--- a/src/connectors/queue/publication.ts
+++ b/src/connectors/queue/publication.ts
@@ -8,7 +8,7 @@ import {
   DB_NOTICE_TYPE,
 
   // tag related
-  MAX_TAG_CONTENT_LENGTH,
+  // MAX_TAG_CONTENT_LENGTH,
   NODE_TYPES,
   PIN_STATE,
   PUBLISH_STATE,
@@ -473,26 +473,27 @@ class PublicationQueue extends BaseQueue {
 
       tags = Array.from(
         new Set(
-          tags
-            .map(stripAllPunct)
-            .filter((tag) => tag && tag.length <= MAX_TAG_CONTENT_LENGTH)
+          tags.map(stripAllPunct)
+          // .filter((tag) => tag && tag.length <= MAX_TAG_CONTENT_LENGTH)
         )
       )
 
       // create tag records, return tag record if already exists
-      const dbTags = (await Promise.all(
-        tags.map((tag: string) =>
-          this.tagService.create(
-            {
-              content: tag,
-              creator: article.authorId,
-              editors: tagEditors,
-              owner: article.authorId,
-            },
-            ['id', 'content']
+      const dbTags = (
+        (await Promise.all(
+          tags.map((tag: string) =>
+            this.tagService.create(
+              {
+                content: tag,
+                creator: article.authorId,
+                editors: tagEditors,
+                owner: article.authorId,
+              },
+              ['id', 'content']
+            )
           )
-        )
-      )) as unknown as [{ id: string; content: string }]
+        )) as unknown as [{ id: string; content: string }]
+      ).filter(Boolean)
 
       // create article_tag record
       await this.tagService.createArticleTags({

--- a/src/connectors/systemService.ts
+++ b/src/connectors/systemService.ts
@@ -164,7 +164,6 @@ export class SystemService extends BaseService {
     entityTypeId: string,
     entityId: string
   ) =>
-    // this.baseFindOrCreate({ path }, data, 'asset')
     this.knex.transaction(async (trx) => {
       // const [newAsset] = await trx.find(asset).into('asset').returning('*')
       const { path, type, authorId, uuid } = data

--- a/src/mutations/article/editArticle.ts
+++ b/src/mutations/article/editArticle.ts
@@ -10,7 +10,7 @@ import {
   CIRCLE_STATE,
   DB_NOTICE_TYPE,
   MAX_ARTICLE_REVISION_COUNT,
-  MAX_TAG_CONTENT_LENGTH,
+  // MAX_TAG_CONTENT_LENGTH,
   MAX_TAGS_PER_ARTICLE_LIMIT,
   NODE_TYPES,
   PUBLISH_STATE,
@@ -146,9 +146,8 @@ const resolver: MutationToEditArticleResolver = async (
       : [article.authorId]
 
     tags = uniq(
-      tags
-        .map(stripAllPunct)
-        .filter((tag) => tag && tag.length <= MAX_TAG_CONTENT_LENGTH)
+      tags.map(stripAllPunct)
+      // .filter((tag) => tag && tag.length <= MAX_TAG_CONTENT_LENGTH)
     )
 
     if (tags.length >= MAX_TAGS_PER_ARTICLE_LIMIT) {

--- a/src/mutations/draft/putDraft.ts
+++ b/src/mutations/draft/putDraft.ts
@@ -6,7 +6,7 @@ import {
   ASSET_TYPE,
   CACHE_KEYWORD,
   CIRCLE_STATE,
-  MAX_TAG_CONTENT_LENGTH,
+  // MAX_TAG_CONTENT_LENGTH,
   MAX_TAGS_PER_ARTICLE_LIMIT,
   NODE_TYPES,
   PUBLISH_STATE,
@@ -35,11 +35,7 @@ import { ItemData, MutationToPutDraftResolver } from 'definitions'
 
 function sanitizeTags(tags: string[] | null | undefined) {
   if (Array.isArray(tags)) {
-    tags = _.uniq(
-      tags
-        .map(stripAllPunct)
-        .filter((tag) => tag && tag.length <= MAX_TAG_CONTENT_LENGTH)
-    )
+    tags = Array.from(new Set(tags.map(stripAllPunct)))
     if (tags.length === 0) {
       return null
     }

--- a/src/types/__test__/draft.test.ts
+++ b/src/types/__test__/draft.test.ts
@@ -1,9 +1,16 @@
 import _get from 'lodash/get'
 
-import { ARTICLE_LICENSE_TYPE, NODE_TYPES } from 'common/enums'
+import {
+  ARTICLE_LICENSE_TYPE,
+  NODE_TYPES,
+  // PUBLISH_STATE
+} from 'common/enums'
 import { toGlobalId } from 'common/utils'
 
-import { putDraft } from './utils'
+import {
+  // publishArticle,
+  putDraft,
+} from './utils'
 
 describe('put draft', () => {
   let draftId: string
@@ -37,18 +44,23 @@ describe('put draft', () => {
     const tags = [
       'abc',
       '123',
-      'tags too long | too long | too long | too long | too long', // will be omitted
+      'tags too long | too long | too long | too long | too long', // will be omitted at publishing time
     ]
-    const result = await putDraft({ draft: { id: draftId, tags } })
-    expect(_get(result, 'tags.length')).toBe(2)
-    expect(_get(result, 'tags.0')).toBe(tags[0])
-    expect(_get(result, 'tags.1')).toBe(tags[1])
+    const draft = await putDraft({ draft: { id: draftId, tags } })
+    expect(_get(draft, 'tags.length')).toBe(3)
+    expect(_get(draft, 'tags.0')).toBe(tags[0])
+    expect(_get(draft, 'tags.1')).toBe(tags[1])
+    // expect(_get(draft, 'tags.2')).toBe(tags[2])
+
+    // const { publishState } = await publishArticle({ id: draft.id })
+    // expect(publishState).toBe(PUBLISH_STATE.pending)
+    // to check dbTags.length should be 2;
 
     // should retain the tags after setting something else, without changing tags
     const tagsResult1 = await putDraft({
       draft: { id: draftId, summary: 'any-summary' },
     })
-    expect(_get(tagsResult1, 'tags.length')).toBe(2)
+    expect(_get(tagsResult1, 'tags.length')).toBe(3)
     expect(_get(tagsResult1, 'tags.0')).toBe(tags[0])
     expect(_get(tagsResult1, 'tags.1')).toBe(tags[1])
 


### PR DESCRIPTION
1. to allow select existing too-long name tag (>40 chars)
2. skip creating of too-long name tag (>40 chars)

resolve #2595

[discussion]( https://mattersnews.slack.com/archives/C88CK7Q7L/p1658283285063969?thread_ts=1658282716.534899&cid=C88CK7Q7L) 