### PR TITLE
feat(notice): revise circle notices and fix putComment notice triggers

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1688,6 +1688,11 @@ type CircleNotice implements Notice {
   actors: [User!]
   type: CircleNoticeType!
   target: Circle!
+
+  """
+  An optional arbitrary node, Comment for broadcast and discussion notices
+  """
+  node: Node
 }
 
 enum CircleNoticeType {

--- a/schema.graphql
+++ b/schema.graphql
@@ -1508,6 +1508,7 @@ enum ArticleNoticeType {
   ArticleNewAppreciation
   RevisedArticlePublished
   RevisedArticleNotPublished
+  CircleNewArticle @deprecated(reason: "No longer in use")
 }
 
 type ArticleArticleNotice implements Notice {
@@ -1559,6 +1560,7 @@ enum CommentNoticeType {
   CommentMentionedYou
   ArticleNewComment
   SubscribedArticleNewComment
+  CircleNewBroadcast @deprecated(reason: "No longer in use")
   CircleBroadcastMentionedYou
   CircleDiscussionMentionedYou
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -1508,7 +1508,6 @@ enum ArticleNoticeType {
   ArticleNewAppreciation
   RevisedArticlePublished
   RevisedArticleNotPublished
-  CircleNewArticle
 }
 
 type ArticleArticleNotice implements Notice {
@@ -1560,15 +1559,8 @@ enum CommentNoticeType {
   CommentMentionedYou
   ArticleNewComment
   SubscribedArticleNewComment
-  CircleNewBroadcast
-  CircleNewDiscussion
-  CircleMemberNewDiscussion
-  CircleMemberNewDiscussionReply
-  CircleMemberNewBroadcastReply
-  InCircleNewBroadcast
-  InCircleNewBroadcastReply
-  InCircleNewDiscussion
-  InCircleNewDiscussionReply
+  CircleBroadcastMentionedYou
+  CircleDiscussionMentionedYou
 }
 
 type CommentCommentNotice implements Notice {
@@ -1697,18 +1689,17 @@ type CircleNotice implements Notice {
 }
 
 enum CircleNoticeType {
+  CircleInvitation
+
+  """for circle owner"""
   CircleNewSubscriber
   CircleNewFollower
   CircleNewUnsubscriber
-  CircleInvitation
-  CircleNewDiscussion
-  CircleNewBroadcast
-  CircleMemberBroadcast
+  CircleMemberNewBroadcastReply
   CircleMemberNewDiscussion
   CircleMemberNewDiscussionReply
-  CircleMemberNewBroadcastReply
-  InCircleNewArticle
-  InCircleNewBroadcast
+
+  """for circle members & followers"""
   InCircleNewBroadcastReply
   InCircleNewDiscussion
   InCircleNewDiscussionReply
@@ -1731,6 +1722,11 @@ type CircleCommentNotice implements Notice {
   comment: Comment!
 }
 
+enum CircleCommentNoticeType {
+  """for circle members & followers"""
+  InCircleNewBroadcast
+}
+
 type CircleArticleNotice implements Notice {
   """Unique ID of this notice."""
   id: ID!
@@ -1748,11 +1744,8 @@ type CircleArticleNotice implements Notice {
   article: Article!
 }
 
-enum CircleCommentNoticeType {
-  CircleNewBroadcast
-}
-
 enum CircleArticleNoticeType {
+  """for circle members & followers"""
   InCircleNewArticle
 }
 

--- a/src/common/enums/notification.ts
+++ b/src/common/enums/notification.ts
@@ -9,7 +9,6 @@ export enum DB_NOTICE_TYPE {
   article_mentioned_you = 'article_mentioned_you',
   revised_article_published = 'revised_article_published',
   revised_article_not_published = 'revised_article_not_published',
-  // circle_new_article = 'circle_new_article',
 
   // article-article
   article_new_collected = 'article_new_collected',
@@ -28,33 +27,30 @@ export enum DB_NOTICE_TYPE {
   // comment
   comment_pinned = 'comment_pinned',
   comment_mentioned_you = 'comment_mentioned_you',
-  circle_broadcast_mentioned_you = 'circle_broadcast_mentioned_you',
-  circle_discussion_mentioned_you = 'circle_discussion_mentioned_you',
   article_new_comment = 'article_new_comment',
   subscribed_article_new_comment = 'subscribed_article_new_comment',
+  circle_broadcast_mentioned_you = 'circle_broadcast_mentioned_you',
+  circle_discussion_mentioned_you = 'circle_discussion_mentioned_you',
 
   // comment-comment
   comment_new_reply = 'comment_new_reply',
-  circle_broadcast_new_reply = 'circle_broadcast_new_reply',
-  circle_discussion_new_reply = 'circle_discussion_new_reply',
 
   // transaction
   payment_received_donation = 'payment_received_donation',
   payment_payout = 'payment_payout',
 
-  // circle owners
+  // circle
+  circle_invitation = 'circle_invitation',
+
+  // for circle owners
   circle_new_subscriber = 'circle_new_subscriber',
   circle_new_follower = 'circle_new_follower',
-  // circle_new_broadcast = 'circle_new_broadcast', // deprecated
-  circle_new_discussion = 'circle_new_discussion',
   circle_new_unsubscriber = 'circle_new_unsubscriber',
-  circle_invitation = 'circle_invitation',
-  circle_member_broadcast = 'circle_member_broadcast',
+  circle_member_new_broadcast_reply = 'circle_member_new_broadcast_reply',
   circle_member_new_discussion = 'circle_member_new_discussion',
   circle_member_new_discussion_reply = 'circle_member_new_discussion_reply',
-  circle_member_new_broadcast_reply = 'circle_member_new_broadcast_reply',
 
-  // members & followers in circle
+  // for circle members & followers
   in_circle_new_article = 'in_circle_new_article',
   in_circle_new_broadcast = 'in_circle_new_broadcast',
   in_circle_new_broadcast_reply = 'in_circle_new_broadcast_reply',

--- a/src/common/enums/notification.ts
+++ b/src/common/enums/notification.ts
@@ -9,6 +9,7 @@ export enum DB_NOTICE_TYPE {
   article_mentioned_you = 'article_mentioned_you',
   revised_article_published = 'revised_article_published',
   revised_article_not_published = 'revised_article_not_published',
+  circle_new_article = 'circle_new_article', // deprecated
 
   // article-article
   article_new_collected = 'article_new_collected',
@@ -29,6 +30,7 @@ export enum DB_NOTICE_TYPE {
   comment_mentioned_you = 'comment_mentioned_you',
   article_new_comment = 'article_new_comment',
   subscribed_article_new_comment = 'subscribed_article_new_comment',
+  circle_new_broadcast = 'circle_new_broadcast', // deprecated
   circle_broadcast_mentioned_you = 'circle_broadcast_mentioned_you',
   circle_discussion_mentioned_you = 'circle_discussion_mentioned_you',
 

--- a/src/connectors/__test__/notificationService.test.ts
+++ b/src/connectors/__test__/notificationService.test.ts
@@ -29,6 +29,7 @@ describe('user notify setting', () => {
     article_mentioned_you: true,
     revised_article_published: true,
     revised_article_not_published: true,
+    circle_new_article: true, // deprecated
 
     // article-article
     article_new_collected: true,
@@ -61,6 +62,7 @@ describe('user notify setting', () => {
 
     // circle
     circle_invitation: true,
+    circle_new_broadcast: true, // deprecated
 
     // circle owners
     circle_new_subscriber: true,

--- a/src/connectors/__test__/notificationService.test.ts
+++ b/src/connectors/__test__/notificationService.test.ts
@@ -29,7 +29,6 @@ describe('user notify setting', () => {
     article_mentioned_you: true,
     revised_article_published: true,
     revised_article_not_published: true,
-    // circle_new_article: true,
 
     // article-article
     article_new_collected: true,
@@ -37,16 +36,13 @@ describe('user notify setting', () => {
     // comment
     comment_pinned: true,
     comment_mentioned_you: true,
-    circle_broadcast_mentioned_you: true,
-    circle_discussion_mentioned_you: true,
     article_new_comment: true,
     subscribed_article_new_comment: false,
-    // circle_new_broadcast: true,
+    circle_broadcast_mentioned_you: true,
+    circle_discussion_mentioned_you: true,
 
     // comment-comment
     comment_new_reply: true,
-    circle_broadcast_new_reply: true,
-    circle_discussion_new_reply: true,
 
     // article-tag
     article_tag_has_been_added: true,
@@ -63,16 +59,16 @@ describe('user notify setting', () => {
     payment_received_donation: true,
     payment_payout: true,
 
+    // circle
+    circle_invitation: true,
+
     // circle owners
     circle_new_subscriber: true,
     circle_new_unsubscriber: true,
-    circle_invitation: true,
     circle_new_follower: true,
-    circle_new_discussion: true,
-    circle_member_broadcast: true,
+    circle_member_new_broadcast_reply: true,
     circle_member_new_discussion: true,
     circle_member_new_discussion_reply: true,
-    circle_member_new_broadcast_reply: true,
 
     // in circle
     in_circle_new_article: true,

--- a/src/connectors/notificationService/index.ts
+++ b/src/connectors/notificationService/index.ts
@@ -81,14 +81,8 @@ export class NotificationService extends BaseService {
       case DB_NOTICE_TYPE.circle_new_subscriber:
       case DB_NOTICE_TYPE.circle_new_follower:
       case DB_NOTICE_TYPE.circle_new_unsubscriber:
-      case DB_NOTICE_TYPE.circle_member_new_broadcast_reply:
-      case DB_NOTICE_TYPE.circle_member_new_discussion:
-      case DB_NOTICE_TYPE.circle_member_new_discussion_reply:
-      case DB_NOTICE_TYPE.in_circle_new_article:
       case DB_NOTICE_TYPE.in_circle_new_broadcast:
-      case DB_NOTICE_TYPE.in_circle_new_broadcast_reply:
-      case DB_NOTICE_TYPE.in_circle_new_discussion:
-      case DB_NOTICE_TYPE.in_circle_new_discussion_reply:
+      case DB_NOTICE_TYPE.in_circle_new_article:
         return {
           type: params.event,
           recipientId: params.recipientId,
@@ -102,6 +96,20 @@ export class NotificationService extends BaseService {
           actorId: params.actorId,
           entities: params.entities,
           resend: true,
+        }
+      case DB_NOTICE_TYPE.circle_member_new_broadcast_reply:
+      case DB_NOTICE_TYPE.circle_member_new_discussion:
+      case DB_NOTICE_TYPE.circle_member_new_discussion_reply:
+      case DB_NOTICE_TYPE.in_circle_new_broadcast_reply:
+      case DB_NOTICE_TYPE.in_circle_new_discussion:
+      case DB_NOTICE_TYPE.in_circle_new_discussion_reply:
+        return {
+          type: params.event,
+          recipientId: params.recipientId,
+          actorId: params.actorId,
+          entities: params.entities,
+          data: params.data, // update latest comment to DB `data` field
+          bundle: { replaceData: true },
         }
       // act as official annonuncement
       case DB_NOTICE_TYPE.official_announcement:

--- a/src/connectors/notificationService/index.ts
+++ b/src/connectors/notificationService/index.ts
@@ -51,7 +51,6 @@ export class NotificationService extends BaseService {
       case DB_NOTICE_TYPE.payment_payout:
       case DB_NOTICE_TYPE.revised_article_published:
       case DB_NOTICE_TYPE.revised_article_not_published:
-      // case DB_NOTICE_TYPE.circle_new_article:
       case DB_NOTICE_TYPE.crypto_wallet_airdrop:
       case DB_NOTICE_TYPE.crypto_wallet_connected:
         return {
@@ -70,8 +69,6 @@ export class NotificationService extends BaseService {
       case DB_NOTICE_TYPE.article_new_comment:
       case DB_NOTICE_TYPE.subscribed_article_new_comment:
       case DB_NOTICE_TYPE.comment_new_reply:
-      case DB_NOTICE_TYPE.circle_broadcast_new_reply:
-      case DB_NOTICE_TYPE.circle_discussion_new_reply:
       case DB_NOTICE_TYPE.article_tag_has_been_added:
       case DB_NOTICE_TYPE.article_tag_has_been_removed:
       case DB_NOTICE_TYPE.payment_received_donation:
@@ -81,13 +78,10 @@ export class NotificationService extends BaseService {
       case DB_NOTICE_TYPE.tag_leave_editor:
       case DB_NOTICE_TYPE.circle_new_subscriber:
       case DB_NOTICE_TYPE.circle_new_follower:
-      // case DB_NOTICE_TYPE.circle_new_broadcast: // deprecated
       case DB_NOTICE_TYPE.circle_new_unsubscriber:
-      case DB_NOTICE_TYPE.circle_new_discussion:
-      case DB_NOTICE_TYPE.circle_member_broadcast:
+      case DB_NOTICE_TYPE.circle_member_new_broadcast_reply:
       case DB_NOTICE_TYPE.circle_member_new_discussion:
       case DB_NOTICE_TYPE.circle_member_new_discussion_reply:
-      case DB_NOTICE_TYPE.circle_member_new_broadcast_reply:
       case DB_NOTICE_TYPE.in_circle_new_article:
       case DB_NOTICE_TYPE.in_circle_new_broadcast:
       case DB_NOTICE_TYPE.in_circle_new_broadcast_reply:

--- a/src/connectors/notificationService/index.ts
+++ b/src/connectors/notificationService/index.ts
@@ -51,6 +51,7 @@ export class NotificationService extends BaseService {
       case DB_NOTICE_TYPE.payment_payout:
       case DB_NOTICE_TYPE.revised_article_published:
       case DB_NOTICE_TYPE.revised_article_not_published:
+      case DB_NOTICE_TYPE.circle_new_article: // deprecated
       case DB_NOTICE_TYPE.crypto_wallet_airdrop:
       case DB_NOTICE_TYPE.crypto_wallet_connected:
         return {
@@ -76,6 +77,7 @@ export class NotificationService extends BaseService {
       case DB_NOTICE_TYPE.tag_leave:
       case DB_NOTICE_TYPE.tag_add_editor:
       case DB_NOTICE_TYPE.tag_leave_editor:
+      case DB_NOTICE_TYPE.circle_new_broadcast: // deprecated
       case DB_NOTICE_TYPE.circle_new_subscriber:
       case DB_NOTICE_TYPE.circle_new_follower:
       case DB_NOTICE_TYPE.circle_new_unsubscriber:

--- a/src/connectors/notificationService/mail/sendDailySummary.ts
+++ b/src/connectors/notificationService/mail/sendDailySummary.ts
@@ -34,16 +34,14 @@ export const sendDailySummary = async ({
     comment_new_reply: NoticeItem[]
     comment_mentioned_you: NoticeItem[]
 
+    circle_invitation: NoticeItem[]
+
     circle_new_subscriber: NoticeItem[]
     circle_new_follower: NoticeItem[]
     circle_new_unsubscriber: NoticeItem[]
-    circle_invitation: NoticeItem[]
-    // circle_new_broadcast: NoticeItem[]
-    circle_new_discussion: NoticeItem[]
-    circle_member_broadcast: NoticeItem[]
+    circle_member_new_broadcast_reply: NoticeItem[]
     circle_member_new_discussion: NoticeItem[]
     circle_member_new_discussion_reply: NoticeItem[]
-    circle_member_new_broadcast_reply: NoticeItem[]
 
     in_circle_new_article: NoticeItem[]
     in_circle_new_broadcast: NoticeItem[]
@@ -106,7 +104,7 @@ export const sendDailySummary = async ({
     }))
   )
 
-  // circle owners
+  // for circle owners
   const circle_new_subscriber = await Promise.all(
     notices.circle_new_subscriber.map(async ({ actors = [], entities }) => ({
       actor: await getUserDigest(actors[0]),
@@ -125,14 +123,8 @@ export const sendDailySummary = async ({
       actorCount: actors.length > 3 ? actors.length : false,
     }))
   )
-  const circle_new_discussion = await Promise.all(
-    notices.circle_new_discussion.map(async ({ actors = [], entities }) => ({
-      actor: await getUserDigest(actors[0]),
-      comment: await getCommentDigest(entities && entities.target),
-    }))
-  )
 
-  // for members in circle
+  // for circle members & followers
   const in_circle_new_article = await Promise.all(
     notices.in_circle_new_article.map(async ({ actors = [], entities }) => ({
       actor: await getUserDigest(actors[0]),
@@ -201,14 +193,12 @@ export const sendDailySummary = async ({
             comment_new_reply,
             comment_mentioned_you,
 
-            // to circle owners
+            // for circle owners
             circle_new_subscriber,
             circle_new_follower,
             circle_new_unsubscriber,
-            // circle_new_broadcast,
-            circle_new_discussion,
 
-            // for members in circle
+            // for circle members & followers
             in_circle_new_article,
             in_circle_new_broadcast,
             in_circle_new_broadcast_reply,

--- a/src/connectors/notificationService/notice.ts
+++ b/src/connectors/notificationService/notice.ts
@@ -526,7 +526,6 @@ class Notice extends BaseService {
       article_mentioned_you: setting.mention,
       revised_article_published: true,
       revised_article_not_published: true,
-      // circle_new_article: true,
 
       // article-article
       article_new_collected: setting.articleNewCollected,
@@ -534,16 +533,13 @@ class Notice extends BaseService {
       // comment
       comment_pinned: setting.articleCommentPinned,
       comment_mentioned_you: setting.mention,
-      circle_broadcast_mentioned_you: setting.mention,
-      circle_discussion_mentioned_you: setting.mention,
       article_new_comment: setting.articleNewComment,
       subscribed_article_new_comment: setting.articleSubscribedNewComment,
-      // circle_new_broadcast: true,
+      circle_broadcast_mentioned_you: setting.mention,
+      circle_discussion_mentioned_you: setting.mention,
 
       // comment-comment
       comment_new_reply: setting.articleNewComment,
-      circle_broadcast_new_reply: true,
-      circle_discussion_new_reply: setting.circleNewDiscussion,
 
       // article-tag
       article_tag_has_been_added: true,
@@ -560,17 +556,17 @@ class Notice extends BaseService {
       payment_received_donation: true,
       payment_payout: true,
 
+      // circle
+      circle_invitation: true,
+
       // circle owners
       circle_new_subscriber: setting.circleNewSubscriber,
       circle_new_unsubscriber: setting.circleNewUnsubscriber,
-      circle_invitation: true,
       circle_new_follower: setting.circleNewFollower,
-      circle_new_discussion: setting.circleNewDiscussion,
-      circle_member_broadcast: setting.circleMemberBroadcast,
+      circle_member_new_broadcast_reply: setting.circleMemberNewBroadcastReply,
       circle_member_new_discussion: setting.circleMemberNewDiscussion,
       circle_member_new_discussion_reply:
         setting.circleMemberNewDiscussionReply,
-      circle_member_new_broadcast_reply: setting.circleMemberNewBroadcastReply,
 
       // in circle
       in_circle_new_article: setting.inCircleNewArticle,

--- a/src/connectors/notificationService/notice.ts
+++ b/src/connectors/notificationService/notice.ts
@@ -526,6 +526,7 @@ class Notice extends BaseService {
       article_mentioned_you: setting.mention,
       revised_article_published: true,
       revised_article_not_published: true,
+      circle_new_article: true, // deprecated
 
       // article-article
       article_new_collected: setting.articleNewCollected,
@@ -535,6 +536,7 @@ class Notice extends BaseService {
       comment_mentioned_you: setting.mention,
       article_new_comment: setting.articleNewComment,
       subscribed_article_new_comment: setting.articleSubscribedNewComment,
+      circle_new_broadcast: true, // deprecated
       circle_broadcast_mentioned_you: setting.mention,
       circle_discussion_mentioned_you: setting.mention,
 

--- a/src/connectors/queue/appreciation.ts
+++ b/src/connectors/queue/appreciation.ts
@@ -143,13 +143,7 @@ class AppreciationQueue extends BaseQueue {
         event: DB_NOTICE_TYPE.article_new_appreciation,
         actorId: sender.id,
         recipientId: author.id,
-        entities: [
-          {
-            type: 'target',
-            entityTable: 'article',
-            entity: article,
-          },
-        ],
+        entities: [{ type: 'target', entityTable: 'article', entity: article }],
       })
 
       // invalidate cache

--- a/src/connectors/queue/emails.ts
+++ b/src/connectors/queue/emails.ts
@@ -101,25 +101,23 @@ class EmailsQueue extends BaseQueue {
                 DB_NOTICE_TYPE.comment_mentioned_you
               ),
 
-              // circle owners
+              // circle
+              circle_invitation: filterNotices(
+                DB_NOTICE_TYPE.circle_invitation
+              ),
+
+              // for circle owners
               circle_new_subscriber: filterNotices(
                 DB_NOTICE_TYPE.circle_new_subscriber
               ),
               circle_new_follower: filterNotices(
                 DB_NOTICE_TYPE.circle_new_follower
               ),
-              // circle_new_broadcast: filterNotices(DB_NOTICE_TYPE.circle_new_broadcast),
-              circle_new_discussion: filterNotices(
-                DB_NOTICE_TYPE.circle_new_discussion
-              ),
               circle_new_unsubscriber: filterNotices(
                 DB_NOTICE_TYPE.circle_new_unsubscriber
               ),
-              circle_invitation: filterNotices(
-                DB_NOTICE_TYPE.circle_invitation
-              ),
-              circle_member_broadcast: filterNotices(
-                DB_NOTICE_TYPE.circle_member_broadcast
+              circle_member_new_broadcast_reply: filterNotices(
+                DB_NOTICE_TYPE.circle_member_new_broadcast_reply
               ),
               circle_member_new_discussion: filterNotices(
                 DB_NOTICE_TYPE.circle_member_new_discussion
@@ -127,11 +125,8 @@ class EmailsQueue extends BaseQueue {
               circle_member_new_discussion_reply: filterNotices(
                 DB_NOTICE_TYPE.circle_member_new_discussion_reply
               ),
-              circle_member_new_broadcast_reply: filterNotices(
-                DB_NOTICE_TYPE.circle_member_new_broadcast_reply
-              ),
 
-              // members in circle
+              // for circle members & followers
               in_circle_new_article: filterNotices(
                 DB_NOTICE_TYPE.circle_member_new_discussion_reply
               ),

--- a/src/connectors/queue/payTo.ts
+++ b/src/connectors/queue/payTo.ts
@@ -1,5 +1,6 @@
 import { invalidateFQC } from '@matters/apollo-response-cache'
 import Queue from 'bull'
+import _capitalize from 'lodash/capitalize'
 
 import {
   DB_NOTICE_TYPE,
@@ -155,13 +156,7 @@ class PayToQueue extends BaseQueue {
         event: DB_NOTICE_TYPE.payment_received_donation,
         actorId: sender.id,
         recipientId: recipient.id,
-        entities: [
-          {
-            type: 'target',
-            entityTable: 'transaction',
-            entity: tx,
-          },
-        ],
+        entities: [{ type: 'target', entityTable: 'transaction', entity: tx }],
       })
 
       this.notificationService.mail.sendPayment({
@@ -185,7 +180,9 @@ class PayToQueue extends BaseQueue {
           tx.targetType
         )
         const entityType =
-          NODE_TYPES[(entity?.table as keyof typeof NODE_TYPES) || '']
+          NODE_TYPES[
+            (_capitalize(entity?.table) as keyof typeof NODE_TYPES) || ''
+          ]
         if (entityType && this.cacheService) {
           invalidateFQC({
             node: { type: entityType, id: tx.targetId },

--- a/src/connectors/queue/publication.ts
+++ b/src/connectors/queue/publication.ts
@@ -313,11 +313,7 @@ class PublicationQueue extends BaseQueue {
           event: DB_NOTICE_TYPE.article_published,
           recipientId: article.authorId,
           entities: [
-            {
-              type: 'target',
-              entityTable: 'article',
-              entity: article,
-            },
+            { type: 'target', entityTable: 'article', entity: article },
           ],
         })
         job.progress(95)
@@ -391,11 +387,7 @@ class PublicationQueue extends BaseQueue {
         recipientId: collection.authorId,
         actorId: article.authorId,
         entities: [
-          {
-            type: 'target',
-            entityTable: 'article',
-            entity: collection,
-          },
+          { type: 'target', entityTable: 'article', entity: collection },
           {
             type: 'collection',
             entityTable: 'article',
@@ -451,11 +443,7 @@ class PublicationQueue extends BaseQueue {
         recipientId,
         actorId: circle.owner, // viewer.id,
         entities: [
-          {
-            type: 'target',
-            entityTable: 'circle',
-            entity: circle,
-          },
+          { type: 'target', entityTable: 'circle', entity: circle },
           {
             type: 'article',
             entityTable: 'article',
@@ -558,13 +546,7 @@ class PublicationQueue extends BaseQueue {
         event: DB_NOTICE_TYPE.article_mentioned_you,
         actorId: article.authorId,
         recipientId,
-        entities: [
-          {
-            type: 'target',
-            entityTable: 'article',
-            entity: article,
-          },
-        ],
+        entities: [{ type: 'target', entityTable: 'article', entity: article }],
       })
     })
   }

--- a/src/connectors/queue/publication.ts
+++ b/src/connectors/queue/publication.ts
@@ -430,7 +430,11 @@ class PublicationQueue extends BaseQueue {
         table: 'article_circle',
         where: data,
         create: { ...data, access: draft.access },
-        update: { ...data, access: draft.access, updatedAt: this.knex.fn.now() },
+        update: {
+          ...data,
+          access: draft.access,
+          updatedAt: this.knex.fn.now(),
+        },
       })
     }
 

--- a/src/connectors/queue/revision.ts
+++ b/src/connectors/queue/revision.ts
@@ -300,11 +300,7 @@ class RevisionQueue extends BaseQueue {
             event: DB_NOTICE_TYPE.revised_article_published,
             recipientId: article.authorId,
             entities: [
-              {
-                type: 'target',
-                entityTable: 'article',
-                entity: article,
-              },
+              { type: 'target', entityTable: 'article', entity: article },
             ],
           })
           job.progress(95)
@@ -351,11 +347,7 @@ class RevisionQueue extends BaseQueue {
           event: DB_NOTICE_TYPE.revised_article_not_published,
           recipientId: article.authorId,
           entities: [
-            {
-              type: 'target',
-              entityTable: 'article',
-              entity: article,
-            },
+            { type: 'target', entityTable: 'article', entity: article },
           ],
         })
 
@@ -417,13 +409,7 @@ class RevisionQueue extends BaseQueue {
         event: DB_NOTICE_TYPE.article_mentioned_you,
         actorId: article.authorId,
         recipientId,
-        entities: [
-          {
-            type: 'target',
-            entityTable: 'article',
-            entity: article,
-          },
-        ],
+        entities: [{ type: 'target', entityTable: 'article', entity: article }],
       })
     })
   }

--- a/src/connectors/userService.ts
+++ b/src/connectors/userService.ts
@@ -827,8 +827,7 @@ export class UserService extends BaseService {
 
     return Array.from(
       new Set([
-        // circle.owner, // add notice to circle owner
-        ...members.map((m) => m.userId),
+        ...members.map((s) => s.userId),
         ...followers.map((f) => f.userId),
       ])
     )

--- a/src/definitions/notification.d.ts
+++ b/src/definitions/notification.d.ts
@@ -302,6 +302,7 @@ export interface NoticeCircleMemberNewBroadcastReplyParams
   recipientId: string
   actorId: string
   entities: [NotificationEntity<'target', 'circle'>]
+  data: { entityTypeId: string; entityId: string }
 }
 
 export interface NoticeCircleMemberNewDiscussionParams
@@ -310,6 +311,7 @@ export interface NoticeCircleMemberNewDiscussionParams
   recipientId: string
   actorId: string
   entities: [NotificationEntity<'target', 'circle'>]
+  data: { entityTypeId: string; entityId: string }
 }
 
 export interface NoticeCircleMemberNewDiscussionReplyParams
@@ -318,6 +320,7 @@ export interface NoticeCircleMemberNewDiscussionReplyParams
   recipientId: string
   actorId: string
   entities: [NotificationEntity<'target', 'circle'>]
+  data: { entityTypeId: string; entityId: string }
 }
 
 // For circle subscrbers & followers
@@ -349,6 +352,7 @@ export interface NoticeInCircleNewDiscussionParams
   actorId: string
   recipientId: string
   entities: [NotificationEntity<'target', 'circle'>]
+  data: { entityTypeId: string; entityId: string }
 }
 
 export interface NoticeInCircleNewBroadcastReplyParams
@@ -357,6 +361,7 @@ export interface NoticeInCircleNewBroadcastReplyParams
   actorId: string
   recipientId: string
   entities: [NotificationEntity<'target', 'circle'>]
+  data: { entityTypeId: string; entityId: string }
 }
 
 export interface NoticeInCircleNewDiscussionReplyParams
@@ -365,6 +370,7 @@ export interface NoticeInCircleNewDiscussionReplyParams
   actorId: string
   recipientId: string
   entities: [NotificationEntity<'target', 'circle'>]
+  data: { entityTypeId: string; entityId: string }
 }
 
 /**
@@ -510,8 +516,13 @@ export type NoticeEntity = {
 export type NoticeEntitiesMap = Record<NoticeEntityType, any>
 export type NoticeMessage = string
 export type NoticeData = {
+  // used by official annoncement notices
   url?: string
+  // reason for banned/frozen users, not in used
   reason?: string
+  // arbitrary entity, used by circle broadcast/discussion notices
+  entityTypeId?: string
+  entityId?: string
 }
 
 export type NoticeDetail = {
@@ -538,5 +549,10 @@ export type PutNoticeParams = {
   entities?: NotificationEntity[]
   message?: NoticeMessage | null
   data?: NoticeData | null
-  resend?: boolean
+
+  resend?: boolean // used by circle invitation notice
+
+  bundle?: {
+    replaceData: boolean // used by circle broadcast/discussion notices
+  }
 }

--- a/src/definitions/notification.d.ts
+++ b/src/definitions/notification.d.ts
@@ -161,87 +161,10 @@ export interface NoticeSubscribedArticleNewCommentParams
   ]
 }
 
-export interface NoticeCircleNewDiscussionParams
-  extends NotificationRequiredParams {
-  event: DB_NOTICE_TYPE.circle_new_discussion
-  recipientId: string
-  actorId: string
-  entities: [
-    NotificationEntity<'target', 'circle'>
-    // NotificationEntity<'comment', 'comment'>,
-  ]
-}
-
-export interface NoticeCircleMemberBroadcastParams
-  extends NotificationRequiredParams {
-  event: DB_NOTICE_TYPE.circle_member_broadcast
-  recipientId: string
-  actorId: string
-  entities: [
-    NotificationEntity<'target', 'circle'>
-    // NotificationEntity<'comment', 'comment'>
-  ]
-}
-
-export interface NoticeCircleMemberNewDiscussionParams
-  extends NotificationRequiredParams {
-  event: DB_NOTICE_TYPE.circle_member_new_discussion
-  recipientId: string
-  actorId: string
-  entities: [
-    NotificationEntity<'target', 'circle'>
-    // NotificationEntity<'comment', 'comment'>,
-  ]
-}
-
-export interface NoticeCircleMemberNewDiscussionReplyParams
-  extends NotificationRequiredParams {
-  event: DB_NOTICE_TYPE.circle_member_new_discussion_reply
-  recipientId: string
-  actorId: string
-  entities: [
-    NotificationEntity<'target', 'circle'>
-    // NotificationEntity<'comment', 'comment'>,
-  ]
-}
-
-export interface NoticeCircleMemberNewBroadcastReplyParams
-  extends NotificationRequiredParams {
-  event: DB_NOTICE_TYPE.circle_member_new_broadcast_reply
-  recipientId: string
-  actorId: string
-  entities: [
-    NotificationEntity<'target', 'circle'>
-    // NotificationEntity<'comment', 'comment'>,
-  ]
-}
-
 // Comment-Comment
 export interface NoticeCommentNewReplyParams
   extends NotificationRequiredParams {
   event: DB_NOTICE_TYPE.comment_new_reply
-  recipientId: string
-  actorId: string
-  entities: [
-    NotificationEntity<'target', 'comment'>,
-    NotificationEntity<'reply', 'comment'>
-  ]
-}
-
-export interface NoticeCircleBroadcastNewReplyParams
-  extends NotificationRequiredParams {
-  event: DB_NOTICE_TYPE.circle_broadcast_new_reply
-  recipientId: string
-  actorId: string
-  entities: [
-    NotificationEntity<'target', 'comment'>,
-    NotificationEntity<'reply', 'comment'>
-  ]
-}
-
-export interface NoticeCircleDiscussionNewReplyParams
-  extends NotificationRequiredParams {
-  event: DB_NOTICE_TYPE.circle_discussion_new_reply
   recipientId: string
   actorId: string
   entities: [
@@ -324,6 +247,15 @@ export interface NoticePaymentPayoutParams extends NotificationRequiredParams {
 /**
  * Circle
  */
+export interface NoticeCircleInvitationParams
+  extends NotificationRequiredParams {
+  event: DB_NOTICE_TYPE.circle_invitation
+  actorId: string
+  recipientId: string
+  entities: [NotificationEntity<'target', 'circle'>]
+}
+
+// for circle owner
 export interface NoticeCircleNewSubscriberParams
   extends NotificationRequiredParams {
   event: DB_NOTICE_TYPE.circle_new_subscriber
@@ -348,14 +280,31 @@ export interface NoticeCircleNewUnsubscriberParams
   entities: [NotificationEntity<'target', 'circle'>]
 }
 
-export interface NoticeCircleInvitationParams
+export interface NoticeCircleMemberNewBroadcastReplyParams
   extends NotificationRequiredParams {
-  event: DB_NOTICE_TYPE.circle_invitation
-  actorId: string
+  event: DB_NOTICE_TYPE.circle_member_new_broadcast_reply
   recipientId: string
+  actorId: string
   entities: [NotificationEntity<'target', 'circle'>]
 }
 
+export interface NoticeCircleMemberNewDiscussionParams
+  extends NotificationRequiredParams {
+  event: DB_NOTICE_TYPE.circle_member_new_discussion
+  recipientId: string
+  actorId: string
+  entities: [NotificationEntity<'target', 'circle'>]
+}
+
+export interface NoticeCircleMemberNewDiscussionReplyParams
+  extends NotificationRequiredParams {
+  event: DB_NOTICE_TYPE.circle_member_new_discussion_reply
+  recipientId: string
+  actorId: string
+  entities: [NotificationEntity<'target', 'circle'>]
+}
+
+// For circle subscrbers & followers
 export interface NoticeInCircleNewArticleParams
   extends NotificationRequiredParams {
   event: DB_NOTICE_TYPE.in_circle_new_article
@@ -383,10 +332,7 @@ export interface NoticeInCircleNewDiscussionParams
   event: DB_NOTICE_TYPE.in_circle_new_discussion
   actorId: string
   recipientId: string
-  entities: [
-    NotificationEntity<'target', 'circle'>
-    // NotificationEntity<'comment', 'comment'>
-  ]
+  entities: [NotificationEntity<'target', 'circle'>]
 }
 
 export interface NoticeInCircleNewBroadcastReplyParams
@@ -394,10 +340,7 @@ export interface NoticeInCircleNewBroadcastReplyParams
   event: DB_NOTICE_TYPE.in_circle_new_broadcast_reply
   actorId: string
   recipientId: string
-  entities: [
-    NotificationEntity<'target', 'circle'>
-    // NotificationEntity<'comment', 'comment'>
-  ]
+  entities: [NotificationEntity<'target', 'circle'>]
 }
 
 export interface NoticeInCircleNewDiscussionReplyParams
@@ -405,10 +348,7 @@ export interface NoticeInCircleNewDiscussionReplyParams
   event: DB_NOTICE_TYPE.in_circle_new_discussion_reply
   actorId: string
   recipientId: string
-  entities: [
-    NotificationEntity<'target', 'circle'>
-    // NotificationEntity<'comment', 'comment'>
-  ]
+  entities: [NotificationEntity<'target', 'circle'>]
 }
 
 /**
@@ -494,23 +434,14 @@ export type NotificationPrarms =
   | NoticeArticleMentionedYouParams
   | NoticeRevisedArticlePublishedParams
   | NoticeRevisedArticleNotPublishedParams
-  // | NoticeCircleNewArticleParams
   // Comment
   | NoticeCommentPinnedParams
   | NoticeCommentMentionedYouParams
+  | NoticeSubscribedArticleNewCommentParams
   | NoticeCircleBroadcastMentionedYouParams
   | NoticeCircleDiscussionMentionedYouParams
-  | NoticeSubscribedArticleNewCommentParams
-  // | NoticeCircleNewBroadcastParams // deprecated
-  | NoticeCircleNewDiscussionParams
-  | NoticeCircleMemberBroadcastParams
-  | NoticeCircleMemberNewDiscussionParams
-  | NoticeCircleMemberNewDiscussionReplyParams
-  | NoticeCircleMemberNewBroadcastReplyParams
   // Comment-Comment
   | NoticeCommentNewReplyParams
-  | NoticeCircleBroadcastNewReplyParams
-  | NoticeCircleDiscussionNewReplyParams
   // Tag
   | NoticeArticleTagHasBeenAddedParams
   | NoticeArticleTagHasBeenRemovedParams
@@ -522,11 +453,15 @@ export type NotificationPrarms =
   | NoticePaymentReceivedDonationParams
   | NoticePaymentPayoutParams
   // Circle
+  | NoticeCircleInvitationParams
+  // Circle: Owner
   | NoticeCircleNewSubscriberParams
   | NoticeCircleNewFollowerParams
   | NoticeCircleNewUnsubscriberParams
-  | NoticeCircleInvitationParams
-  // Circle members
+  | NoticeCircleMemberNewBroadcastReplyParams
+  | NoticeCircleMemberNewDiscussionParams
+  | NoticeCircleMemberNewDiscussionReplyParams
+  // Circle: Members & Followers
   | NoticeInCircleNewArticleParams
   | NoticeInCircleNewBroadcastParams
   | NoticeInCircleNewDiscussionParams

--- a/src/definitions/notification.d.ts
+++ b/src/definitions/notification.d.ts
@@ -93,6 +93,14 @@ export interface NoticeRevisedArticleNotPublishedParams
   entities: [NotificationEntity<'target', 'article'>]
 }
 
+// deprecated
+export interface NoticeCircleNewArticleParams
+  extends NotificationRequiredParams {
+  event: DB_NOTICE_TYPE.circle_new_article
+  recipientId: string
+  entities: [NotificationEntity<'target', 'article'>]
+}
+
 // Article-Article
 export interface NoticeArticleNewCollectedParams
   extends NotificationRequiredParams {
@@ -159,6 +167,14 @@ export interface NoticeSubscribedArticleNewCommentParams
     NotificationEntity<'target', 'article'>,
     NotificationEntity<'comment', 'comment'>
   ]
+}
+
+export interface NoticeCircleNewBroadcastParams
+  extends NotificationRequiredParams {
+  event: DB_NOTICE_TYPE.circle_new_broadcast
+  recipientId: string
+  actorId: string
+  entities: [NotificationEntity<'target', 'comment'>]
 }
 
 // Comment-Comment
@@ -434,10 +450,12 @@ export type NotificationPrarms =
   | NoticeArticleMentionedYouParams
   | NoticeRevisedArticlePublishedParams
   | NoticeRevisedArticleNotPublishedParams
+  | NoticeCircleNewArticleParams // deprecated
   // Comment
   | NoticeCommentPinnedParams
   | NoticeCommentMentionedYouParams
   | NoticeSubscribedArticleNewCommentParams
+  | NoticeCircleNewBroadcastParams // deprecated
   | NoticeCircleBroadcastMentionedYouParams
   | NoticeCircleDiscussionMentionedYouParams
   // Comment-Comment

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -2095,7 +2095,6 @@ export const enum GQLArticleNoticeType {
   ArticleNewAppreciation = 'ArticleNewAppreciation',
   RevisedArticlePublished = 'RevisedArticlePublished',
   RevisedArticleNotPublished = 'RevisedArticleNotPublished',
-  CircleNewArticle = 'CircleNewArticle',
 }
 
 export interface GQLArticleArticleNotice extends GQLNotice {
@@ -2163,15 +2162,8 @@ export const enum GQLCommentNoticeType {
   CommentMentionedYou = 'CommentMentionedYou',
   ArticleNewComment = 'ArticleNewComment',
   SubscribedArticleNewComment = 'SubscribedArticleNewComment',
-  CircleNewBroadcast = 'CircleNewBroadcast',
-  CircleNewDiscussion = 'CircleNewDiscussion',
-  CircleMemberNewDiscussion = 'CircleMemberNewDiscussion',
-  CircleMemberNewDiscussionReply = 'CircleMemberNewDiscussionReply',
-  CircleMemberNewBroadcastReply = 'CircleMemberNewBroadcastReply',
-  InCircleNewBroadcast = 'InCircleNewBroadcast',
-  InCircleNewBroadcastReply = 'InCircleNewBroadcastReply',
-  InCircleNewDiscussion = 'InCircleNewDiscussion',
-  InCircleNewDiscussionReply = 'InCircleNewDiscussionReply',
+  CircleBroadcastMentionedYou = 'CircleBroadcastMentionedYou',
+  CircleDiscussionMentionedYou = 'CircleDiscussionMentionedYou',
 }
 
 export interface GQLCommentCommentNotice extends GQLNotice {
@@ -2345,18 +2337,21 @@ export interface GQLCircleNotice extends GQLNotice {
 }
 
 export const enum GQLCircleNoticeType {
+  CircleInvitation = 'CircleInvitation',
+
+  /**
+   * for circle owner
+   */
   CircleNewSubscriber = 'CircleNewSubscriber',
   CircleNewFollower = 'CircleNewFollower',
   CircleNewUnsubscriber = 'CircleNewUnsubscriber',
-  CircleInvitation = 'CircleInvitation',
-  CircleNewDiscussion = 'CircleNewDiscussion',
-  CircleNewBroadcast = 'CircleNewBroadcast',
-  CircleMemberBroadcast = 'CircleMemberBroadcast',
+  CircleMemberNewBroadcastReply = 'CircleMemberNewBroadcastReply',
   CircleMemberNewDiscussion = 'CircleMemberNewDiscussion',
   CircleMemberNewDiscussionReply = 'CircleMemberNewDiscussionReply',
-  CircleMemberNewBroadcastReply = 'CircleMemberNewBroadcastReply',
-  InCircleNewArticle = 'InCircleNewArticle',
-  InCircleNewBroadcast = 'InCircleNewBroadcast',
+
+  /**
+   * for circle members & followers
+   */
   InCircleNewBroadcastReply = 'InCircleNewBroadcastReply',
   InCircleNewDiscussion = 'InCircleNewDiscussion',
   InCircleNewDiscussionReply = 'InCircleNewDiscussionReply',
@@ -2387,6 +2382,13 @@ export interface GQLCircleCommentNotice extends GQLNotice {
   comment: GQLComment
 }
 
+export const enum GQLCircleCommentNoticeType {
+  /**
+   * for circle members & followers
+   */
+  InCircleNewBroadcast = 'InCircleNewBroadcast',
+}
+
 export interface GQLCircleArticleNotice extends GQLNotice {
   /**
    * Unique ID of this notice.
@@ -2412,11 +2414,10 @@ export interface GQLCircleArticleNotice extends GQLNotice {
   article: GQLArticle
 }
 
-export const enum GQLCircleCommentNoticeType {
-  CircleNewBroadcast = 'CircleNewBroadcast',
-}
-
 export const enum GQLCircleArticleNoticeType {
+  /**
+   * for circle members & followers
+   */
   InCircleNewArticle = 'InCircleNewArticle',
 }
 

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -2095,6 +2095,12 @@ export const enum GQLArticleNoticeType {
   ArticleNewAppreciation = 'ArticleNewAppreciation',
   RevisedArticlePublished = 'RevisedArticlePublished',
   RevisedArticleNotPublished = 'RevisedArticleNotPublished',
+
+  /**
+   *
+   * @deprecated No longer in use
+   */
+  CircleNewArticle = 'CircleNewArticle',
 }
 
 export interface GQLArticleArticleNotice extends GQLNotice {
@@ -2162,6 +2168,12 @@ export const enum GQLCommentNoticeType {
   CommentMentionedYou = 'CommentMentionedYou',
   ArticleNewComment = 'ArticleNewComment',
   SubscribedArticleNewComment = 'SubscribedArticleNewComment',
+
+  /**
+   *
+   * @deprecated No longer in use
+   */
+  CircleNewBroadcast = 'CircleNewBroadcast',
   CircleBroadcastMentionedYou = 'CircleBroadcastMentionedYou',
   CircleDiscussionMentionedYou = 'CircleDiscussionMentionedYou',
 }

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -2346,6 +2346,11 @@ export interface GQLCircleNotice extends GQLNotice {
   actors?: Array<GQLUser>
   type: GQLCircleNoticeType
   target: GQLCircle
+
+  /**
+   * An optional arbitrary node, Comment for broadcast and discussion notices
+   */
+  node?: GQLNode
 }
 
 export const enum GQLCircleNoticeType {
@@ -9278,6 +9283,7 @@ export interface GQLCircleNoticeTypeResolver<TParent = any> {
   actors?: CircleNoticeToActorsResolver<TParent>
   type?: CircleNoticeToTypeResolver<TParent>
   target?: CircleNoticeToTargetResolver<TParent>
+  node?: CircleNoticeToNodeResolver<TParent>
 }
 
 export interface CircleNoticeToIdResolver<TParent = any, TResult = any> {
@@ -9326,6 +9332,15 @@ export interface CircleNoticeToTypeResolver<TParent = any, TResult = any> {
 }
 
 export interface CircleNoticeToTargetResolver<TParent = any, TResult = any> {
+  (
+    parent: TParent,
+    args: {},
+    context: Context,
+    info: GraphQLResolveInfo
+  ): TResult
+}
+
+export interface CircleNoticeToNodeResolver<TParent = any, TResult = any> {
   (
     parent: TParent,
     args: {},

--- a/src/mutations/article/addArticlesTags.ts
+++ b/src/mutations/article/addArticlesTags.ts
@@ -45,11 +45,7 @@ const triggerNotice = async ({
       recipientId: user,
       actorId: viewerId,
       entities: [
-        {
-          type: 'target',
-          entityTable: 'article',
-          entity: article,
-        },
+        { type: 'target', entityTable: 'article', entity: article },
         {
           type: 'tag',
           entityTable: 'tag',

--- a/src/mutations/article/deleteArticlesTags.ts
+++ b/src/mutations/article/deleteArticlesTags.ts
@@ -72,11 +72,7 @@ const resolver: MutationToDeleteArticlesTagsResolver = async (
       recipientId: article.authorId,
       actorId: viewer.id,
       entities: [
-        {
-          type: 'target',
-          entityTable: 'article',
-          entity: article,
-        },
+        { type: 'target', entityTable: 'article', entity: article },
         {
           type: 'tag',
           entityTable: 'tag',

--- a/src/mutations/article/editArticle.ts
+++ b/src/mutations/article/editArticle.ts
@@ -350,11 +350,7 @@ const resolver: MutationToEditArticleResolver = async (
         recipientId: targetCollection.authorId,
         actorId: article.authorId,
         entities: [
-          {
-            type: 'target',
-            entityTable: 'article',
-            entity: targetCollection,
-          },
+          { type: 'target', entityTable: 'article', entity: targetCollection },
           {
             type: 'collection',
             entityTable: 'article',

--- a/src/mutations/article/toggleSubscribeArticle.ts
+++ b/src/mutations/article/toggleSubscribeArticle.ts
@@ -85,13 +85,7 @@ const resolver: MutationToToggleSubscribeArticleResolver = async (
       event: DB_NOTICE_TYPE.article_new_subscriber,
       actorId: viewer.id,
       recipientId: article.authorId,
-      entities: [
-        {
-          type: 'target',
-          entityTable: 'article',
-          entity: article,
-        },
-      ],
+      entities: [{ type: 'target', entityTable: 'article', entity: article }],
     })
   } else {
     await atomService.deleteMany({

--- a/src/mutations/article/updateArticlesTags.ts
+++ b/src/mutations/article/updateArticlesTags.ts
@@ -43,11 +43,7 @@ const triggerNotice = async ({
       recipientId: user,
       actorId: viewerId,
       entities: [
-        {
-          type: 'target',
-          entityTable: 'article',
-          entity: article,
-        },
+        { type: 'target', entityTable: 'article', entity: article },
         {
           type: 'tag',
           entityTable: 'tag',

--- a/src/mutations/article/updateTagSetting.ts
+++ b/src/mutations/article/updateTagSetting.ts
@@ -101,13 +101,7 @@ const resolver: MutationToUpdateTagSettingResolver = async (
           event: DB_NOTICE_TYPE.tag_adoption,
           recipientId: participant.authorId,
           actorId: viewer.id,
-          entities: [
-            {
-              type: 'target',
-              entityTable: 'tag',
-              entity: tag,
-            },
-          ],
+          entities: [{ type: 'target', entityTable: 'tag', entity: tag }],
         })
       })
       break
@@ -136,13 +130,7 @@ const resolver: MutationToUpdateTagSettingResolver = async (
             event: DB_NOTICE_TYPE.tag_leave,
             recipientId: editor,
             actorId: viewer.id,
-            entities: [
-              {
-                type: 'target',
-                entityTable: 'tag',
-                entity: tag,
-              },
-            ],
+            entities: [{ type: 'target', entityTable: 'tag', entity: tag }],
           })
         })
       }
@@ -210,13 +198,7 @@ const resolver: MutationToUpdateTagSettingResolver = async (
           event: DB_NOTICE_TYPE.tag_add_editor,
           recipientId: recipient.id,
           actorId: viewer.id,
-          entities: [
-            {
-              type: 'target',
-              entityTable: 'tag',
-              entity: tag,
-            },
-          ],
+          entities: [{ type: 'target', entityTable: 'tag', entity: tag }],
         })
       })
       break
@@ -268,13 +250,7 @@ const resolver: MutationToUpdateTagSettingResolver = async (
           event: DB_NOTICE_TYPE.tag_leave_editor,
           recipientId: tag.owner,
           actorId: viewer.id,
-          entities: [
-            {
-              type: 'target',
-              entityTable: 'tag',
-              entity: tag,
-            },
-          ],
+          entities: [{ type: 'target', entityTable: 'tag', entity: tag }],
         })
       }
       break

--- a/src/mutations/circle/invite.ts
+++ b/src/mutations/circle/invite.ts
@@ -198,13 +198,7 @@ const resolver: MutationToInviteResolver = async (
         event: DB_NOTICE_TYPE.circle_invitation,
         actorId: viewer.id,
         recipientId: recipient.id,
-        entities: [
-          {
-            type: 'target',
-            entityTable: 'circle',
-            entity: circle,
-          },
-        ],
+        entities: [{ type: 'target', entityTable: 'circle', entity: circle }],
       })
     }
 

--- a/src/mutations/circle/putCircleArticles.ts
+++ b/src/mutations/circle/putCircleArticles.ts
@@ -210,16 +210,8 @@ const resolver: MutationToPutCircleArticlesResolver = async (
           actorId: viewer.id,
           recipientId,
           entities: [
-            {
-              type: 'target',
-              entityTable: 'circle',
-              entity: circle,
-            },
-            {
-              type: 'article',
-              entityTable: 'article',
-              entity: article,
-            },
+            { type: 'target', entityTable: 'circle', entity: circle },
+            { type: 'article', entityTable: 'article', entity: article },
           ],
         })
       })

--- a/src/mutations/circle/subscribeCircle.ts
+++ b/src/mutations/circle/subscribeCircle.ts
@@ -176,13 +176,7 @@ const resolver: MutationToSubscribeCircleResolver = async (
       event: DB_NOTICE_TYPE.circle_new_subscriber,
       actorId: viewer.id,
       recipientId: circle.owner,
-      entities: [
-        {
-          type: 'target',
-          entityTable: 'circle',
-          entity: circle,
-        },
-      ],
+      entities: [{ type: 'target', entityTable: 'circle', entity: circle }],
     })
 
     // auto follow circle without notification

--- a/src/mutations/circle/toggleFollowCircle.ts
+++ b/src/mutations/circle/toggleFollowCircle.ts
@@ -78,13 +78,7 @@ const resolver: MutationToToggleFollowCircleResolver = async (
           event: DB_NOTICE_TYPE.circle_new_follower,
           actorId: viewer.id,
           recipientId: circle.owner,
-          entities: [
-            {
-              type: 'target',
-              entityTable: 'circle',
-              entity: circle,
-            },
-          ],
+          entities: [{ type: 'target', entityTable: 'circle', entity: circle }],
         })
       }
       break

--- a/src/mutations/circle/unsubscribeCircle.ts
+++ b/src/mutations/circle/unsubscribeCircle.ts
@@ -149,13 +149,7 @@ const resolver: MutationToUnsubscribeCircleResolver = async (
     event: DB_NOTICE_TYPE.circle_new_unsubscriber,
     actorId: viewer.id,
     recipientId: circle.owner,
-    entities: [
-      {
-        type: 'target',
-        entityTable: 'circle',
-        entity: circle,
-      },
-    ],
+    entities: [{ type: 'target', entityTable: 'circle', entity: circle }],
   })
 
   // invalidate cache

--- a/src/mutations/comment/putComment.ts
+++ b/src/mutations/comment/putComment.ts
@@ -305,85 +305,56 @@ const resolver: MutationToPutCommentResolver = async (
     const isReplyingLevel2Comment =
       !isLevel1Comment && parentCommentId !== replyToCommentId
 
-    // notify article's author
+    // article: notify article's author
     const shouldNotifyArticleAuthor =
       article &&
       (isLevel1Comment ||
         (targetAuthor !== parentCommentAuthor &&
           targetAuthor !== replyToCommentAuthor))
 
-    if (shouldNotifyArticleAuthor) {
+    if (isArticleType && shouldNotifyArticleAuthor) {
       notificationService.trigger({
         event: DB_NOTICE_TYPE.article_new_comment,
         actorId: viewer.id,
         recipientId: targetAuthor,
         entities: [
-          {
-            type: 'target',
-            entityTable: 'article',
-            entity: article,
-          },
-          {
-            type: 'comment',
-            entityTable: 'comment',
-            entity: newComment,
-          },
+          { type: 'target', entityTable: 'article', entity: article },
+          { type: 'comment', entityTable: 'comment', entity: newComment },
         ],
       })
     }
 
-    // notify parentComment's author
-    const replyEvent = isCircleBroadcast
-      ? DB_NOTICE_TYPE.circle_broadcast_new_reply
-      : isCircleDiscussion
-      ? DB_NOTICE_TYPE.circle_discussion_new_reply
-      : DB_NOTICE_TYPE.comment_new_reply
+    // article: notify parentComment's author
     const shouldNotifyParentCommentAuthor =
       isReplyLevel1Comment || parentCommentAuthor !== replyToCommentAuthor
-    if (shouldNotifyParentCommentAuthor) {
+    if (isArticleType && shouldNotifyParentCommentAuthor) {
       notificationService.trigger({
-        event: replyEvent,
+        event: DB_NOTICE_TYPE.comment_new_reply,
         actorId: viewer.id,
         recipientId: parentCommentAuthor,
         entities: [
-          {
-            type: 'target',
-            entityTable: 'comment',
-            entity: parentComment,
-          },
-          {
-            type: 'reply',
-            entityTable: 'comment',
-            entity: newComment,
-          },
+          { type: 'target', entityTable: 'comment', entity: parentComment },
+          { type: 'reply', entityTable: 'comment', entity: newComment },
         ],
       })
     }
 
-    // notify replyToComment's author
+    // article: notify replyToComment's author
     const shouldNotifyReplyToCommentAuthor = isReplyingLevel2Comment
-    if (shouldNotifyReplyToCommentAuthor) {
+    if (isArticleType && shouldNotifyReplyToCommentAuthor) {
       notificationService.trigger({
-        event: replyEvent,
+        event: DB_NOTICE_TYPE.comment_new_reply,
         actorId: viewer.id,
         recipientId: replyToCommentAuthor,
         entities: [
-          {
-            type: 'target',
-            entityTable: 'comment',
-            entity: replyToComment,
-          },
-          {
-            type: 'reply',
-            entityTable: 'comment',
-            entity: newComment,
-          },
+          { type: 'target', entityTable: 'comment', entity: replyToComment },
+          { type: 'reply', entityTable: 'comment', entity: newComment },
         ],
       })
     }
 
-    // notify article's subscribers
-    if (article) {
+    // article: notify article's subscribers
+    if (isArticleType && article) {
       const articleSubscribers = await articleService.findSubscriptions({
         id: article.id,
       })
@@ -393,148 +364,72 @@ const resolver: MutationToPutCommentResolver = async (
           actorId: viewer.id,
           recipientId: subscriber.id,
           entities: [
-            {
-              type: 'target',
-              entityTable: 'article',
-              entity: article,
-            },
-            {
-              type: 'comment',
-              entityTable: 'comment',
-              entity: newComment,
-            },
+            { type: 'target', entityTable: 'article', entity: article },
+            { type: 'comment', entityTable: 'comment', entity: newComment },
           ],
         })
       })
     }
 
-    // notify cirlce owner & members & followers
-    if (
-      circle &&
-      // isLevel1Comment &&
-      (isCircleBroadcast || isCircleDiscussion)
-    ) {
+    if (circle && (isCircleBroadcast || isCircleDiscussion)) {
       const recipients = await userService.findCircleRecipients(circle.id)
 
-      if (isCircleBroadcast) {
+      // circle: notify members & followers for new broadcast
+      if (isCircleBroadcast && isLevel1Comment) {
         recipients.forEach((recipientId: any) => {
           notificationService.trigger({
-            event: DB_NOTICE_TYPE.in_circle_new_broadcast, // circle_new_broadcast,
+            event: DB_NOTICE_TYPE.in_circle_new_broadcast,
             actorId: viewer.id,
             recipientId,
             entities: [
-              {
-                type: 'target',
-                entityTable: 'circle',
-                entity: circle,
-              },
+              { type: 'target', entityTable: 'circle', entity: circle },
               { type: 'comment', entityTable: 'comment', entity: newComment },
-              // {type: 'target', entityTable: 'comment', entity: newComment,},
             ],
           })
         })
-
-        if (!isLevel1Comment) {
-          notificationService.trigger({
-            event: DB_NOTICE_TYPE.circle_member_new_broadcast_reply,
-            actorId: viewer.id,
-            recipientId: circle.owner,
-            entities: [
-              {
-                type: 'target',
-                entityTable: 'circle',
-                entity: circle,
-              },
-            ],
-          })
-        }
-
-        // for in circle events
-        if (!isLevel1Comment) {
-          recipients.forEach((recipientId: any) => {
-            notificationService.trigger({
-              event: DB_NOTICE_TYPE.in_circle_new_broadcast_reply,
-              actorId: viewer.id,
-              recipientId,
-              entities: [
-                {
-                  type: 'target',
-                  entityTable: 'circle',
-                  entity: circle,
-                },
-                // {type: 'comment', entityTable: 'comment', entity: newComment,},
-              ],
-            })
-          })
-        } else {
-          recipients.forEach((recipientId: any) => {
-            notificationService.trigger({
-              event: DB_NOTICE_TYPE.in_circle_new_broadcast,
-              actorId: viewer.id,
-              recipientId,
-              entities: [
-                {
-                  type: 'target',
-                  entityTable: 'circle',
-                  entity: circle,
-                },
-                { type: 'comment', entityTable: 'comment', entity: newComment },
-              ],
-            })
-          })
-        }
       }
 
-      if (isCircleDiscussion) {
-        if (viewer.id !== circle.owner) {
-          notificationService.trigger({
-            event: !isLevel1Comment // replyToComment?.type === COMMENT_TYPE.circleDiscussion
-              ? DB_NOTICE_TYPE.circle_member_new_discussion_reply
-              : DB_NOTICE_TYPE.circle_member_new_discussion,
-            actorId: viewer.id,
-            recipientId: circle.owner,
-            entities: [
-              {
-                type: 'target',
-                entityTable: 'circle',
-                entity: circle,
-              },
-              // {type: 'comment', entityTable: 'comment', entity: newComment,},
-            ],
-          })
-        }
+      // circle: notify owner, members & followers for new broadcast reply
+      if (isCircleBroadcast && !isLevel1Comment) {
+        notificationService.trigger({
+          event: DB_NOTICE_TYPE.circle_member_new_broadcast_reply,
+          actorId: viewer.id,
+          recipientId: circle.owner,
+          entities: [{ type: 'target', entityTable: 'circle', entity: circle }],
+        })
 
         recipients.forEach((recipientId: any) => {
           notificationService.trigger({
-            event: DB_NOTICE_TYPE.circle_new_discussion,
+            event: DB_NOTICE_TYPE.in_circle_new_broadcast_reply,
             actorId: viewer.id,
             recipientId,
             entities: [
-              {
-                type: 'target',
-                entityTable: 'circle',
-                entity: circle,
-              },
+              { type: 'target', entityTable: 'circle', entity: circle },
             ],
           })
         })
+      }
 
-        // for in circle events
-        const eventInCircle =
-          replyToComment?.type === COMMENT_TYPE.circleDiscussion
-            ? DB_NOTICE_TYPE.in_circle_new_discussion_reply
-            : DB_NOTICE_TYPE.in_circle_new_discussion
+      // circle: notify owner, members & followers for new discussion and reply
+      if (isCircleDiscussion) {
+        notificationService.trigger({
+          event: isLevel1Comment
+            ? DB_NOTICE_TYPE.circle_member_new_discussion
+            : DB_NOTICE_TYPE.circle_member_new_discussion_reply,
+          actorId: viewer.id,
+          recipientId: circle.owner,
+          entities: [{ type: 'target', entityTable: 'circle', entity: circle }],
+        })
+
         recipients.forEach((recipientId: any) => {
           notificationService.trigger({
-            event: eventInCircle,
+            event: isLevel1Comment
+              ? DB_NOTICE_TYPE.in_circle_new_discussion
+              : DB_NOTICE_TYPE.in_circle_new_discussion_reply,
             actorId: viewer.id,
             recipientId,
             entities: [
-              {
-                type: 'target',
-                entityTable: 'circle',
-                entity: circle,
-              },
+              { type: 'target', entityTable: 'circle', entity: circle },
             ],
           })
         })
@@ -542,24 +437,20 @@ const resolver: MutationToPutCommentResolver = async (
     }
   }
 
-  // notify mentioned users
+  // article & circle: notify mentioned users
   if (data.mentionedUserIds) {
     const mentionedEvent = isCircleBroadcast
-      ? DB_NOTICE_TYPE.circle_broadcast_mentioned_you
+      ? DB_NOTICE_TYPE.circle_broadcast_mentioned_you // circle
       : isCircleDiscussion
-      ? DB_NOTICE_TYPE.circle_discussion_mentioned_you
-      : DB_NOTICE_TYPE.comment_mentioned_you
+      ? DB_NOTICE_TYPE.circle_discussion_mentioned_you // circle
+      : DB_NOTICE_TYPE.comment_mentioned_you // article
     data.mentionedUserIds.forEach((userId: string) => {
       notificationService.trigger({
         event: mentionedEvent,
         actorId: viewer.id,
         recipientId: userId,
         entities: [
-          {
-            type: 'target',
-            entityTable: 'comment',
-            entity: newComment,
-          },
+          { type: 'target', entityTable: 'comment', entity: newComment },
         ],
       })
     })

--- a/src/mutations/comment/putComment.ts
+++ b/src/mutations/comment/putComment.ts
@@ -50,6 +50,7 @@ const resolver: MutationToPutCommentResolver = async (
       articleService,
       notificationService,
       userService,
+      systemService,
     },
     knex,
   }
@@ -373,6 +374,8 @@ const resolver: MutationToPutCommentResolver = async (
 
     if (circle && (isCircleBroadcast || isCircleDiscussion)) {
       const recipients = await userService.findCircleRecipients(circle.id)
+      const { id: commentEntityTypeId } =
+        await systemService.baseFindEntityTypeId('comment')
 
       // circle: notify members & followers for new broadcast
       if (isCircleBroadcast && isLevel1Comment) {
@@ -396,6 +399,7 @@ const resolver: MutationToPutCommentResolver = async (
           actorId: viewer.id,
           recipientId: circle.owner,
           entities: [{ type: 'target', entityTable: 'circle', entity: circle }],
+          data: { entityTypeId: commentEntityTypeId, entityId: newComment.id },
         })
 
         recipients.forEach((recipientId: any) => {
@@ -406,6 +410,10 @@ const resolver: MutationToPutCommentResolver = async (
             entities: [
               { type: 'target', entityTable: 'circle', entity: circle },
             ],
+            data: {
+              entityTypeId: commentEntityTypeId,
+              entityId: newComment.id,
+            },
           })
         })
       }
@@ -419,6 +427,7 @@ const resolver: MutationToPutCommentResolver = async (
           actorId: viewer.id,
           recipientId: circle.owner,
           entities: [{ type: 'target', entityTable: 'circle', entity: circle }],
+          data: { entityTypeId: commentEntityTypeId, entityId: newComment.id },
         })
 
         recipients.forEach((recipientId: any) => {
@@ -431,6 +440,10 @@ const resolver: MutationToPutCommentResolver = async (
             entities: [
               { type: 'target', entityTable: 'circle', entity: circle },
             ],
+            data: {
+              entityTypeId: commentEntityTypeId,
+              entityId: newComment.id,
+            },
           })
         })
       }

--- a/src/mutations/comment/togglePinComment.ts
+++ b/src/mutations/comment/togglePinComment.ts
@@ -108,13 +108,7 @@ const resolver: MutationToTogglePinCommentResolver = async (
       event: DB_NOTICE_TYPE.comment_pinned,
       actorId: viewer.id,
       recipientId: comment.authorId,
-      entities: [
-        {
-          type: 'target',
-          entityTable: 'comment',
-          entity: comment,
-        },
-      ],
+      entities: [{ type: 'target', entityTable: 'comment', entity: comment }],
     })
   } else {
     pinnedComment = await atomService.update({

--- a/src/mutations/user/userRegister.ts
+++ b/src/mutations/user/userRegister.ts
@@ -135,13 +135,7 @@ const resolver: MutationToUserRegisterResolver = async (
         event: DB_NOTICE_TYPE.circle_invitation,
         actorId: invitation.inviter,
         recipientId: newUser.id,
-        entities: [
-          {
-            type: 'target',
-            entityTable: 'circle',
-            entity: circle,
-          },
-        ],
+        entities: [{ type: 'target', entityTable: 'circle', entity: circle }],
       })
     })
   )

--- a/src/queries/notice/index.ts
+++ b/src/queries/notice/index.ts
@@ -80,7 +80,6 @@ const notice: {
         article_mentioned_you: NOTICE_TYPE.ArticleNotice,
         revised_article_published: NOTICE_TYPE.ArticleNotice,
         revised_article_not_published: NOTICE_TYPE.ArticleNotice,
-        // circle_new_article: NOTICE_TYPE.ArticleNotice,
 
         // article-artilce
         article_new_collected: NOTICE_TYPE.ArticleArticleNotice,
@@ -99,36 +98,30 @@ const notice: {
         // comment
         comment_pinned: NOTICE_TYPE.CommentNotice,
         comment_mentioned_you: NOTICE_TYPE.CommentNotice,
-        circle_broadcast_mentioned_you: NOTICE_TYPE.CommentNotice,
-        circle_discussion_mentioned_you: NOTICE_TYPE.CommentNotice,
         article_new_comment: NOTICE_TYPE.CommentNotice,
         subscribed_article_new_comment: NOTICE_TYPE.CommentNotice,
-
-        // have both target circle, and comment
-        // circle_new_broadcast: NOTICE_TYPE.CircleCommentNotice,
+        circle_broadcast_mentioned_you: NOTICE_TYPE.CommentNotice,
+        circle_discussion_mentioned_you: NOTICE_TYPE.CommentNotice,
 
         // comment-comment
         comment_new_reply: NOTICE_TYPE.CommentCommentNotice,
-        circle_broadcast_new_reply: NOTICE_TYPE.CommentCommentNotice,
-        circle_discussion_new_reply: NOTICE_TYPE.CommentCommentNotice,
 
         // transaction
         payment_received_donation: NOTICE_TYPE.TransactionNotice,
         payment_payout: NOTICE_TYPE.TransactionNotice,
 
-        // circle owners
+        // circle
+        circle_invitation: NOTICE_TYPE.CircleNotice,
+
+        // for circle owners
         circle_new_subscriber: NOTICE_TYPE.CircleNotice,
         circle_new_unsubscriber: NOTICE_TYPE.CircleNotice,
-        circle_invitation: NOTICE_TYPE.CircleNotice,
         circle_new_follower: NOTICE_TYPE.CircleNotice,
-
-        circle_new_discussion: NOTICE_TYPE.CircleNotice,
-        circle_member_broadcast: NOTICE_TYPE.CircleNotice,
         circle_member_new_discussion: NOTICE_TYPE.CircleNotice,
         circle_member_new_discussion_reply: NOTICE_TYPE.CircleNotice,
         circle_member_new_broadcast_reply: NOTICE_TYPE.CircleNotice,
 
-        // in circle
+        // for circle members & followers
         in_circle_new_article: NOTICE_TYPE.CircleArticleNotice,
         in_circle_new_broadcast: NOTICE_TYPE.CircleCommentNotice,
         in_circle_new_broadcast_reply: NOTICE_TYPE.CircleNotice,
@@ -175,7 +168,6 @@ const notice: {
           return GQLArticleNoticeType.RevisedArticlePublished
         case DB_NOTICE_TYPE.revised_article_not_published:
           return GQLArticleNoticeType.RevisedArticleNotPublished
-        // case DB_NOTICE_TYPE.circle_new_article: return GQLArticleNoticeType.CircleNewArticle
       }
     },
     target: ({ entities }, _, { dataSources: { draftService } }) =>
@@ -204,8 +196,6 @@ const notice: {
           return GQLArticleTagNoticeType.ArticleTagAdded
         case DB_NOTICE_TYPE.article_tag_has_been_removed:
           return GQLArticleTagNoticeType.ArticleTagRemoved
-        case DB_NOTICE_TYPE.article_tag_has_been_unselected:
-          return GQLArticleTagNoticeType.ArticleTagUnselected
       }
     },
     target: ({ entities }, _, { dataSources: { draftService } }) =>
@@ -233,76 +223,23 @@ const notice: {
         case DB_NOTICE_TYPE.comment_pinned:
           return GQLCommentNoticeType.CommentPinned
         case DB_NOTICE_TYPE.comment_mentioned_you:
-        case DB_NOTICE_TYPE.circle_broadcast_mentioned_you:
-        case DB_NOTICE_TYPE.circle_discussion_mentioned_you:
           return GQLCommentNoticeType.CommentMentionedYou
         case DB_NOTICE_TYPE.article_new_comment:
           return GQLCommentNoticeType.ArticleNewComment
         case DB_NOTICE_TYPE.subscribed_article_new_comment:
           return GQLCommentNoticeType.SubscribedArticleNewComment
-        // case DB_NOTICE_TYPE.circle_new_broadcast: return GQLCommentNoticeType.CircleNewBroadcast
-        case DB_NOTICE_TYPE.circle_new_discussion:
-          return GQLCommentNoticeType.CircleNewDiscussion
-        case DB_NOTICE_TYPE.circle_member_new_discussion:
-          return GQLCommentNoticeType.CircleMemberNewDiscussion
-        case DB_NOTICE_TYPE.circle_member_new_discussion_reply:
-          return GQLCommentNoticeType.CircleMemberNewDiscussionReply
-        case DB_NOTICE_TYPE.circle_member_new_broadcast_reply:
-          return GQLCommentNoticeType.CircleMemberNewBroadcastReply
-
-        // in Circle
-        // case DB_NOTICE_TYPE.in_circle_new_article:
-        // return GQLCommentNoticeType.InCircleNewArticle
-        case DB_NOTICE_TYPE.in_circle_new_broadcast:
-          return GQLCommentNoticeType.InCircleNewBroadcast
-        case DB_NOTICE_TYPE.in_circle_new_broadcast_reply:
-          return GQLCommentNoticeType.InCircleNewBroadcastReply
-        case DB_NOTICE_TYPE.in_circle_new_discussion:
-          return GQLCommentNoticeType.InCircleNewDiscussion
-        case DB_NOTICE_TYPE.in_circle_new_discussion_reply:
-          return GQLCommentNoticeType.InCircleNewDiscussionReply
-      }
-    },
-    target: ({ entities, type }) => {
-      switch (type) {
-        case DB_NOTICE_TYPE.comment_pinned:
-        case DB_NOTICE_TYPE.comment_mentioned_you:
         case DB_NOTICE_TYPE.circle_broadcast_mentioned_you:
+          return GQLCommentNoticeType.CircleBroadcastMentionedYou
         case DB_NOTICE_TYPE.circle_discussion_mentioned_you:
-        // return entities.target
-
-        case DB_NOTICE_TYPE.article_new_comment:
-        case DB_NOTICE_TYPE.subscribed_article_new_comment:
-
-        case DB_NOTICE_TYPE.circle_new_discussion:
-        case DB_NOTICE_TYPE.circle_member_new_broadcast_reply:
-        case DB_NOTICE_TYPE.circle_member_new_discussion:
-        case DB_NOTICE_TYPE.circle_member_new_discussion_reply:
-        case DB_NOTICE_TYPE.in_circle_new_broadcast:
-        case DB_NOTICE_TYPE.in_circle_new_broadcast_reply:
-        case DB_NOTICE_TYPE.in_circle_new_discussion:
-        case DB_NOTICE_TYPE.in_circle_new_discussion_reply:
-          return entities.target
-
-        // case DB_NOTICE_TYPE.circle_new_broadcast: return entities.comment
-
-        case DB_NOTICE_TYPE.in_circle_new_article:
-          return entities.article
+          return GQLCommentNoticeType.CircleDiscussionMentionedYou
       }
     },
-    /* comment: ({ entities, type }) => {
-      switch (type) {
-        case DB_NOTICE_TYPE.circle_new_broadcast:
-          return entities.comment
-      }
-    }, */
+    target: ({ entities, type }) => entities.target,
   },
   CommentCommentNotice: {
     type: ({ type }) => {
       switch (type) {
         case DB_NOTICE_TYPE.comment_new_reply:
-        case DB_NOTICE_TYPE.circle_broadcast_new_reply:
-        case DB_NOTICE_TYPE.circle_discussion_new_reply:
           return GQLCommentCommentNoticeType.CommentNewReply
       }
     },
@@ -310,8 +247,6 @@ const notice: {
     comment: ({ entities, type }) => {
       switch (type) {
         case DB_NOTICE_TYPE.comment_new_reply:
-        case DB_NOTICE_TYPE.circle_broadcast_new_reply:
-        case DB_NOTICE_TYPE.circle_discussion_new_reply:
           return entities.reply
       }
     },
@@ -330,28 +265,24 @@ const notice: {
   CircleNotice: {
     type: ({ type }) => {
       switch (type) {
+        case DB_NOTICE_TYPE.circle_invitation:
+          return GQLCircleNoticeType.CircleInvitation
+
+        // for circle owner
         case DB_NOTICE_TYPE.circle_new_subscriber:
           return GQLCircleNoticeType.CircleNewSubscriber
         case DB_NOTICE_TYPE.circle_new_follower:
           return GQLCircleNoticeType.CircleNewFollower
         case DB_NOTICE_TYPE.circle_new_unsubscriber:
           return GQLCircleNoticeType.CircleNewUnsubscriber
-        case DB_NOTICE_TYPE.circle_invitation:
-          return GQLCircleNoticeType.CircleInvitation
-
-        // case DB_NOTICE_TYPE.circle_new_broadcast: return GQLCommentNoticeType.CircleNewBroadcast
-        case DB_NOTICE_TYPE.circle_new_discussion:
-          return GQLCommentNoticeType.CircleNewDiscussion
+        case DB_NOTICE_TYPE.circle_member_new_broadcast_reply:
+          return GQLCircleNoticeType.CircleMemberNewBroadcastReply
         case DB_NOTICE_TYPE.circle_member_new_discussion:
           return GQLCircleNoticeType.CircleMemberNewDiscussion
         case DB_NOTICE_TYPE.circle_member_new_discussion_reply:
           return GQLCircleNoticeType.CircleMemberNewDiscussionReply
-        case DB_NOTICE_TYPE.circle_member_new_broadcast_reply:
-          return GQLCircleNoticeType.CircleMemberNewBroadcastReply
 
-        // case DB_NOTICE_TYPE.in_circle_new_article: return GQLCircleArticleNoticeType.InCircleNewArticle
-        case DB_NOTICE_TYPE.in_circle_new_broadcast:
-          return GQLCircleNoticeType.InCircleNewBroadcast
+        // for circle members & followers
         case DB_NOTICE_TYPE.in_circle_new_broadcast_reply:
           return GQLCircleNoticeType.InCircleNewBroadcastReply
         case DB_NOTICE_TYPE.in_circle_new_discussion:
@@ -360,75 +291,28 @@ const notice: {
           return GQLCircleNoticeType.InCircleNewDiscussionReply
       }
     },
-    target: ({ entities, type }) => {
-      switch (type) {
-        case DB_NOTICE_TYPE.circle_new_subscriber:
-        case DB_NOTICE_TYPE.circle_new_follower:
-        case DB_NOTICE_TYPE.circle_new_unsubscriber:
-        case DB_NOTICE_TYPE.circle_invitation:
-
-        // case DB_NOTICE_TYPE.circle_new_broadcast:
-        case DB_NOTICE_TYPE.circle_new_discussion:
-        case DB_NOTICE_TYPE.circle_member_new_discussion:
-        case DB_NOTICE_TYPE.circle_member_new_discussion_reply:
-        case DB_NOTICE_TYPE.circle_member_new_broadcast_reply:
-
-        // in Circle
-        case DB_NOTICE_TYPE.in_circle_new_article:
-        case DB_NOTICE_TYPE.in_circle_new_broadcast:
-        case DB_NOTICE_TYPE.in_circle_new_broadcast_reply:
-        case DB_NOTICE_TYPE.in_circle_new_discussion:
-        case DB_NOTICE_TYPE.in_circle_new_discussion_reply:
-          return entities.target
-      }
-    },
+    target: ({ entities }) => entities.target,
   },
   CircleCommentNotice: {
     type: ({ type }) => {
       switch (type) {
         case DB_NOTICE_TYPE.in_circle_new_broadcast:
-          return GQLCircleCommentNoticeType.CircleNewBroadcast
+          return GQLCircleCommentNoticeType.InCircleNewBroadcast
       }
     },
-    target: ({ entities, type }) => {
-      switch (type) {
-        case DB_NOTICE_TYPE.in_circle_new_broadcast:
-          return entities.target
-      }
-    },
-    comment: ({ entities, type }) => {
-      switch (type) {
-        case DB_NOTICE_TYPE.in_circle_new_broadcast:
-          return entities.comment
-      }
-    },
+    target: ({ entities, type }) => entities.target,
+    comment: ({ entities, type }) => entities.comment,
   },
   CircleArticleNotice: {
     type: ({ type }) => {
-      // console.log('in CircleArticleNotice type:', { type })
       switch (type) {
         case DB_NOTICE_TYPE.in_circle_new_article:
           return GQLCircleArticleNoticeType.InCircleNewArticle
       }
-      // return GQLCircleArticleNoticeType.InCircleNewArticle
     },
-    target: ({ entities, type }) => {
-      // console.log('in CircleArticleNotice target:', { entities, type })
-      switch (type) {
-        case DB_NOTICE_TYPE.in_circle_new_article:
-          return entities.target
-      }
-      // return entities.target
-    },
-    article: ({ entities, type }, _, { dataSources: { draftService } }) => {
-      // console.log('in CircleArticleNotice article:', { entities, type })
-      switch (type) {
-        case DB_NOTICE_TYPE.in_circle_new_article:
-          return draftService.dataloader.load(entities.article.draftId)
-        // return entities.article
-      }
-      // return entities.article
-    },
+    target: ({ entities, type }) => entities.target,
+    article: ({ entities, type }, _, { dataSources: { draftService } }) =>
+      draftService.dataloader.load(entities.article.draftId),
   },
   CryptoNotice: {
     type: ({ type }) => {

--- a/src/queries/notice/index.ts
+++ b/src/queries/notice/index.ts
@@ -1,4 +1,6 @@
-import { DB_NOTICE_TYPE } from 'common/enums'
+import _capitalize from 'lodash/capitalize'
+
+import { DB_NOTICE_TYPE, NODE_TYPES } from 'common/enums'
 import {
   DBNoticeType,
   GQLArticleArticleNoticeType,
@@ -308,6 +310,28 @@ const notice: {
       }
     },
     target: ({ entities }) => entities.target,
+    node: async (
+      { data }: { data: any },
+      _,
+      { dataSources: { systemService, commentService } }
+    ) => {
+      const { entityTypeId, entityId } = data || {}
+
+      if (!entityTypeId || !entityId) {
+        return
+      }
+
+      const entity = await systemService.baseFindEntityTypeTable(entityTypeId)
+      const entityType =
+        NODE_TYPES[
+          (_capitalize(entity?.table) as keyof typeof NODE_TYPES) || ''
+        ]
+
+      if (entityType === NODE_TYPES.Comment) {
+        const comment = commentService.dataloader.load(entityId)
+        return { ...comment, __type: entityType }
+      }
+    },
   },
   CircleCommentNotice: {
     type: ({ type }) => {

--- a/src/routes/pay/likecoin.ts
+++ b/src/routes/pay/likecoin.ts
@@ -288,11 +288,7 @@ likecoinRouter.post('/', async (req, res, next) => {
       actorId: sender.id,
       recipientId: recipient.id,
       entities: [
-        {
-          type: 'target',
-          entityTable: 'transaction',
-          entity: resultTx,
-        },
+        { type: 'target', entityTable: 'transaction', entity: resultTx },
       ],
     })
     notificationService.mail.sendPayment({

--- a/src/routes/pay/stripe/circle.ts
+++ b/src/routes/pay/stripe/circle.ts
@@ -108,13 +108,7 @@ export const completeCircleSubscription = async ({
     event: DB_NOTICE_TYPE.circle_new_subscriber,
     actorId: userId,
     recipientId: circle.owner,
-    entities: [
-      {
-        type: 'target',
-        entityTable: 'circle',
-        entity: circle,
-      },
-    ],
+    entities: [{ type: 'target', entityTable: 'circle', entity: circle }],
   })
 
   // auto follow circle without notification

--- a/src/types/notice.ts
+++ b/src/types/notice.ts
@@ -94,8 +94,6 @@ export default /* GraphQL */ `
     ArticleNewAppreciation
     RevisedArticlePublished
     RevisedArticleNotPublished
-    CircleNewArticle
-    # InCircleNewArticle
   }
 
   type ArticleArticleNotice implements Notice {
@@ -123,7 +121,6 @@ export default /* GraphQL */ `
   }
 
 
-
   #################################
   #                               #
   #           Comment             #
@@ -149,18 +146,11 @@ export default /* GraphQL */ `
 
   enum CommentNoticeType {
     CommentPinned
-    CommentMentionedYou
+    CommentMentionedYou # article comment
     ArticleNewComment
     SubscribedArticleNewComment
-    CircleNewBroadcast
-    CircleNewDiscussion
-    CircleMemberNewDiscussion
-    CircleMemberNewDiscussionReply
-    CircleMemberNewBroadcastReply
-    InCircleNewBroadcast
-    InCircleNewBroadcastReply
-    InCircleNewDiscussion
-    InCircleNewDiscussionReply
+    CircleBroadcastMentionedYou # circle broadcast
+    CircleDiscussionMentionedYou # circle discussion
   }
 
   type CommentCommentNotice implements Notice {
@@ -297,19 +287,17 @@ export default /* GraphQL */ `
   }
 
   enum CircleNoticeType {
+    CircleInvitation
+
+    # for circle owner
     CircleNewSubscriber
     CircleNewFollower
     CircleNewUnsubscriber
-    CircleInvitation
-    CircleNewDiscussion
-    CircleNewBroadcast
-    CircleMemberBroadcast
+    CircleMemberNewBroadcastReply
     CircleMemberNewDiscussion
     CircleMemberNewDiscussionReply
-    CircleMemberNewBroadcastReply
 
-    InCircleNewArticle
-    InCircleNewBroadcast
+    # for circle members & followers
     InCircleNewBroadcastReply
     InCircleNewDiscussion
     InCircleNewDiscussionReply
@@ -335,6 +323,11 @@ export default /* GraphQL */ `
     comment: Comment! @logCache(type: "${NODE_TYPES.Comment}")
   }
 
+  enum CircleCommentNoticeType {
+    # for circle members & followers
+    InCircleNewBroadcast
+  }
+
   type CircleArticleNotice implements Notice {
     "Unique ID of this notice."
     id: ID!
@@ -355,11 +348,8 @@ export default /* GraphQL */ `
     article: Article! @logCache(type: "${NODE_TYPES.Article}")
   }
 
-  enum CircleCommentNoticeType {
-    CircleNewBroadcast
-  }
-
   enum CircleArticleNoticeType {
+    # for circle members & followers
     InCircleNewArticle
   }
 

--- a/src/types/notice.ts
+++ b/src/types/notice.ts
@@ -94,6 +94,7 @@ export default /* GraphQL */ `
     ArticleNewAppreciation
     RevisedArticlePublished
     RevisedArticleNotPublished
+    CircleNewArticle @deprecated(reason: "No longer in use")
   }
 
   type ArticleArticleNotice implements Notice {
@@ -149,6 +150,7 @@ export default /* GraphQL */ `
     CommentMentionedYou # article comment
     ArticleNewComment
     SubscribedArticleNewComment
+    CircleNewBroadcast @deprecated(reason: "No longer in use")
     CircleBroadcastMentionedYou # circle broadcast
     CircleDiscussionMentionedYou # circle discussion
   }

--- a/src/types/notice.ts
+++ b/src/types/notice.ts
@@ -286,6 +286,9 @@ export default /* GraphQL */ `
     type: CircleNoticeType!
 
     target: Circle! @logCache(type: "${NODE_TYPES.Circle}")
+
+    "An optional arbitrary node, Comment for broadcast and discussion notices"
+    node: Node @logCache(type: "${NODE_TYPES.Node}")
   }
 
   enum CircleNoticeType {


### PR DESCRIPTION
* Add `CircleDiscussionMentionedYou` and `CircleBroadcastMentionedYou` to `CommentNoticeType`;
* Add optional `node` field to `CircleNoticeType`, used by circle broadcast/discussion notices (`node` as latest comment);
* Move `InCircleNewBroadcast` from `CircleNoticeType` to `CircleCommentNoticeType`;
* Remove dups and unused notices (breaking changes, will cause downtime during deployment);
  * `CircleMemberBroadcast`
  * `CircleNewDiscussion`
* Deprecate `CircleNewArticle` & `CircleNewBroadcast`;
* Fix notification triggers on `putComment` mutation;