### PR TITLE
feat(related-tags): add shuffle api to related tags

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1975,6 +1975,7 @@ input ConnectionArgs {
   after: String
   first: Int
   oss: Boolean
+  filter: FilterInput
 }
 
 """Common input to toggle single item for `toggleXXX` mutations"""

--- a/src/connectors/tagService.ts
+++ b/src/connectors/tagService.ts
@@ -1214,8 +1214,6 @@ export class TagService extends BaseService {
 
     const countRelsCount = countRels?.count || 0
 
-    // console.log('countRelsCount:', { countRels })
-
     const subquery = this.knex
       .from(VIEW.tags_lasts_view)
       .joinRaw(
@@ -1302,9 +1300,6 @@ export class TagService extends BaseService {
           this.offset(skip)
         }
       })
-
-    // console.log('findRelatedTags: use query:', query.toString())
-
     return query
   }
 }

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -2751,6 +2751,7 @@ export interface GQLConnectionArgs {
   after?: string
   first?: number
   oss?: boolean
+  filter?: GQLFilterInput
 }
 
 /**

--- a/src/queries/article/tag/recommended.ts
+++ b/src/queries/article/tag/recommended.ts
@@ -1,4 +1,5 @@
 import { chunk } from 'lodash'
+
 import { TAGS_RECOMMENDED_LIMIT } from 'common/enums'
 import {
   connectionFromArray,
@@ -12,39 +13,46 @@ const resolver: TagToRecommendedResolver = async (
   { input },
   { dataSources: { tagService, userService } }
 ) => {
-
   const { take, skip } = fromConnectionArgs(input, {
-    allowTakeAll: true, 
+    allowTakeAll: true,
     maxTake: TAGS_RECOMMENDED_LIMIT,
     maxSkip: TAGS_RECOMMENDED_LIMIT,
-    })
+  })
+
   if (!id) {
     return connectionFromArray([], input)
   }
   const { filter } = input
-
 
   if (typeof filter?.random === 'number') {
     const { random } = filter
     const draw = input.first || 5
     const limit = 50
 
-  //take (limit * draw) amounts of related tags
-  const related = await tagService.findRelatedTags({ id, content, take: limit * draw, skip })
-  //chunk the list of tags per draw
-  const chunks = chunk(related, draw)
-  const index = Math.min(random, limit, chunks.length - 1)
-  const filteredTags = chunks[index] || []
+    // take (limit * draw) amounts of related tags
+    const related = await tagService.findRelatedTags({
+      id,
+      content,
+      take: limit * draw,
+      skip,
+    })
+    // chunk the list of tags per draw
+    const chunks = chunk(related, draw)
+    const index = Math.min(random, limit, chunks.length - 1)
+    const filteredTags = chunks[index] || []
 
+    return connectionFromPromisedArray(
+      tagService.dataloader.loadMany(
+        filteredTags.map((tag: any) => `${tag.id}`)
+      ),
+      input,
+      related.length
+    )
+  }
   return connectionFromPromisedArray(
-    tagService.dataloader.loadMany(
-      filteredTags.map((tag: any) => `${tag.id}`)
-    ),
-    input,
-    related.length
+    tagService.findRelatedTags({ id, content, take, skip }),
+    input
   )
-}
-  return connectionFromPromisedArray(tagService.findRelatedTags({ id, content, take, skip }), input)
 }
 
 export default resolver

--- a/src/queries/article/tag/recommended.ts
+++ b/src/queries/article/tag/recommended.ts
@@ -1,3 +1,4 @@
+import { chunk } from 'lodash'
 import { TAGS_RECOMMENDED_LIMIT } from 'common/enums'
 import {
   connectionFromArray,
@@ -11,19 +12,39 @@ const resolver: TagToRecommendedResolver = async (
   { input },
   { dataSources: { tagService, userService } }
 ) => {
+
+  const { take, skip } = fromConnectionArgs(input, {
+    allowTakeAll: true, 
+    maxTake: TAGS_RECOMMENDED_LIMIT,
+    maxSkip: TAGS_RECOMMENDED_LIMIT,
+    })
   if (!id) {
     return connectionFromArray([], input)
   }
+  const { filter } = input
 
-  const { take, skip } = fromConnectionArgs(input, {
-    allowTakeAll: true, // max 100 isn't too badly hurting
-    maxTake: TAGS_RECOMMENDED_LIMIT,
-    maxSkip: TAGS_RECOMMENDED_LIMIT,
-  })
 
-  const related = tagService.findRelatedTags({ id, content, take, skip })
+  if (typeof filter?.random === 'number') {
+    const { random } = filter
+    const draw = input.first || 5
+    const limit = 50
 
-  return connectionFromPromisedArray(related, input)
+  //take (limit * draw) amounts of related tags
+  const related = await tagService.findRelatedTags({ id, content, take: limit * draw, skip })
+  //chunk the list of tags per draw
+  const chunks = chunk(related, draw)
+  const index = Math.min(random, limit, chunks.length - 1)
+  const filteredTags = chunks[index] || []
+
+  return connectionFromPromisedArray(
+    tagService.dataloader.loadMany(
+      filteredTags.map((tag: any) => `${tag.id}`)
+    ),
+    input,
+    related.length
+  )
+}
+  return connectionFromPromisedArray(tagService.findRelatedTags({ id, content, take, skip }), input)
 }
 
 export default resolver

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -254,6 +254,7 @@ export default /* GraphQL */ `
     after: String
     first: Int @constraint(min: 0)
     oss: Boolean
+    filter: FilterInput
   }
 
   "Common input to toggle single item for \`toggleXXX\` mutations"


### PR DESCRIPTION
### Changes
Get `random` index from front-end, draw the data from random index