### PR TITLE
feat(notice): merge circle comment notics into `CircleNewBroadcastComments` and `CircleNewDiscussionComemnts`

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1514,7 +1514,7 @@ enum ArticleNoticeType {
   ArticleNewAppreciation
   RevisedArticlePublished
   RevisedArticleNotPublished
-  CircleNewArticle @deprecated(reason: "No longer in use")
+  CircleNewArticle
 }
 
 type ArticleArticleNotice implements Notice {
@@ -1566,7 +1566,7 @@ enum CommentNoticeType {
   CommentMentionedYou
   ArticleNewComment
   SubscribedArticleNewComment
-  CircleNewBroadcast @deprecated(reason: "No longer in use")
+  CircleNewBroadcast
 }
 
 type CommentCommentNotice implements Notice {
@@ -1693,73 +1693,22 @@ type CircleNotice implements Notice {
   type: CircleNoticeType!
   target: Circle!
 
-  """
-  An optional arbitrary node, Comment for broadcast and discussion notices
-  """
-  node: Node
+  """Optional discussion/broadcast comments for bundled notices"""
+  comments: [Comment!]
+
+  """Optional discussion/broadcast replies for bundled notices"""
+  replies: [Comment!]
+
+  """Optional mention comments for bundled notices"""
+  mentions: [Comment!]
 }
 
 enum CircleNoticeType {
   CircleInvitation
-  CircleBroadcastMentionedYou
-  CircleDiscussionMentionedYou
-
-  """for circle owner"""
   CircleNewSubscriber
   CircleNewFollower
   CircleNewUnsubscriber
-  CircleMemberNewBroadcastReply
-  CircleMemberNewDiscussion
-  CircleMemberNewDiscussionReply
-
-  """for circle members & followers"""
-  InCircleNewBroadcastReply
-  InCircleNewDiscussion
-  InCircleNewDiscussionReply
-}
-
-type CircleCommentNotice implements Notice {
-  """Unique ID of this notice."""
-  id: ID!
-
-  """The value determines if the notice is unread or not."""
-  unread: Boolean!
-
-  """Time of this notice was created."""
-  createdAt: DateTime!
-
-  """List of notice actors."""
-  actors: [User!]
-  type: CircleCommentNoticeType!
-  target: Circle!
-  comment: Comment!
-}
-
-enum CircleCommentNoticeType {
-  """for circle members & followers"""
-  InCircleNewBroadcast
-}
-
-type CircleArticleNotice implements Notice {
-  """Unique ID of this notice."""
-  id: ID!
-
-  """The value determines if the notice is unread or not."""
-  unread: Boolean!
-
-  """Time of this notice was created."""
-  createdAt: DateTime!
-
-  """List of notice actors."""
-  actors: [User!]
-  type: CircleArticleNoticeType!
-  target: Circle!
-  article: Article!
-}
-
-enum CircleArticleNoticeType {
-  """for circle members & followers"""
-  InCircleNewArticle
+  CircleNewBundled
 }
 
 """
@@ -2485,13 +2434,11 @@ type NotificationSetting {
   circleNewSubscriber: Boolean!
   circleNewFollower: Boolean!
   circleNewUnsubscriber: Boolean!
-  circleNewDiscussion: Boolean!
-  circleMemberBroadcast: Boolean!
+  circleMemberNewBroadcastReply: Boolean!
   circleMemberNewDiscussion: Boolean!
   circleMemberNewDiscussionReply: Boolean!
-  circleMemberNewBroadcastReply: Boolean!
 
-  """for circle members"""
+  """for circle members & followers"""
   inCircleNewArticle: Boolean!
   inCircleNewBroadcast: Boolean!
   inCircleNewBroadcastReply: Boolean!

--- a/schema.graphql
+++ b/schema.graphql
@@ -1708,7 +1708,7 @@ enum CircleNoticeType {
   CircleNewSubscriber
   CircleNewFollower
   CircleNewUnsubscriber
-  CircleNewBundled
+  CircleNewComments
 }
 
 """

--- a/schema.graphql
+++ b/schema.graphql
@@ -1708,7 +1708,8 @@ enum CircleNoticeType {
   CircleNewSubscriber
   CircleNewFollower
   CircleNewUnsubscriber
-  CircleNewComments
+  CircleNewBroadcastComments
+  CircleNewDiscussionComments
 }
 
 """

--- a/src/common/enums/notification.ts
+++ b/src/common/enums/notification.ts
@@ -9,7 +9,7 @@ export enum DB_NOTICE_TYPE {
   article_mentioned_you = 'article_mentioned_you',
   revised_article_published = 'revised_article_published',
   revised_article_not_published = 'revised_article_not_published',
-  circle_new_article = 'circle_new_article', // deprecated
+  circle_new_article = 'circle_new_article',
 
   // article-article
   article_new_collected = 'article_new_collected',
@@ -30,9 +30,7 @@ export enum DB_NOTICE_TYPE {
   comment_mentioned_you = 'comment_mentioned_you',
   article_new_comment = 'article_new_comment',
   subscribed_article_new_comment = 'subscribed_article_new_comment',
-  circle_new_broadcast = 'circle_new_broadcast', // deprecated
-  circle_broadcast_mentioned_you = 'circle_broadcast_mentioned_you',
-  circle_discussion_mentioned_you = 'circle_discussion_mentioned_you',
+  circle_new_broadcast = 'circle_new_broadcast',
 
   // comment-comment
   comment_new_reply = 'comment_new_reply',
@@ -43,21 +41,10 @@ export enum DB_NOTICE_TYPE {
 
   // circle
   circle_invitation = 'circle_invitation',
-
-  // for circle owners
   circle_new_subscriber = 'circle_new_subscriber',
   circle_new_follower = 'circle_new_follower',
   circle_new_unsubscriber = 'circle_new_unsubscriber',
-  circle_member_new_broadcast_reply = 'circle_member_new_broadcast_reply',
-  circle_member_new_discussion = 'circle_member_new_discussion',
-  circle_member_new_discussion_reply = 'circle_member_new_discussion_reply',
-
-  // for circle members & followers
-  in_circle_new_article = 'in_circle_new_article',
-  in_circle_new_broadcast = 'in_circle_new_broadcast',
-  in_circle_new_broadcast_reply = 'in_circle_new_broadcast_reply',
-  in_circle_new_discussion = 'in_circle_new_discussion',
-  in_circle_new_discussion_reply = 'in_circle_new_discussion_reply',
+  circle_new_bundled = 'circle_new_bundled',
 
   // crypto
   crypto_wallet_airdrop = 'crypto_wallet_airdrop',
@@ -65,6 +52,17 @@ export enum DB_NOTICE_TYPE {
 
   // misc
   official_announcement = 'official_announcement',
+}
+
+export enum BUNDLED_NOTICE_TYPE {
+  'circle_broadcast_mentioned_you' = 'circle_broadcast_mentioned_you',
+  'circle_discussion_mentioned_you' = 'circle_discussion_mentioned_you',
+  'circle_member_new_broadcast_reply' = 'circle_member_new_broadcast_reply',
+  'circle_member_new_discussion' = 'circle_member_new_discussion',
+  'circle_member_new_discussion_reply' = 'circle_member_new_discussion_reply',
+  'in_circle_new_broadcast_reply' = 'in_circle_new_broadcast_reply',
+  'in_circle_new_discussion' = 'in_circle_new_discussion',
+  'in_circle_new_discussion_reply' = 'in_circle_new_discussion_reply',
 }
 
 // types act as `official_announcement`

--- a/src/common/enums/notification.ts
+++ b/src/common/enums/notification.ts
@@ -44,7 +44,8 @@ export enum DB_NOTICE_TYPE {
   circle_new_subscriber = 'circle_new_subscriber',
   circle_new_follower = 'circle_new_follower',
   circle_new_unsubscriber = 'circle_new_unsubscriber',
-  circle_new_comments = 'circle_new_comments',
+  circle_new_broadcast_comments = 'circle_new_broadcast_comments',
+  circle_new_discussion_comments = 'circle_new_discussion_comments',
 
   // crypto
   crypto_wallet_airdrop = 'crypto_wallet_airdrop',
@@ -55,15 +56,17 @@ export enum DB_NOTICE_TYPE {
 }
 
 export enum BUNDLED_NOTICE_TYPE {
-  // CircleNewComments
-  'circle_broadcast_mentioned_you' = 'circle_broadcast_mentioned_you',
-  'circle_discussion_mentioned_you' = 'circle_discussion_mentioned_you',
-  'circle_member_new_broadcast_reply' = 'circle_member_new_broadcast_reply',
-  'circle_member_new_discussion' = 'circle_member_new_discussion',
-  'circle_member_new_discussion_reply' = 'circle_member_new_discussion_reply',
+  // CircleNewBroadcasts
   'in_circle_new_broadcast_reply' = 'in_circle_new_broadcast_reply',
+  'circle_member_new_broadcast_reply' = 'circle_member_new_broadcast_reply',
+  'circle_broadcast_mentioned_you' = 'circle_broadcast_mentioned_you',
+
+  // CircleNewDiscussions
   'in_circle_new_discussion' = 'in_circle_new_discussion',
   'in_circle_new_discussion_reply' = 'in_circle_new_discussion_reply',
+  'circle_member_new_discussion' = 'circle_member_new_discussion',
+  'circle_member_new_discussion_reply' = 'circle_member_new_discussion_reply',
+  'circle_discussion_mentioned_you' = 'circle_discussion_mentioned_you',
 }
 
 // types act as `official_announcement`

--- a/src/common/enums/notification.ts
+++ b/src/common/enums/notification.ts
@@ -44,7 +44,7 @@ export enum DB_NOTICE_TYPE {
   circle_new_subscriber = 'circle_new_subscriber',
   circle_new_follower = 'circle_new_follower',
   circle_new_unsubscriber = 'circle_new_unsubscriber',
-  circle_new_bundled = 'circle_new_bundled',
+  circle_new_comments = 'circle_new_comments',
 
   // crypto
   crypto_wallet_airdrop = 'crypto_wallet_airdrop',
@@ -55,6 +55,7 @@ export enum DB_NOTICE_TYPE {
 }
 
 export enum BUNDLED_NOTICE_TYPE {
+  // CircleNewComments
   'circle_broadcast_mentioned_you' = 'circle_broadcast_mentioned_you',
   'circle_discussion_mentioned_you' = 'circle_discussion_mentioned_you',
   'circle_member_new_broadcast_reply' = 'circle_member_new_broadcast_reply',

--- a/src/connectors/__test__/notificationService.test.ts
+++ b/src/connectors/__test__/notificationService.test.ts
@@ -29,7 +29,7 @@ describe('user notify setting', () => {
     article_mentioned_you: true,
     revised_article_published: true,
     revised_article_not_published: true,
-    circle_new_article: true, // deprecated
+    circle_new_article: true,
 
     // article-article
     article_new_collected: true,
@@ -39,8 +39,6 @@ describe('user notify setting', () => {
     comment_mentioned_you: true,
     article_new_comment: true,
     subscribed_article_new_comment: false,
-    circle_broadcast_mentioned_you: true,
-    circle_discussion_mentioned_you: true,
 
     // comment-comment
     comment_new_reply: true,
@@ -62,7 +60,10 @@ describe('user notify setting', () => {
 
     // circle
     circle_invitation: true,
-    circle_new_broadcast: true, // deprecated
+    circle_new_broadcast: true,
+    circle_broadcast_mentioned_you: true,
+    circle_discussion_mentioned_you: true,
+    circle_new_bundled: true,
 
     // circle owners
     circle_new_subscriber: true,
@@ -73,8 +74,6 @@ describe('user notify setting', () => {
     circle_member_new_discussion_reply: true,
 
     // in circle
-    in_circle_new_article: true,
-    in_circle_new_broadcast: true,
     in_circle_new_broadcast_reply: false,
     in_circle_new_discussion: true,
     in_circle_new_discussion_reply: false,

--- a/src/connectors/__test__/notificationService.test.ts
+++ b/src/connectors/__test__/notificationService.test.ts
@@ -63,7 +63,7 @@ describe('user notify setting', () => {
     circle_new_broadcast: true,
     circle_broadcast_mentioned_you: true,
     circle_discussion_mentioned_you: true,
-    circle_new_bundled: true,
+    circle_new_comments: true,
 
     // circle owners
     circle_new_subscriber: true,

--- a/src/connectors/__test__/notificationService.test.ts
+++ b/src/connectors/__test__/notificationService.test.ts
@@ -39,6 +39,7 @@ describe('user notify setting', () => {
     comment_mentioned_you: true,
     article_new_comment: true,
     subscribed_article_new_comment: false,
+    circle_new_broadcast: true,
 
     // comment-comment
     comment_new_reply: true,
@@ -60,21 +61,19 @@ describe('user notify setting', () => {
 
     // circle
     circle_invitation: true,
-    circle_new_broadcast: true,
-    circle_broadcast_mentioned_you: true,
-    circle_discussion_mentioned_you: true,
-    circle_new_comments: true,
-
-    // circle owners
     circle_new_subscriber: true,
     circle_new_unsubscriber: true,
     circle_new_follower: true,
+
+    circle_new_broadcast_comments: true, // only a placeholder
+    circle_broadcast_mentioned_you: true,
     circle_member_new_broadcast_reply: true,
+    in_circle_new_broadcast_reply: false,
+
+    circle_new_discussion_comments: true, // only a placeholder
+    circle_discussion_mentioned_you: true,
     circle_member_new_discussion: true,
     circle_member_new_discussion_reply: true,
-
-    // in circle
-    in_circle_new_broadcast_reply: false,
     in_circle_new_discussion: true,
     in_circle_new_discussion_reply: false,
 

--- a/src/connectors/notificationService/index.ts
+++ b/src/connectors/notificationService/index.ts
@@ -97,15 +97,26 @@ export class NotificationService extends BaseService {
           entities: params.entities,
           resend: true,
         }
-      // bundled: circle_new_comments
+      // bundled: circle_new_broadcast_comments
+      case BUNDLED_NOTICE_TYPE.circle_broadcast_mentioned_you:
       case BUNDLED_NOTICE_TYPE.circle_member_new_broadcast_reply:
+      case BUNDLED_NOTICE_TYPE.in_circle_new_broadcast_reply:
+        return {
+          type: DB_NOTICE_TYPE.circle_new_broadcast_comments,
+          recipientId: params.recipientId,
+          actorId: params.actorId,
+          entities: params.entities,
+          data: params.data, // update latest comment to DB `data` field
+          bundle: { mergeData: true },
+        }
+      // bundled: circle_new_discussion_comments
+      case BUNDLED_NOTICE_TYPE.circle_discussion_mentioned_you:
       case BUNDLED_NOTICE_TYPE.circle_member_new_discussion:
       case BUNDLED_NOTICE_TYPE.circle_member_new_discussion_reply:
-      case BUNDLED_NOTICE_TYPE.in_circle_new_broadcast_reply:
       case BUNDLED_NOTICE_TYPE.in_circle_new_discussion:
       case BUNDLED_NOTICE_TYPE.in_circle_new_discussion_reply:
         return {
-          type: DB_NOTICE_TYPE.circle_new_comments,
+          type: DB_NOTICE_TYPE.circle_new_discussion_comments,
           recipientId: params.recipientId,
           actorId: params.actorId,
           entities: params.entities,
@@ -224,7 +235,6 @@ export class NotificationService extends BaseService {
       setting: notifySetting,
     })
 
-    console.log('notificationService.__trigger:', { notifySetting, enable })
     if (!enable) {
       logger.info(
         `Send ${noticeParams.type} to ${noticeParams.recipientId} skipped`
@@ -234,8 +244,6 @@ export class NotificationService extends BaseService {
 
     // Put Notice to DB
     const { created, bundled } = await this.notice.process(noticeParams)
-
-    console.log('notificationService.__trigger:', { created, bundled })
 
     if (!created && !bundled) {
       logger.info(`Notice ${params.event} to ${params.recipientId} skipped`)

--- a/src/connectors/notificationService/index.ts
+++ b/src/connectors/notificationService/index.ts
@@ -1,4 +1,8 @@
-import { DB_NOTICE_TYPE, OFFICIAL_NOTICE_EXTEND_TYPE } from 'common/enums'
+import {
+  BUNDLED_NOTICE_TYPE,
+  DB_NOTICE_TYPE,
+  OFFICIAL_NOTICE_EXTEND_TYPE,
+} from 'common/enums'
 import logger from 'common/logger'
 import { BaseService, UserService } from 'connectors'
 import {
@@ -79,8 +83,6 @@ export class NotificationService extends BaseService {
       case DB_NOTICE_TYPE.circle_new_subscriber:
       case DB_NOTICE_TYPE.circle_new_follower:
       case DB_NOTICE_TYPE.circle_new_unsubscriber:
-      case DB_NOTICE_TYPE.in_circle_new_broadcast:
-      case DB_NOTICE_TYPE.in_circle_new_article:
         return {
           type: params.event,
           recipientId: params.recipientId,
@@ -95,21 +97,20 @@ export class NotificationService extends BaseService {
           entities: params.entities,
           resend: true,
         }
-      case DB_NOTICE_TYPE.circle_broadcast_mentioned_you:
-      case DB_NOTICE_TYPE.circle_discussion_mentioned_you:
-      case DB_NOTICE_TYPE.circle_member_new_broadcast_reply:
-      case DB_NOTICE_TYPE.circle_member_new_discussion:
-      case DB_NOTICE_TYPE.circle_member_new_discussion_reply:
-      case DB_NOTICE_TYPE.in_circle_new_broadcast_reply:
-      case DB_NOTICE_TYPE.in_circle_new_discussion:
-      case DB_NOTICE_TYPE.in_circle_new_discussion_reply:
+      // bundled: circle_new_bundled
+      case BUNDLED_NOTICE_TYPE.circle_member_new_broadcast_reply:
+      case BUNDLED_NOTICE_TYPE.circle_member_new_discussion:
+      case BUNDLED_NOTICE_TYPE.circle_member_new_discussion_reply:
+      case BUNDLED_NOTICE_TYPE.in_circle_new_broadcast_reply:
+      case BUNDLED_NOTICE_TYPE.in_circle_new_discussion:
+      case BUNDLED_NOTICE_TYPE.in_circle_new_discussion_reply:
         return {
-          type: params.event,
+          type: DB_NOTICE_TYPE.circle_new_bundled,
           recipientId: params.recipientId,
           actorId: params.actorId,
           entities: params.entities,
           data: params.data, // update latest comment to DB `data` field
-          bundle: { replaceData: true },
+          bundle: { mergeData: true },
         }
       // act as official annonuncement
       case DB_NOTICE_TYPE.official_announcement:

--- a/src/connectors/notificationService/index.ts
+++ b/src/connectors/notificationService/index.ts
@@ -97,7 +97,7 @@ export class NotificationService extends BaseService {
           entities: params.entities,
           resend: true,
         }
-      // bundled: circle_new_bundled
+      // bundled: circle_new_comments
       case BUNDLED_NOTICE_TYPE.circle_member_new_broadcast_reply:
       case BUNDLED_NOTICE_TYPE.circle_member_new_discussion:
       case BUNDLED_NOTICE_TYPE.circle_member_new_discussion_reply:
@@ -105,7 +105,7 @@ export class NotificationService extends BaseService {
       case BUNDLED_NOTICE_TYPE.in_circle_new_discussion:
       case BUNDLED_NOTICE_TYPE.in_circle_new_discussion_reply:
         return {
-          type: DB_NOTICE_TYPE.circle_new_bundled,
+          type: DB_NOTICE_TYPE.circle_new_comments,
           recipientId: params.recipientId,
           actorId: params.actorId,
           entities: params.entities,

--- a/src/connectors/notificationService/mail/sendDailySummary.ts
+++ b/src/connectors/notificationService/mail/sendDailySummary.ts
@@ -41,7 +41,8 @@ export const sendDailySummary = async ({
     circle_new_unsubscriber: NoticeItem[]
     circle_new_article: NoticeItem[]
     circle_new_broadcast: NoticeItem[]
-    circle_new_comments: NoticeItem[]
+    circle_new_broadcast_comments: NoticeItem[]
+    circle_new_discussion_comments: NoticeItem[]
   }
 }) => {
   const templateId = EMAIL_TEMPLATE_ID.dailySummary[language]
@@ -176,7 +177,8 @@ export const sendDailySummary = async ({
             circle_new_unsubscriber,
             // circle_new_article,
             // circle_new_broadcast,
-            // circle_new_comments
+            // circle_new_broadcast_comments
+            // circle_new_discussion_comments
           },
         },
       },

--- a/src/connectors/notificationService/mail/sendDailySummary.ts
+++ b/src/connectors/notificationService/mail/sendDailySummary.ts
@@ -39,15 +39,9 @@ export const sendDailySummary = async ({
     circle_new_subscriber: NoticeItem[]
     circle_new_follower: NoticeItem[]
     circle_new_unsubscriber: NoticeItem[]
-    circle_member_new_broadcast_reply: NoticeItem[]
-    circle_member_new_discussion: NoticeItem[]
-    circle_member_new_discussion_reply: NoticeItem[]
-
-    in_circle_new_article: NoticeItem[]
-    in_circle_new_broadcast: NoticeItem[]
-    in_circle_new_broadcast_reply: NoticeItem[]
-    in_circle_new_discussion: NoticeItem[]
-    in_circle_new_discussion_reply: NoticeItem[]
+    circle_new_article: NoticeItem[]
+    circle_new_broadcast: NoticeItem[]
+    circle_new_bundled: NoticeItem[]
   }
 }) => {
   const templateId = EMAIL_TEMPLATE_ID.dailySummary[language]
@@ -103,8 +97,6 @@ export const sendDailySummary = async ({
       comment: await getCommentDigest(entities && entities.target),
     }))
   )
-
-  // for circle owners
   const circle_new_subscriber = await Promise.all(
     notices.circle_new_subscriber.map(async ({ actors = [], entities }) => ({
       actor: await getUserDigest(actors[0]),
@@ -123,40 +115,27 @@ export const sendDailySummary = async ({
       actorCount: actors.length > 3 ? actors.length : false,
     }))
   )
-
-  // for circle members & followers
-  const in_circle_new_article = await Promise.all(
-    notices.in_circle_new_article.map(async ({ actors = [], entities }) => ({
-      actor: await getUserDigest(actors[0]),
-      article: await getArticleDigest(entities && entities.target),
-    }))
-  )
-  const in_circle_new_broadcast = await Promise.all(
-    notices.in_circle_new_broadcast.map(async ({ actors = [], entities }) => ({
-      actor: await getUserDigest(actors[0]),
-      comment: await getCommentDigest(entities && entities.target),
-    }))
-  )
-  const in_circle_new_broadcast_reply = await Promise.all(
-    notices.in_circle_new_broadcast_reply.map(
-      async ({ actors = [], entities }) => ({
-        actor: await getUserDigest(actors[0]),
-        comment: await getCommentDigest(entities && entities.target),
-      })
-    )
-  )
-  const in_circle_new_discussion = await Promise.all(
-    notices.in_circle_new_discussion.map(async ({ actors = [], entities }) => ({
-      actor: await getUserDigest(actors[0]),
-      comment: await getCommentDigest(entities && entities.target),
-    }))
-  )
-  const in_circle_new_discussion_reply = await Promise.all(
-    notices.in_circle_new_discussion.map(async ({ actors = [], entities }) => ({
-      actor: await getUserDigest(actors[0]),
-      comment: await getCommentDigest(entities && entities.target),
-    }))
-  )
+  // TODO
+  // const circle_new_article = await Promise.all(
+  //   notices.circle_new_article.map(async ({ actors = [], entities }) => ({
+  //     actor: await getUserDigest(actors[0]),
+  //     article: await getArticleDigest(entities && entities.target),
+  //   }))
+  // )
+  // const circle_new_broadcast = await Promise.all(
+  //   notices.circle_new_broadcast.map(async ({ actors = [], entities }) => ({
+  //     actor: await getUserDigest(actors[0]),
+  //     comment: await getCommentDigest(entities && entities.target),
+  //   }))
+  // )
+  // const in_circle_new_broadcast_reply = await Promise.all(
+  //   notices.circle_new_bundled.map(
+  //     async ({ actors = [], entities }) => ({
+  //       actor: await getUserDigest(actors[0]),
+  //       comment: await getCommentDigest(entities && entities.target),
+  //     })
+  //   )
+  // )
 
   notificationQueue.sendMail({
     from: environment.emailFromAsk as string,
@@ -192,18 +171,12 @@ export const sendDailySummary = async ({
             article_mentioned_you,
             comment_new_reply,
             comment_mentioned_you,
-
-            // for circle owners
             circle_new_subscriber,
             circle_new_follower,
             circle_new_unsubscriber,
-
-            // for circle members & followers
-            in_circle_new_article,
-            in_circle_new_broadcast,
-            in_circle_new_broadcast_reply,
-            in_circle_new_discussion,
-            in_circle_new_discussion_reply,
+            // circle_new_article,
+            // circle_new_broadcast,
+            // circle_new_bundled
           },
         },
       },

--- a/src/connectors/notificationService/mail/sendDailySummary.ts
+++ b/src/connectors/notificationService/mail/sendDailySummary.ts
@@ -41,7 +41,7 @@ export const sendDailySummary = async ({
     circle_new_unsubscriber: NoticeItem[]
     circle_new_article: NoticeItem[]
     circle_new_broadcast: NoticeItem[]
-    circle_new_bundled: NoticeItem[]
+    circle_new_comments: NoticeItem[]
   }
 }) => {
   const templateId = EMAIL_TEMPLATE_ID.dailySummary[language]
@@ -129,7 +129,7 @@ export const sendDailySummary = async ({
   //   }))
   // )
   // const in_circle_new_broadcast_reply = await Promise.all(
-  //   notices.circle_new_bundled.map(
+  //   notices.circle_new_comments.map(
   //     async ({ actors = [], entities }) => ({
   //       actor: await getUserDigest(actors[0]),
   //       comment: await getCommentDigest(entities && entities.target),
@@ -176,7 +176,7 @@ export const sendDailySummary = async ({
             circle_new_unsubscriber,
             // circle_new_article,
             // circle_new_broadcast,
-            // circle_new_bundled
+            // circle_new_comments
           },
         },
       },

--- a/src/connectors/notificationService/notice.ts
+++ b/src/connectors/notificationService/notice.ts
@@ -157,8 +157,8 @@ class Notice extends BaseService {
   }: {
     noticeId: string
     data: NoticeData
-  }): Promise<void> {
-    this.knex('notice_detail')
+  }) {
+    return this.knex('notice_detail')
       .update({ data })
       .whereIn('id', function () {
         this.select('notice_detail_id').from('notice').where({ id: noticeId })
@@ -182,6 +182,7 @@ class Notice extends BaseService {
       })
 
       if (params.bundle?.mergeData && params.data) {
+        console.log('...merge')
         await this.updateNoticeData({
           noticeId: bundleables[0].id,
           data: mergeDataWith(bundleables[0].data, params.data),
@@ -591,7 +592,7 @@ class Notice extends BaseService {
       circle_new_follower: setting.circleNewFollower,
 
       // circle bundles
-      circle_new_bundled: true, // just a placeholder, determined by below BundledNoticeType
+      circle_new_comments: true, // just a placeholder, determined by below BundledNoticeType
       circle_broadcast_mentioned_you: true,
       circle_discussion_mentioned_you: true,
       circle_member_new_broadcast_reply: setting.circleMemberNewBroadcastReply,

--- a/src/connectors/notificationService/notice.ts
+++ b/src/connectors/notificationService/notice.ts
@@ -182,7 +182,6 @@ class Notice extends BaseService {
       })
 
       if (params.bundle?.mergeData && params.data) {
-        console.log('...merge')
         await this.updateNoticeData({
           noticeId: bundleables[0].id,
           data: mergeDataWith(bundleables[0].data, params.data),
@@ -592,14 +591,16 @@ class Notice extends BaseService {
       circle_new_follower: setting.circleNewFollower,
 
       // circle bundles
-      circle_new_comments: true, // just a placeholder, determined by below BundledNoticeType
+      circle_new_broadcast_comments: true, // only a placeholder
       circle_broadcast_mentioned_you: true,
-      circle_discussion_mentioned_you: true,
       circle_member_new_broadcast_reply: setting.circleMemberNewBroadcastReply,
+      in_circle_new_broadcast_reply: setting.inCircleNewBroadcastReply,
+
+      circle_new_discussion_comments: true, // only a placeholder
+      circle_discussion_mentioned_you: true,
       circle_member_new_discussion: setting.circleMemberNewDiscussion,
       circle_member_new_discussion_reply:
         setting.circleMemberNewDiscussionReply,
-      in_circle_new_broadcast_reply: setting.inCircleNewBroadcastReply,
       in_circle_new_discussion: setting.inCircleNewDiscussion,
       in_circle_new_discussion_reply: setting.inCircleNewDiscussionReply,
 

--- a/src/connectors/queue/emails.ts
+++ b/src/connectors/queue/emails.ts
@@ -120,8 +120,8 @@ class EmailsQueue extends BaseQueue {
               circle_new_broadcast: filterNotices(
                 DB_NOTICE_TYPE.circle_new_broadcast
               ),
-              circle_new_bundled: filterNotices(
-                DB_NOTICE_TYPE.circle_new_bundled
+              circle_new_comments: filterNotices(
+                DB_NOTICE_TYPE.circle_new_comments
               ),
             },
             language: user.language,

--- a/src/connectors/queue/emails.ts
+++ b/src/connectors/queue/emails.ts
@@ -105,8 +105,6 @@ class EmailsQueue extends BaseQueue {
               circle_invitation: filterNotices(
                 DB_NOTICE_TYPE.circle_invitation
               ),
-
-              // for circle owners
               circle_new_subscriber: filterNotices(
                 DB_NOTICE_TYPE.circle_new_subscriber
               ),
@@ -116,31 +114,14 @@ class EmailsQueue extends BaseQueue {
               circle_new_unsubscriber: filterNotices(
                 DB_NOTICE_TYPE.circle_new_unsubscriber
               ),
-              circle_member_new_broadcast_reply: filterNotices(
-                DB_NOTICE_TYPE.circle_member_new_broadcast_reply
+              circle_new_article: filterNotices(
+                DB_NOTICE_TYPE.circle_new_article
               ),
-              circle_member_new_discussion: filterNotices(
-                DB_NOTICE_TYPE.circle_member_new_discussion
+              circle_new_broadcast: filterNotices(
+                DB_NOTICE_TYPE.circle_new_broadcast
               ),
-              circle_member_new_discussion_reply: filterNotices(
-                DB_NOTICE_TYPE.circle_member_new_discussion_reply
-              ),
-
-              // for circle members & followers
-              in_circle_new_article: filterNotices(
-                DB_NOTICE_TYPE.circle_member_new_discussion_reply
-              ),
-              in_circle_new_broadcast: filterNotices(
-                DB_NOTICE_TYPE.in_circle_new_broadcast
-              ),
-              in_circle_new_broadcast_reply: filterNotices(
-                DB_NOTICE_TYPE.in_circle_new_broadcast_reply
-              ),
-              in_circle_new_discussion: filterNotices(
-                DB_NOTICE_TYPE.in_circle_new_discussion
-              ),
-              in_circle_new_discussion_reply: filterNotices(
-                DB_NOTICE_TYPE.in_circle_new_discussion_reply
+              circle_new_bundled: filterNotices(
+                DB_NOTICE_TYPE.circle_new_bundled
               ),
             },
             language: user.language,

--- a/src/connectors/queue/emails.ts
+++ b/src/connectors/queue/emails.ts
@@ -120,8 +120,11 @@ class EmailsQueue extends BaseQueue {
               circle_new_broadcast: filterNotices(
                 DB_NOTICE_TYPE.circle_new_broadcast
               ),
-              circle_new_comments: filterNotices(
-                DB_NOTICE_TYPE.circle_new_comments
+              circle_new_broadcast_comments: filterNotices(
+                DB_NOTICE_TYPE.circle_new_broadcast_comments
+              ),
+              circle_new_discussion_comments: filterNotices(
+                DB_NOTICE_TYPE.circle_new_discussion_comments
               ),
             },
             language: user.language,

--- a/src/connectors/queue/publication.ts
+++ b/src/connectors/queue/publication.ts
@@ -430,26 +430,16 @@ class PublicationQueue extends BaseQueue {
       })
     }
 
-    // handle 'in_circle_new_article' notification
+    // handle 'circle_new_article' notification
     const recipients = await this.userService.findCircleRecipients(
       draft.circleId
     )
 
-    const circle = await this.atomService.circleIdLoader.load(draft.circleId)
-
     recipients.forEach((recipientId: any) => {
       this.notificationService.trigger({
-        event: DB_NOTICE_TYPE.in_circle_new_article, // circle_new_article,
+        event: DB_NOTICE_TYPE.circle_new_article,
         recipientId,
-        actorId: circle.owner, // viewer.id,
-        entities: [
-          { type: 'target', entityTable: 'circle', entity: circle },
-          {
-            type: 'article',
-            entityTable: 'article',
-            entity: article,
-          },
-        ],
+        entities: [{ type: 'target', entityTable: 'article', entity: article }],
       })
     })
 

--- a/src/definitions/notification.d.ts
+++ b/src/definitions/notification.d.ts
@@ -1,10 +1,13 @@
 import {
   DB_NOTICE_TYPE,
+  BUNDLED_NOTICE_TYPE,
   OFFICIAL_NOTICE_EXTEND_TYPE,
 } from 'common/enums/notification'
 import { TableName, User } from 'definitions'
 
 export type DBNoticeType = keyof typeof DB_NOTICE_TYPE
+
+export type BundledNoticeType = keyof typeof BUNDLED_NOTICE_TYPE
 
 export type OfficialNoticeExtendType = keyof typeof OFFICIAL_NOTICE_EXTEND_TYPE
 
@@ -19,7 +22,10 @@ export type NoticeEntityType =
   | 'article'
   | 'circle'
 
-export type NotificationType = DBNoticeType | OfficialNoticeExtendType
+export type NotificationType =
+  | DBNoticeType
+  | BundledNoticeType
+  | OfficialNoticeExtendType
 
 export interface NotificationRequiredParams {
   event: NotificationType
@@ -93,7 +99,6 @@ export interface NoticeRevisedArticleNotPublishedParams
   entities: [NotificationEntity<'target', 'article'>]
 }
 
-// deprecated
 export interface NoticeCircleNewArticleParams
   extends NotificationRequiredParams {
   event: DB_NOTICE_TYPE.circle_new_article
@@ -298,81 +303,13 @@ export interface NoticeCircleNewUnsubscriberParams
   entities: [NotificationEntity<'target', 'circle'>]
 }
 
-export interface NoticeCircleMemberNewBroadcastReplyParams
+export interface NoticeCircleNewBundledParams
   extends NotificationRequiredParams {
-  event: DB_NOTICE_TYPE.circle_member_new_broadcast_reply
+  event: BundledNoticeType
   recipientId: string
   actorId: string
   entities: [NotificationEntity<'target', 'circle'>]
-  data: { entityTypeId: string; entityId: string }
-}
-
-export interface NoticeCircleMemberNewDiscussionParams
-  extends NotificationRequiredParams {
-  event: DB_NOTICE_TYPE.circle_member_new_discussion
-  recipientId: string
-  actorId: string
-  entities: [NotificationEntity<'target', 'circle'>]
-  data: { entityTypeId: string; entityId: string }
-}
-
-export interface NoticeCircleMemberNewDiscussionReplyParams
-  extends NotificationRequiredParams {
-  event: DB_NOTICE_TYPE.circle_member_new_discussion_reply
-  recipientId: string
-  actorId: string
-  entities: [NotificationEntity<'target', 'circle'>]
-  data: { entityTypeId: string; entityId: string }
-}
-
-// For circle subscrbers & followers
-export interface NoticeInCircleNewArticleParams
-  extends NotificationRequiredParams {
-  event: DB_NOTICE_TYPE.in_circle_new_article
-  actorId: string
-  recipientId: string
-  entities: [
-    NotificationEntity<'target', 'circle'>,
-    NotificationEntity<'article', 'article'>
-  ]
-}
-
-export interface NoticeInCircleNewBroadcastParams
-  extends NotificationRequiredParams {
-  event: DB_NOTICE_TYPE.in_circle_new_broadcast
-  actorId: string
-  recipientId: string
-  entities: [
-    NotificationEntity<'target', 'circle'>,
-    NotificationEntity<'comment', 'comment'>
-  ]
-}
-
-export interface NoticeInCircleNewDiscussionParams
-  extends NotificationRequiredParams {
-  event: DB_NOTICE_TYPE.in_circle_new_discussion
-  actorId: string
-  recipientId: string
-  entities: [NotificationEntity<'target', 'circle'>]
-  data: { entityTypeId: string; entityId: string }
-}
-
-export interface NoticeInCircleNewBroadcastReplyParams
-  extends NotificationRequiredParams {
-  event: DB_NOTICE_TYPE.in_circle_new_broadcast_reply
-  actorId: string
-  recipientId: string
-  entities: [NotificationEntity<'target', 'circle'>]
-  data: { entityTypeId: string; entityId: string }
-}
-
-export interface NoticeInCircleNewDiscussionReplyParams
-  extends NotificationRequiredParams {
-  event: DB_NOTICE_TYPE.in_circle_new_discussion_reply
-  actorId: string
-  recipientId: string
-  entities: [NotificationEntity<'target', 'circle'>]
-  data: { entityTypeId: string; entityId: string }
+  data: { comments?: string[]; replies?: string[]; mentions?: string[] }
 }
 
 /**
@@ -458,12 +395,12 @@ export type NotificationPrarms =
   | NoticeArticleMentionedYouParams
   | NoticeRevisedArticlePublishedParams
   | NoticeRevisedArticleNotPublishedParams
-  | NoticeCircleNewArticleParams // deprecated
+  | NoticeCircleNewArticleParams
   // Comment
   | NoticeCommentPinnedParams
   | NoticeCommentMentionedYouParams
   | NoticeSubscribedArticleNewCommentParams
-  | NoticeCircleNewBroadcastParams // deprecated
+  | NoticeCircleNewBroadcastParams
   // Comment-Comment
   | NoticeCommentNewReplyParams
   // Tag
@@ -478,21 +415,10 @@ export type NotificationPrarms =
   | NoticePaymentPayoutParams
   // Circle
   | NoticeCircleInvitationParams
-  | NoticeCircleBroadcastMentionedYouParams
-  | NoticeCircleDiscussionMentionedYouParams
-  // Circle: Owner
   | NoticeCircleNewSubscriberParams
   | NoticeCircleNewFollowerParams
   | NoticeCircleNewUnsubscriberParams
-  | NoticeCircleMemberNewBroadcastReplyParams
-  | NoticeCircleMemberNewDiscussionParams
-  | NoticeCircleMemberNewDiscussionReplyParams
-  // Circle: Members & Followers
-  | NoticeInCircleNewArticleParams
-  | NoticeInCircleNewBroadcastParams
-  | NoticeInCircleNewDiscussionParams
-  | NoticeInCircleNewBroadcastReplyParams
-  | NoticeInCircleNewDiscussionReplyParams
+  | NoticeCircleNewBundledParams
   // Official
   | NoticeOfficialAnnouncementParams
   | NoticeUserActivatedParams
@@ -522,9 +448,11 @@ export type NoticeData = {
   url?: string
   // reason for banned/frozen users, not in used
   reason?: string
-  // arbitrary entity, used by circle broadcast/discussion notices
-  entityTypeId?: string
-  entityId?: string
+
+  // usde by circle new bundled notices
+  comments?: string[]
+  replies?: string[]
+  mentions?: string[]
 }
 
 export type NoticeDetail = {
@@ -555,6 +483,6 @@ export type PutNoticeParams = {
   resend?: boolean // used by circle invitation notice
 
   bundle?: {
-    replaceData: boolean // used by circle broadcast/discussion notices
+    mergeData: boolean // used by circle bundled notice
   }
 }

--- a/src/definitions/notification.d.ts
+++ b/src/definitions/notification.d.ts
@@ -303,7 +303,16 @@ export interface NoticeCircleNewUnsubscriberParams
   entities: [NotificationEntity<'target', 'circle'>]
 }
 
-export interface NoticeCircleNewCommentsParams
+export interface NoticeCircleNewBroadcastCommentsParams
+  extends NotificationRequiredParams {
+  event: BundledNoticeType
+  recipientId: string
+  actorId: string
+  entities: [NotificationEntity<'target', 'circle'>]
+  data: { comments?: string[]; replies?: string[]; mentions?: string[] }
+}
+
+export interface NoticeCircleNewDiscussionCommentsParams
   extends NotificationRequiredParams {
   event: BundledNoticeType
   recipientId: string
@@ -418,7 +427,8 @@ export type NotificationPrarms =
   | NoticeCircleNewSubscriberParams
   | NoticeCircleNewFollowerParams
   | NoticeCircleNewUnsubscriberParams
-  | NoticeCircleNewCommentsParams
+  | NoticeCircleNewBroadcastCommentsParams
+  | NoticeCircleNewDiscussionCommentsParams
   // Official
   | NoticeOfficialAnnouncementParams
   | NoticeUserActivatedParams

--- a/src/definitions/notification.d.ts
+++ b/src/definitions/notification.d.ts
@@ -303,7 +303,7 @@ export interface NoticeCircleNewUnsubscriberParams
   entities: [NotificationEntity<'target', 'circle'>]
 }
 
-export interface NoticeCircleNewBundledParams
+export interface NoticeCircleNewCommentsParams
   extends NotificationRequiredParams {
   event: BundledNoticeType
   recipientId: string
@@ -418,7 +418,7 @@ export type NotificationPrarms =
   | NoticeCircleNewSubscriberParams
   | NoticeCircleNewFollowerParams
   | NoticeCircleNewUnsubscriberParams
-  | NoticeCircleNewBundledParams
+  | NoticeCircleNewCommentsParams
   // Official
   | NoticeOfficialAnnouncementParams
   | NoticeUserActivatedParams

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -2362,7 +2362,7 @@ export const enum GQLCircleNoticeType {
   CircleNewSubscriber = 'CircleNewSubscriber',
   CircleNewFollower = 'CircleNewFollower',
   CircleNewUnsubscriber = 'CircleNewUnsubscriber',
-  CircleNewBundled = 'CircleNewBundled',
+  CircleNewComments = 'CircleNewComments',
 }
 
 /**

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -2362,7 +2362,8 @@ export const enum GQLCircleNoticeType {
   CircleNewSubscriber = 'CircleNewSubscriber',
   CircleNewFollower = 'CircleNewFollower',
   CircleNewUnsubscriber = 'CircleNewUnsubscriber',
-  CircleNewComments = 'CircleNewComments',
+  CircleNewBroadcastComments = 'CircleNewBroadcastComments',
+  CircleNewDiscussionComments = 'CircleNewDiscussionComments',
 }
 
 /**

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -1999,8 +1999,6 @@ export type GQLPossibleNoticeTypeNames =
   | 'TagNotice'
   | 'TransactionNotice'
   | 'CircleNotice'
-  | 'CircleCommentNotice'
-  | 'CircleArticleNotice'
   | 'CryptoNotice'
   | 'OfficialAnnouncementNotice'
 
@@ -2015,8 +2013,6 @@ export interface GQLNoticeNameMap {
   TagNotice: GQLTagNotice
   TransactionNotice: GQLTransactionNotice
   CircleNotice: GQLCircleNotice
-  CircleCommentNotice: GQLCircleCommentNotice
-  CircleArticleNotice: GQLCircleArticleNotice
   CryptoNotice: GQLCryptoNotice
   OfficialAnnouncementNotice: GQLOfficialAnnouncementNotice
 }
@@ -2105,11 +2101,6 @@ export const enum GQLArticleNoticeType {
   ArticleNewAppreciation = 'ArticleNewAppreciation',
   RevisedArticlePublished = 'RevisedArticlePublished',
   RevisedArticleNotPublished = 'RevisedArticleNotPublished',
-
-  /**
-   *
-   * @deprecated No longer in use
-   */
   CircleNewArticle = 'CircleNewArticle',
 }
 
@@ -2178,11 +2169,6 @@ export const enum GQLCommentNoticeType {
   CommentMentionedYou = 'CommentMentionedYou',
   ArticleNewComment = 'ArticleNewComment',
   SubscribedArticleNewComment = 'SubscribedArticleNewComment',
-
-  /**
-   *
-   * @deprecated No longer in use
-   */
   CircleNewBroadcast = 'CircleNewBroadcast',
 }
 
@@ -2356,96 +2342,27 @@ export interface GQLCircleNotice extends GQLNotice {
   target: GQLCircle
 
   /**
-   * An optional arbitrary node, Comment for broadcast and discussion notices
+   * Optional discussion/broadcast comments for bundled notices
    */
-  node?: GQLNode
+  comments?: Array<GQLComment>
+
+  /**
+   * Optional discussion/broadcast replies for bundled notices
+   */
+  replies?: Array<GQLComment>
+
+  /**
+   * Optional mention comments for bundled notices
+   */
+  mentions?: Array<GQLComment>
 }
 
 export const enum GQLCircleNoticeType {
   CircleInvitation = 'CircleInvitation',
-  CircleBroadcastMentionedYou = 'CircleBroadcastMentionedYou',
-  CircleDiscussionMentionedYou = 'CircleDiscussionMentionedYou',
-
-  /**
-   * for circle owner
-   */
   CircleNewSubscriber = 'CircleNewSubscriber',
   CircleNewFollower = 'CircleNewFollower',
   CircleNewUnsubscriber = 'CircleNewUnsubscriber',
-  CircleMemberNewBroadcastReply = 'CircleMemberNewBroadcastReply',
-  CircleMemberNewDiscussion = 'CircleMemberNewDiscussion',
-  CircleMemberNewDiscussionReply = 'CircleMemberNewDiscussionReply',
-
-  /**
-   * for circle members & followers
-   */
-  InCircleNewBroadcastReply = 'InCircleNewBroadcastReply',
-  InCircleNewDiscussion = 'InCircleNewDiscussion',
-  InCircleNewDiscussionReply = 'InCircleNewDiscussionReply',
-}
-
-export interface GQLCircleCommentNotice extends GQLNotice {
-  /**
-   * Unique ID of this notice.
-   */
-  id: string
-
-  /**
-   * The value determines if the notice is unread or not.
-   */
-  unread: boolean
-
-  /**
-   * Time of this notice was created.
-   */
-  createdAt: GQLDateTime
-
-  /**
-   * List of notice actors.
-   */
-  actors?: Array<GQLUser>
-  type: GQLCircleCommentNoticeType
-  target: GQLCircle
-  comment: GQLComment
-}
-
-export const enum GQLCircleCommentNoticeType {
-  /**
-   * for circle members & followers
-   */
-  InCircleNewBroadcast = 'InCircleNewBroadcast',
-}
-
-export interface GQLCircleArticleNotice extends GQLNotice {
-  /**
-   * Unique ID of this notice.
-   */
-  id: string
-
-  /**
-   * The value determines if the notice is unread or not.
-   */
-  unread: boolean
-
-  /**
-   * Time of this notice was created.
-   */
-  createdAt: GQLDateTime
-
-  /**
-   * List of notice actors.
-   */
-  actors?: Array<GQLUser>
-  type: GQLCircleArticleNoticeType
-  target: GQLCircle
-  article: GQLArticle
-}
-
-export const enum GQLCircleArticleNoticeType {
-  /**
-   * for circle members & followers
-   */
-  InCircleNewArticle = 'InCircleNewArticle',
+  CircleNewBundled = 'CircleNewBundled',
 }
 
 /**
@@ -3464,14 +3381,12 @@ export interface GQLNotificationSetting {
   circleNewSubscriber: boolean
   circleNewFollower: boolean
   circleNewUnsubscriber: boolean
-  circleNewDiscussion: boolean
-  circleMemberBroadcast: boolean
+  circleMemberNewBroadcastReply: boolean
   circleMemberNewDiscussion: boolean
   circleMemberNewDiscussionReply: boolean
-  circleMemberNewBroadcastReply: boolean
 
   /**
-   * for circle members
+   * for circle members & followers
    */
   inCircleNewArticle: boolean
   inCircleNewBroadcast: boolean
@@ -4431,8 +4346,6 @@ export interface GQLResolver {
   TagNotice?: GQLTagNoticeTypeResolver
   TransactionNotice?: GQLTransactionNoticeTypeResolver
   CircleNotice?: GQLCircleNoticeTypeResolver
-  CircleCommentNotice?: GQLCircleCommentNoticeTypeResolver
-  CircleArticleNotice?: GQLCircleArticleNoticeTypeResolver
   CryptoNotice?: GQLCryptoNoticeTypeResolver
   OfficialAnnouncementNotice?: GQLOfficialAnnouncementNoticeTypeResolver
   DateTime?: GraphQLScalarType
@@ -8656,8 +8569,6 @@ export interface GQLNoticeTypeResolver<TParent = any> {
     | 'TagNotice'
     | 'TransactionNotice'
     | 'CircleNotice'
-    | 'CircleCommentNotice'
-    | 'CircleArticleNotice'
     | 'CryptoNotice'
     | 'OfficialAnnouncementNotice'
     | Promise<
@@ -8670,8 +8581,6 @@ export interface GQLNoticeTypeResolver<TParent = any> {
         | 'TagNotice'
         | 'TransactionNotice'
         | 'CircleNotice'
-        | 'CircleCommentNotice'
-        | 'CircleArticleNotice'
         | 'CryptoNotice'
         | 'OfficialAnnouncementNotice'
       >
@@ -9351,7 +9260,9 @@ export interface GQLCircleNoticeTypeResolver<TParent = any> {
   actors?: CircleNoticeToActorsResolver<TParent>
   type?: CircleNoticeToTypeResolver<TParent>
   target?: CircleNoticeToTargetResolver<TParent>
-  node?: CircleNoticeToNodeResolver<TParent>
+  comments?: CircleNoticeToCommentsResolver<TParent>
+  replies?: CircleNoticeToRepliesResolver<TParent>
+  mentions?: CircleNoticeToMentionsResolver<TParent>
 }
 
 export interface CircleNoticeToIdResolver<TParent = any, TResult = any> {
@@ -9408,7 +9319,7 @@ export interface CircleNoticeToTargetResolver<TParent = any, TResult = any> {
   ): TResult
 }
 
-export interface CircleNoticeToNodeResolver<TParent = any, TResult = any> {
+export interface CircleNoticeToCommentsResolver<TParent = any, TResult = any> {
   (
     parent: TParent,
     args: {},
@@ -9417,17 +9328,7 @@ export interface CircleNoticeToNodeResolver<TParent = any, TResult = any> {
   ): TResult
 }
 
-export interface GQLCircleCommentNoticeTypeResolver<TParent = any> {
-  id?: CircleCommentNoticeToIdResolver<TParent>
-  unread?: CircleCommentNoticeToUnreadResolver<TParent>
-  createdAt?: CircleCommentNoticeToCreatedAtResolver<TParent>
-  actors?: CircleCommentNoticeToActorsResolver<TParent>
-  type?: CircleCommentNoticeToTypeResolver<TParent>
-  target?: CircleCommentNoticeToTargetResolver<TParent>
-  comment?: CircleCommentNoticeToCommentResolver<TParent>
-}
-
-export interface CircleCommentNoticeToIdResolver<TParent = any, TResult = any> {
+export interface CircleNoticeToRepliesResolver<TParent = any, TResult = any> {
   (
     parent: TParent,
     args: {},
@@ -9436,161 +9337,7 @@ export interface CircleCommentNoticeToIdResolver<TParent = any, TResult = any> {
   ): TResult
 }
 
-export interface CircleCommentNoticeToUnreadResolver<
-  TParent = any,
-  TResult = any
-> {
-  (
-    parent: TParent,
-    args: {},
-    context: Context,
-    info: GraphQLResolveInfo
-  ): TResult
-}
-
-export interface CircleCommentNoticeToCreatedAtResolver<
-  TParent = any,
-  TResult = any
-> {
-  (
-    parent: TParent,
-    args: {},
-    context: Context,
-    info: GraphQLResolveInfo
-  ): TResult
-}
-
-export interface CircleCommentNoticeToActorsResolver<
-  TParent = any,
-  TResult = any
-> {
-  (
-    parent: TParent,
-    args: {},
-    context: Context,
-    info: GraphQLResolveInfo
-  ): TResult
-}
-
-export interface CircleCommentNoticeToTypeResolver<
-  TParent = any,
-  TResult = any
-> {
-  (
-    parent: TParent,
-    args: {},
-    context: Context,
-    info: GraphQLResolveInfo
-  ): TResult
-}
-
-export interface CircleCommentNoticeToTargetResolver<
-  TParent = any,
-  TResult = any
-> {
-  (
-    parent: TParent,
-    args: {},
-    context: Context,
-    info: GraphQLResolveInfo
-  ): TResult
-}
-
-export interface CircleCommentNoticeToCommentResolver<
-  TParent = any,
-  TResult = any
-> {
-  (
-    parent: TParent,
-    args: {},
-    context: Context,
-    info: GraphQLResolveInfo
-  ): TResult
-}
-
-export interface GQLCircleArticleNoticeTypeResolver<TParent = any> {
-  id?: CircleArticleNoticeToIdResolver<TParent>
-  unread?: CircleArticleNoticeToUnreadResolver<TParent>
-  createdAt?: CircleArticleNoticeToCreatedAtResolver<TParent>
-  actors?: CircleArticleNoticeToActorsResolver<TParent>
-  type?: CircleArticleNoticeToTypeResolver<TParent>
-  target?: CircleArticleNoticeToTargetResolver<TParent>
-  article?: CircleArticleNoticeToArticleResolver<TParent>
-}
-
-export interface CircleArticleNoticeToIdResolver<TParent = any, TResult = any> {
-  (
-    parent: TParent,
-    args: {},
-    context: Context,
-    info: GraphQLResolveInfo
-  ): TResult
-}
-
-export interface CircleArticleNoticeToUnreadResolver<
-  TParent = any,
-  TResult = any
-> {
-  (
-    parent: TParent,
-    args: {},
-    context: Context,
-    info: GraphQLResolveInfo
-  ): TResult
-}
-
-export interface CircleArticleNoticeToCreatedAtResolver<
-  TParent = any,
-  TResult = any
-> {
-  (
-    parent: TParent,
-    args: {},
-    context: Context,
-    info: GraphQLResolveInfo
-  ): TResult
-}
-
-export interface CircleArticleNoticeToActorsResolver<
-  TParent = any,
-  TResult = any
-> {
-  (
-    parent: TParent,
-    args: {},
-    context: Context,
-    info: GraphQLResolveInfo
-  ): TResult
-}
-
-export interface CircleArticleNoticeToTypeResolver<
-  TParent = any,
-  TResult = any
-> {
-  (
-    parent: TParent,
-    args: {},
-    context: Context,
-    info: GraphQLResolveInfo
-  ): TResult
-}
-
-export interface CircleArticleNoticeToTargetResolver<
-  TParent = any,
-  TResult = any
-> {
-  (
-    parent: TParent,
-    args: {},
-    context: Context,
-    info: GraphQLResolveInfo
-  ): TResult
-}
-
-export interface CircleArticleNoticeToArticleResolver<
-  TParent = any,
-  TResult = any
-> {
+export interface CircleNoticeToMentionsResolver<TParent = any, TResult = any> {
   (
     parent: TParent,
     args: {},
@@ -11437,11 +11184,9 @@ export interface GQLNotificationSettingTypeResolver<TParent = any> {
   circleNewSubscriber?: NotificationSettingToCircleNewSubscriberResolver<TParent>
   circleNewFollower?: NotificationSettingToCircleNewFollowerResolver<TParent>
   circleNewUnsubscriber?: NotificationSettingToCircleNewUnsubscriberResolver<TParent>
-  circleNewDiscussion?: NotificationSettingToCircleNewDiscussionResolver<TParent>
-  circleMemberBroadcast?: NotificationSettingToCircleMemberBroadcastResolver<TParent>
+  circleMemberNewBroadcastReply?: NotificationSettingToCircleMemberNewBroadcastReplyResolver<TParent>
   circleMemberNewDiscussion?: NotificationSettingToCircleMemberNewDiscussionResolver<TParent>
   circleMemberNewDiscussionReply?: NotificationSettingToCircleMemberNewDiscussionReplyResolver<TParent>
-  circleMemberNewBroadcastReply?: NotificationSettingToCircleMemberNewBroadcastReplyResolver<TParent>
   inCircleNewArticle?: NotificationSettingToInCircleNewArticleResolver<TParent>
   inCircleNewBroadcast?: NotificationSettingToInCircleNewBroadcastResolver<TParent>
   inCircleNewBroadcastReply?: NotificationSettingToInCircleNewBroadcastReplyResolver<TParent>
@@ -11605,19 +11350,7 @@ export interface NotificationSettingToCircleNewUnsubscriberResolver<
   ): TResult
 }
 
-export interface NotificationSettingToCircleNewDiscussionResolver<
-  TParent = any,
-  TResult = any
-> {
-  (
-    parent: TParent,
-    args: {},
-    context: Context,
-    info: GraphQLResolveInfo
-  ): TResult
-}
-
-export interface NotificationSettingToCircleMemberBroadcastResolver<
+export interface NotificationSettingToCircleMemberNewBroadcastReplyResolver<
   TParent = any,
   TResult = any
 > {
@@ -11642,18 +11375,6 @@ export interface NotificationSettingToCircleMemberNewDiscussionResolver<
 }
 
 export interface NotificationSettingToCircleMemberNewDiscussionReplyResolver<
-  TParent = any,
-  TResult = any
-> {
-  (
-    parent: TParent,
-    args: {},
-    context: Context,
-    info: GraphQLResolveInfo
-  ): TResult
-}
-
-export interface NotificationSettingToCircleMemberNewBroadcastReplyResolver<
   TParent = any,
   TResult = any
 > {

--- a/src/mutations/circle/putCircleArticles.ts
+++ b/src/mutations/circle/putCircleArticles.ts
@@ -206,12 +206,10 @@ const resolver: MutationToPutCircleArticlesResolver = async (
       // notify
       recipients.forEach((recipientId: any) => {
         notificationService.trigger({
-          event: DB_NOTICE_TYPE.in_circle_new_article,
-          actorId: viewer.id,
+          event: DB_NOTICE_TYPE.circle_new_article,
           recipientId,
           entities: [
-            { type: 'target', entityTable: 'circle', entity: circle },
-            { type: 'article', entityTable: 'article', entity: article },
+            { type: 'target', entityTable: 'article', entity: article },
           ],
         })
       })

--- a/src/queries/notice/index.ts
+++ b/src/queries/notice/index.ts
@@ -109,7 +109,7 @@ const notice: {
         circle_new_subscriber: NOTICE_TYPE.CircleNotice,
         circle_new_unsubscriber: NOTICE_TYPE.CircleNotice,
         circle_new_follower: NOTICE_TYPE.CircleNotice,
-        circle_new_bundled: NOTICE_TYPE.CircleNotice,
+        circle_new_comments: NOTICE_TYPE.CircleNotice,
 
         // crypto
         crypto_wallet_airdrop: NOTICE_TYPE.CryptoNotice,
@@ -266,8 +266,8 @@ const notice: {
           return GQLCircleNoticeType.CircleNewFollower
         case DB_NOTICE_TYPE.circle_new_unsubscriber:
           return GQLCircleNoticeType.CircleNewUnsubscriber
-        case DB_NOTICE_TYPE.circle_new_bundled:
-          return GQLCircleNoticeType.CircleNewBundled
+        case DB_NOTICE_TYPE.circle_new_comments:
+          return GQLCircleNoticeType.CircleNewComments
       }
     },
     target: ({ entities }) => entities.target,

--- a/src/queries/notice/index.ts
+++ b/src/queries/notice/index.ts
@@ -109,7 +109,8 @@ const notice: {
         circle_new_subscriber: NOTICE_TYPE.CircleNotice,
         circle_new_unsubscriber: NOTICE_TYPE.CircleNotice,
         circle_new_follower: NOTICE_TYPE.CircleNotice,
-        circle_new_comments: NOTICE_TYPE.CircleNotice,
+        circle_new_broadcast_comments: NOTICE_TYPE.CircleNotice,
+        circle_new_discussion_comments: NOTICE_TYPE.CircleNotice,
 
         // crypto
         crypto_wallet_airdrop: NOTICE_TYPE.CryptoNotice,
@@ -266,8 +267,10 @@ const notice: {
           return GQLCircleNoticeType.CircleNewFollower
         case DB_NOTICE_TYPE.circle_new_unsubscriber:
           return GQLCircleNoticeType.CircleNewUnsubscriber
-        case DB_NOTICE_TYPE.circle_new_comments:
-          return GQLCircleNoticeType.CircleNewComments
+        case DB_NOTICE_TYPE.circle_new_broadcast_comments:
+          return GQLCircleNoticeType.CircleNewBroadcastComments
+        case DB_NOTICE_TYPE.circle_new_discussion_comments:
+          return GQLCircleNoticeType.CircleNewDiscussionComments
       }
     },
     target: ({ entities }) => entities.target,

--- a/src/types/notice.ts
+++ b/src/types/notice.ts
@@ -300,7 +300,7 @@ export default /* GraphQL */ `
     CircleNewSubscriber
     CircleNewFollower
     CircleNewUnsubscriber
-    CircleNewBundled
+    CircleNewComments
   }
 
   #################################

--- a/src/types/notice.ts
+++ b/src/types/notice.ts
@@ -300,7 +300,8 @@ export default /* GraphQL */ `
     CircleNewSubscriber
     CircleNewFollower
     CircleNewUnsubscriber
-    CircleNewComments
+    CircleNewBroadcastComments
+    CircleNewDiscussionComments
   }
 
   #################################

--- a/src/types/notice.ts
+++ b/src/types/notice.ts
@@ -94,7 +94,7 @@ export default /* GraphQL */ `
     ArticleNewAppreciation
     RevisedArticlePublished
     RevisedArticleNotPublished
-    CircleNewArticle @deprecated(reason: "No longer in use")
+    CircleNewArticle
   }
 
   type ArticleArticleNotice implements Notice {
@@ -150,7 +150,7 @@ export default /* GraphQL */ `
     CommentMentionedYou # article comment
     ArticleNewComment
     SubscribedArticleNewComment
-    CircleNewBroadcast @deprecated(reason: "No longer in use")
+    CircleNewBroadcast
   }
 
   type CommentCommentNotice implements Notice {
@@ -285,78 +285,22 @@ export default /* GraphQL */ `
 
     target: Circle! @logCache(type: "${NODE_TYPES.Circle}")
 
-    "An optional arbitrary node, Comment for broadcast and discussion notices"
-    node: Node @logCache(type: "${NODE_TYPES.Node}")
+    "Optional discussion/broadcast comments for bundled notices"
+    comments: [Comment!] @logCache(type: "${NODE_TYPES.Comment}")
+
+    "Optional discussion/broadcast replies for bundled notices"
+    replies: [Comment!] @logCache(type: "${NODE_TYPES.Comment}")
+
+    "Optional mention comments for bundled notices"
+    mentions: [Comment!] @logCache(type: "${NODE_TYPES.Comment}")
   }
 
   enum CircleNoticeType {
     CircleInvitation
-    CircleBroadcastMentionedYou
-    CircleDiscussionMentionedYou
-
-    # for circle owner
     CircleNewSubscriber
     CircleNewFollower
     CircleNewUnsubscriber
-    CircleMemberNewBroadcastReply
-    CircleMemberNewDiscussion
-    CircleMemberNewDiscussionReply
-
-    # for circle members & followers
-    InCircleNewBroadcastReply
-    InCircleNewDiscussion
-    InCircleNewDiscussionReply
-
-  }
-
-  type CircleCommentNotice implements Notice {
-    "Unique ID of this notice."
-    id: ID!
-
-    "The value determines if the notice is unread or not."
-    unread: Boolean!
-
-    "Time of this notice was created."
-    createdAt: DateTime!
-
-    "List of notice actors."
-    actors: [User!] @logCache(type: "${NODE_TYPES.User}")
-
-    type: CircleCommentNoticeType!
-
-    target: Circle! @logCache(type: "${NODE_TYPES.Circle}")
-
-    comment: Comment! @logCache(type: "${NODE_TYPES.Comment}")
-  }
-
-  enum CircleCommentNoticeType {
-    # for circle members & followers
-    InCircleNewBroadcast
-  }
-
-  type CircleArticleNotice implements Notice {
-    "Unique ID of this notice."
-    id: ID!
-
-    "The value determines if the notice is unread or not."
-    unread: Boolean!
-
-    "Time of this notice was created."
-    createdAt: DateTime!
-
-    "List of notice actors."
-    actors: [User!] @logCache(type: "${NODE_TYPES.User}")
-
-    type: CircleArticleNoticeType!
-
-    target: Circle! @logCache(type: "${NODE_TYPES.Circle}")
-
-    article: Article! @logCache(type: "${NODE_TYPES.Article}")
-  }
-
-  enum CircleArticleNoticeType {
-    # for circle members & followers
-    InCircleNewArticle
+    CircleNewBundled
   }
 
   #################################

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -361,20 +361,15 @@ export default /* GraphQL */ `
     articleSubscribedNewComment: Boolean!
     articleCommentPinned: Boolean!
 
-    # circleNewFollower: Boolean! # deprecated
-    # circleNewDiscussion: Boolean!
-
     "for circle owners"
     circleNewSubscriber: Boolean!
     circleNewFollower: Boolean!
     circleNewUnsubscriber: Boolean!
-    circleNewDiscussion: Boolean!
-    circleMemberBroadcast: Boolean! # deprecated
+    circleMemberNewBroadcastReply: Boolean!
     circleMemberNewDiscussion: Boolean!
     circleMemberNewDiscussionReply: Boolean!
-    circleMemberNewBroadcastReply: Boolean!
 
-    "for circle members"
+    "for circle members & followers"
     inCircleNewArticle: Boolean!
     inCircleNewBroadcast: Boolean!
     inCircleNewBroadcastReply: Boolean!


### PR DESCRIPTION
* merge all comment-related notices into `CircleNewBroadcastComments` and `CircleNewDiscussionComemnts` and which is bundleable with optional `comments`, `replies` and `mentions`;
* reenable `CircleNewArticle` and `CircleNewBroadcast` since they still fit with product's need;
* temp disable email circle notices;