### PR TITLE
fix/tag-name: allow re-use old existing non-standard tag names

### DIFF
--- a/src/connectors/__test__/tagService.test.ts
+++ b/src/connectors/__test__/tagService.test.ts
@@ -21,7 +21,9 @@ test('create', async () => {
       editors: [],
       owner: '0',
     },
-    ['id', 'content']
+    {
+      columns: ['id', 'content'],
+    }
   )
   expect(tag.content).toEqual(content)
 })

--- a/src/connectors/queue/publication.ts
+++ b/src/connectors/queue/publication.ts
@@ -20,8 +20,8 @@ import {
   countWords,
   extractAssetDataFromHtml,
   fromGlobalId,
-  // normalizeTagInput,
-  stripAllPunct,
+  normalizeTagInput,
+  // stripAllPunct,
 } from 'common/utils'
 
 import { BaseQueue } from './baseQueue'
@@ -430,20 +430,25 @@ class PublicationQueue extends BaseQueue {
         ? [environment.mattyId, article.authorId]
         : [article.authorId]
 
-      tags = Array.from(new Set(tags.map(stripAllPunct).filter(Boolean)))
+      // tags = Array.from(new Set(tags.map(stripAllPunct).filter(Boolean)))
 
       // create tag records, return tag record if already exists
       const dbTags = (
         (await Promise.all(
-          tags.map((tag: string) =>
+          tags.filter(Boolean).map((content: string) =>
             this.tagService.create(
               {
-                content: tag,
+                content,
                 creator: article.authorId,
                 editors: tagEditors,
                 owner: article.authorId,
               },
-              ['id', 'content']
+              {
+                columns: ['id', 'content'],
+                skipCreate:
+                  // !content // || content.length > MAX_TAG_CONTENT_LENGTH,
+                  normalizeTagInput(content) !== content,
+              }
             )
           )
         )) as unknown as [{ id: string; content: string }]

--- a/src/connectors/tagService.ts
+++ b/src/connectors/tagService.ts
@@ -7,7 +7,7 @@ import {
   ARTICLE_STATE,
   DEFAULT_TAKE_PER_PAGE,
   // MATERIALIZED_VIEW,
-  MAX_TAG_CONTENT_LENGTH,
+  // MAX_TAG_CONTENT_LENGTH,
   // MAX_TAG_DESCRIPTION_LENGTH,
   TAG_ACTION,
   TAGS_RECOMMENDED_LIMIT,
@@ -204,8 +204,9 @@ export class TagService extends BaseService {
       })
 
   /**
-   * Create a tag, but return one if it's existing.
-   * update: this create may skip (return null) if content.length > MAX_TAG_CONTENT_LENGTH
+   * findOrCreate:
+   * find one existing tag, or create it if not existed before
+   * this create may return null if skipCreate
    */
   create = async (
     {
@@ -223,7 +224,14 @@ export class TagService extends BaseService {
       editors: string[]
       owner: string
     },
-    columns: string[] = ['*']
+    {
+      // options
+      columns = ['*'],
+      skipCreate = false,
+    }: {
+      columns?: string[]
+      skipCreate?: boolean
+    } = {}
   ) => {
     const tag = await this.baseFindOrCreate({
       where: { content },
@@ -238,7 +246,7 @@ export class TagService extends BaseService {
           )
           .merge({ deleted: false })
       },
-      skipCreate: content.length > MAX_TAG_CONTENT_LENGTH, // || (description && description.length > MAX_TAG_DESCRIPTION_LENGTH),
+      skipCreate, // : content.length > MAX_TAG_CONTENT_LENGTH, // || (description && description.length > MAX_TAG_DESCRIPTION_LENGTH),
     })
 
     // add tag into search engine

--- a/src/mutations/article/editArticle.ts
+++ b/src/mutations/article/editArticle.ts
@@ -34,9 +34,9 @@ import {
   correctHtml,
   fromGlobalId,
   measureDiffs,
-  // normalizeTagInput,
+  normalizeTagInput,
   sanitize,
-  stripAllPunct,
+  // stripAllPunct,
   stripClass,
 } from 'common/utils'
 import { revisionQueue } from 'connectors/queue'
@@ -145,7 +145,7 @@ const resolver: MutationToEditArticleResolver = async (
       ? [environment.mattyId, article.authorId]
       : [article.authorId]
 
-    tags = uniq(tags.map(stripAllPunct).filter(Boolean))
+    // tags = uniq(tags.map(stripAllPunct).filter(Boolean))
 
     if (tags.length >= MAX_TAGS_PER_ARTICLE_LIMIT) {
       throw new TooManyTagsForArticleError(
@@ -156,15 +156,20 @@ const resolver: MutationToEditArticleResolver = async (
     // create tag records
     const dbTags = (
       await Promise.all(
-        tags.map(async (tag: string) =>
+        // eslint-disable-next-line no-shadow
+        // tslint:disable-next-line
+        tags.filter(Boolean).map(async (content: string) =>
           tagService.create(
             {
-              content: tag,
+              content,
               creator: article.authorId,
               editors: tagEditors,
               owner: article.authorId,
             },
-            ['id', 'content']
+            {
+              columns: ['id', 'content'],
+              skipCreate: normalizeTagInput(content) !== content, // || content.length > MAX_TAG_CONTENT_LENGTH,
+            }
           )
         )
       )

--- a/src/mutations/draft/putDraft.ts
+++ b/src/mutations/draft/putDraft.ts
@@ -29,13 +29,13 @@ import {
   fromGlobalId,
   // normalizeTagInput,
   sanitize,
-  stripAllPunct,
+  // stripAllPunct,
 } from 'common/utils'
 import { ItemData, MutationToPutDraftResolver } from 'definitions'
 
 function sanitizeTags(tags: string[] | null | undefined) {
   if (Array.isArray(tags)) {
-    tags = Array.from(new Set(tags.map(stripAllPunct).filter(Boolean)))
+    // tags = Array.from(new Set(tags.map(stripAllPunct).filter(Boolean)))
     if (tags.length === 0) {
       return null
     }

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -320,8 +320,8 @@ export default /* GraphQL */ `
     isOfficial: Boolean
 
     "Counts of this tag."
-    numArticles: Int! @cacheControl(maxAge: ${CACHE_TTL.MEDIUM})
-    numAuthors: Int! @cacheControl(maxAge: ${CACHE_TTL.MEDIUM})
+    numArticles: Int! @objectCache(maxAge: ${CACHE_TTL.MEDIUM}) ## cache for 1 hour
+    numAuthors: Int! @objectCache(maxAge: ${CACHE_TTL.MEDIUM})  ## cache for 1 hour
     ## numArticlesR3m: Int
     ## numAuthorsR3m: Int
 


### PR DESCRIPTION
call `normalizeTagInput(content)` instead of `stripAllPunct` pre-filter'ing