### PR TITLE
fix(ipns-publishing): change to re-use previous published lastDataHash

### DIFF
--- a/src/connectors/queue/publication.ts
+++ b/src/connectors/queue/publication.ts
@@ -262,7 +262,7 @@ class PublicationQueue extends BaseQueue {
         }
         job.progress(80)
 
-        await this.articleService.publishFeedToIPNS(author)
+        await this.articleService.publishFeedToIPNS(author, dataHash)
         job.progress(85)
 
         // Step 7: add to search


### PR DESCRIPTION
only append the `latestArticleDataHash` once only, to save from timeout