### PR TITLE
feat(knex-call): normalize all querybuilder.offset calls

### DIFF
--- a/src/connectors/articleService.ts
+++ b/src/connectors/articleService.ts
@@ -518,11 +518,11 @@ export class ArticleService extends BaseService {
         // always as last orderBy
         builder.orderBy('article.id', 'desc')
 
-        if (take !== undefined && Number.isFinite(take)) {
-          builder.limit(take)
-        }
         if (skip !== undefined && Number.isFinite(skip)) {
           builder.offset(skip)
+        }
+        if (take !== undefined && Number.isFinite(take)) {
+          builder.limit(take)
         }
       })
 
@@ -562,8 +562,8 @@ export class ArticleService extends BaseService {
     id: string
     skip?: number
     take?: number
-  }) => {
-    const query = this.knex
+  }) =>
+    this.knex
       .select('article.*')
       .max('comment.id', { as: '_comment_id_' })
       .from('comment')
@@ -574,16 +574,14 @@ export class ArticleService extends BaseService {
       })
       .groupBy('article.id')
       .orderBy('_comment_id_', 'desc')
-
-    if (skip) {
-      query.offset(skip)
-    }
-    if (take || take === 0) {
-      query.limit(take)
-    }
-
-    return query
-  }
+      .modify((builder: Knex.QueryBuilder) => {
+        if (skip !== undefined && Number.isFinite(skip)) {
+          builder.offset(skip)
+        }
+        if (take !== undefined && Number.isFinite(take)) {
+          builder.limit(take)
+        }
+      })
 
   /*********************************
    *                               *
@@ -885,8 +883,8 @@ export class ArticleService extends BaseService {
     referenceId: string
     take?: number
     skip?: number
-  }) => {
-    const query = this.knex('appreciation')
+  }) =>
+    this.knex('appreciation')
       .select('reference_id', 'sender_id')
       .where({
         referenceId,
@@ -896,16 +894,14 @@ export class ArticleService extends BaseService {
       .sum('amount as amount')
       .max('created_at as created_at')
       .orderBy('created_at', 'desc')
-
-    if (skip) {
-      query.offset(skip)
-    }
-    if (take || take === 0) {
-      query.limit(take)
-    }
-
-    return query
-  }
+      .modify((builder: Knex.QueryBuilder) => {
+        if (skip !== undefined && Number.isFinite(skip)) {
+          builder.offset(skip)
+        }
+        if (take !== undefined && Number.isFinite(take)) {
+          builder.limit(take)
+        }
+      })
 
   appreciateLeftByUser = async ({
     articleId,
@@ -1026,22 +1022,20 @@ export class ArticleService extends BaseService {
     id: string
     take?: number
     skip?: number
-  }) => {
-    const query = this.knex
+  }) =>
+    this.knex
       .select()
       .from('action_article')
       .where({ targetId, action: USER_ACTION.subscribe })
       .orderBy('id', 'desc')
-
-    if (skip) {
-      query.offset(skip)
-    }
-    if (take || take === 0) {
-      query.limit(take)
-    }
-
-    return query
-  }
+      .modify((builder: Knex.QueryBuilder) => {
+        if (skip !== undefined && Number.isFinite(skip)) {
+          builder.offset(skip)
+        }
+        if (take !== undefined && Number.isFinite(take)) {
+          builder.limit(take)
+        }
+      })
 
   /*********************************
    *                               *
@@ -1198,22 +1192,20 @@ export class ArticleService extends BaseService {
     entranceId: string
     take?: number
     skip?: number
-  }) => {
-    const query = this.knex('collection')
+  }) =>
+    this.knex('collection')
       .select('article_id', 'state')
       .innerJoin('article', 'article.id', 'article_id')
       .where({ entranceId, state: ARTICLE_STATE.active })
       .orderBy('order', 'asc')
-
-    if (skip) {
-      query.offset(skip)
-    }
-    if (take || take === 0) {
-      query.limit(take)
-    }
-
-    return query
-  }
+      .modify((builder: Knex.QueryBuilder) => {
+        if (skip !== undefined && Number.isFinite(skip)) {
+          builder.offset(skip)
+        }
+        if (take !== undefined && Number.isFinite(take)) {
+          builder.limit(take)
+        }
+      })
 
   /**
    * Count an article is collected by how many active articles.
@@ -1451,7 +1443,7 @@ export class ArticleService extends BaseService {
     targetType?: TRANSACTION_TARGET_TYPE
   }) => {
     const { id: entityTypeId } = await this.baseFindEntityTypeId(targetType)
-    const query = this.knex('transaction')
+    return this.knex('transaction')
       .select('sender_id', 'target_id')
       .where({
         purpose,
@@ -1463,15 +1455,14 @@ export class ArticleService extends BaseService {
       .sum('amount as amount')
       .max('created_at as created_at')
       .orderBy('created_at', 'desc')
-
-    if (skip) {
-      query.offset(skip)
-    }
-    if (take || take === 0) {
-      query.limit(take)
-    }
-
-    return query
+      .modify((builder: Knex.QueryBuilder) => {
+        if (skip !== undefined && Number.isFinite(skip)) {
+          builder.offset(skip)
+        }
+        if (take !== undefined && Number.isFinite(take)) {
+          builder.limit(take)
+        }
+      })
   }
 
   /**
@@ -1580,10 +1571,10 @@ export class ArticleService extends BaseService {
       notIn,
     })
 
-    if (skip) {
+    if (skip !== undefined && Number.isFinite(skip)) {
       query.offset(skip)
     }
-    if (take || take === 0) {
+    if (take !== undefined && Number.isFinite(take)) {
       query.limit(take)
     }
 

--- a/src/connectors/tagService.ts
+++ b/src/connectors/tagService.ts
@@ -57,10 +57,10 @@ export class TagService extends BaseService {
       query = sortCreatedAt('desc')
     }
 
-    if (skip) {
+    if (skip !== undefined && Number.isFinite(skip)) {
       query.offset(skip)
     }
-    if (take || take === 0) {
+    if (take !== undefined && Number.isFinite(take)) {
       query.limit(take)
     }
 
@@ -178,12 +178,12 @@ export class TagService extends BaseService {
       .orderByRaw(`num_articles DESC`)
       .orderByRaw(`last_use DESC NULLS LAST`)
       .orderByRaw(`x.id DESC`)
-      .modify(function (this: Knex.QueryBuilder) {
-        if (take !== undefined) {
-          this.limit(take)
+      .modify((builder: Knex.QueryBuilder) => {
+        if (skip !== undefined && Number.isFinite(skip)) {
+          builder.offset(skip)
         }
-        if (skip !== undefined) {
-          this.offset(skip)
+        if (take !== undefined && Number.isFinite(take)) {
+          builder.limit(take)
         }
       })
 
@@ -201,12 +201,12 @@ export class TagService extends BaseService {
       .from('action_tag')
       .where({ userId, action: TAG_ACTION.pin })
       .orderBy('updated_at', 'desc') // update updated_at to re-order
-      .modify(function (this: Knex.QueryBuilder) {
-        if (take !== undefined) {
-          this.limit(take)
+      .modify((builder: Knex.QueryBuilder) => {
+        if (skip !== undefined && Number.isFinite(skip)) {
+          builder.offset(skip)
         }
-        if (skip !== undefined) {
-          this.offset(skip)
+        if (take !== undefined && Number.isFinite(take)) {
+          builder.limit(take)
         }
       })
 
@@ -350,11 +350,11 @@ export class TagService extends BaseService {
       query.whereNotIn('author_id', exclude)
     }
 
-    if (take || take === 0) {
-      query.limit(take)
-    }
-    if (skip) {
+    if (skip !== undefined && Number.isFinite(skip)) {
       query.offset(skip)
+    }
+    if (take !== undefined && Number.isFinite(take)) {
+      query.limit(take)
     }
 
     return query
@@ -640,12 +640,12 @@ export class TagService extends BaseService {
         .orderBy('num_authors', 'desc')
         .orderBy('num_articles', 'desc')
         .orderBy('created_at', 'asc')
-        .modify(function (this: Knex.QueryBuilder) {
-          if (take !== undefined) {
-            this.limit(take)
+        .modify((builder: Knex.QueryBuilder) => {
+          if (skip !== undefined && Number.isFinite(skip)) {
+            builder.offset(skip)
           }
-          if (skip !== undefined) {
-            this.offset(skip)
+          if (take !== undefined && Number.isFinite(take)) {
+            builder.limit(take)
           }
         })
 
@@ -749,12 +749,12 @@ export class TagService extends BaseService {
       .orderByRaw('num_authors DESC NULLS LAST, num_articles DESC NULLS LAST')
       .orderByRaw('span_days DESC NULLS LAST')
       .orderByRaw('created_at') // ascending from earliest to latest
-      .modify(function (this: Knex.QueryBuilder) {
-        if (take !== undefined) {
-          this.limit(take)
+      .modify((builder: Knex.QueryBuilder) => {
+        if (skip !== undefined && Number.isFinite(skip)) {
+          builder.offset(skip)
         }
-        if (skip !== undefined) {
-          this.offset(skip)
+        if (take !== undefined && Number.isFinite(take)) {
+          builder.limit(take)
         }
       })
 
@@ -768,10 +768,10 @@ export class TagService extends BaseService {
       .join('matters_choice_tag as c', 'c.tag_id', 'tag.id')
       .orderBy('chose_at', 'desc')
 
-    if (skip) {
+    if (skip !== undefined && Number.isFinite(skip)) {
       query.offset(skip)
     }
-    if (take || take === 0) {
+    if (take !== undefined && Number.isFinite(take)) {
       query.limit(take)
     }
 
@@ -991,11 +991,11 @@ export class TagService extends BaseService {
         }
         builder.orderBy('article.id', 'desc')
 
-        if (take !== undefined && Number.isFinite(take)) {
-          builder.limit(take)
-        }
         if (skip !== undefined && Number.isFinite(skip)) {
           builder.offset(skip)
+        }
+        if (take !== undefined && Number.isFinite(take)) {
+          builder.limit(take)
         }
       })
 

--- a/src/queries/article/collection.ts
+++ b/src/queries/article/collection.ts
@@ -4,7 +4,7 @@ import {
   fromConnectionArgs,
   loadManyFilterError,
 } from 'common/utils'
-import { ArticleToCollectionResolver } from 'definitions'
+import { ArticleToCollectionResolver, Item } from 'definitions'
 
 const resolver: ArticleToCollectionResolver = async (
   { articleId },
@@ -33,7 +33,7 @@ const resolver: ArticleToCollectionResolver = async (
 
   return connectionFromPromisedArray(
     articleService.draftLoader
-      .loadMany(collections.map((collection) => collection.articleId))
+      .loadMany(collections.map((collection: Item) => collection.articleId))
       .then(loadManyFilterError),
     input,
     totalCount

--- a/src/queries/article/transactionsReceivedBy.ts
+++ b/src/queries/article/transactionsReceivedBy.ts
@@ -1,5 +1,5 @@
 import { connectionFromPromisedArray, fromConnectionArgs } from 'common/utils'
-import { ArticleToTransactionsReceivedByResolver } from 'definitions'
+import { ArticleToTransactionsReceivedByResolver, Item } from 'definitions'
 
 const resolver: ArticleToTransactionsReceivedByResolver = async (
   { articleId },
@@ -18,7 +18,7 @@ const resolver: ArticleToTransactionsReceivedByResolver = async (
   ])
 
   return connectionFromPromisedArray(
-    userService.dataloader.loadMany(txs.map(({ senderId }) => senderId)),
+    userService.dataloader.loadMany(txs.map(({ senderId }: Item) => senderId)),
     input,
     totalCount
   )


### PR DESCRIPTION
there are occasoinally some warning lines:

    A valid integer must be provided to offset

add check `Number.isFinite(...)` should suffice