### PR TITLE
fix(likecoin): use `/like/info/like/amount` to get liker's balance

### DIFF
--- a/src/connectors/likecoin/index.ts
+++ b/src/connectors/likecoin/index.ts
@@ -51,7 +51,7 @@ const ENDPOINTS = {
   check: '/users/new/check',
   register: '/users/new/matters',
   edit: '/users/edit/matters',
-  total: '/like/info/like/history/total',
+  total: '/like/info/like/amount',
   like: '/like/likebutton',
   rate: '/misc/price',
   superlike: '/like/share',
@@ -322,7 +322,7 @@ export class LikeCoin {
       throw res
     }
 
-    return data.total
+    return data.cosmosLIKE || data.walletLIKE
   }
 
   rate = async (currency: 'usd' | 'twd' = 'usd') => {


### PR DESCRIPTION
Notice: The [`GET /like/info/like/amount`](https://api.docs.like.co/#28ca3081-69d6-4a8a-9815-d96717eab287) has a undocumented field `cosmosLIKE`, and it should be the correct value of liker's balance.

https://mattersnews.slack.com/archives/CC032ME07/p1665214073263229