### PR TITLE
fix `blockchain_transaction` having unexpected data

### DIFF
--- a/src/connectors/__test__/paymentService.test.ts
+++ b/src/connectors/__test__/paymentService.test.ts
@@ -82,12 +82,14 @@ describe('Transaction CRUD', () => {
     expect(blockchainTxn3.id).toEqual(blockchainTxn.id)
   })
   test('get or create Transaction by Txhash', async () => {
+    const txHash2 =
+      '0xd65dc6bf6dcc111237f9acfbfa6003ea4a4d88f2e071f4307d3af81ae876f7bf'
     const currencyUSDT = PAYMENT_CURRENCY.USDT
 
     // create
     const txn = await paymentService.findOrCreateTransactionByBlockchainTxHash({
       chain,
-      txHash,
+      txHash: txHash2,
       amount,
       fee,
       state,
@@ -100,7 +102,10 @@ describe('Transaction CRUD', () => {
       remark,
     })
     const blockchainTxn =
-      await paymentService.findOrCreateBlockchainTransaction({ chain, txHash })
+      await paymentService.findOrCreateBlockchainTransaction({
+        chain,
+        txHash: txHash2,
+      })
 
     expect(parseInt(txn.amount, 10)).toEqual(amount)
     expect(parseFloat(txn.fee)).toEqual(fee)
@@ -115,11 +120,13 @@ describe('Transaction CRUD', () => {
     expect(txn.targetType).toBeDefined()
     expect(txn.remark).toEqual(txn.remark)
 
+    expect(blockchainTxn.transactionId).toBe(txn.id)
+
     // get
     const txn2 = await paymentService.findOrCreateTransactionByBlockchainTxHash(
       {
         chain,
-        txHash,
+        txHash: txHash2,
         amount,
         fee,
         state,

--- a/src/connectors/paymentService.ts
+++ b/src/connectors/paymentService.ts
@@ -336,7 +336,7 @@ export class PaymentService extends BaseService {
           },
           trx
         )
-        this.knex('blockchain_transaction')
+        await this.knex('blockchain_transaction')
           .where({ id: blockchainTx.id })
           .update({ transactionId: tx.id })
           .transacting(trx)

--- a/src/connectors/queue/payTo/payToByBlockchain.ts
+++ b/src/connectors/queue/payTo/payToByBlockchain.ts
@@ -307,7 +307,7 @@ class PayToByBlockchainQueue extends BaseQueue {
     if (blockchainTx.transactionId) {
       tx = await this.paymentService.baseFindById(blockchainTx.transactionId)
     } else {
-      tx = await this.atomService.findUnique({
+      tx = await this.atomService.findFirst({
         table: 'transaction',
         where: {
           provider: PAYMENT_PROVIDER.blockchain as string,
@@ -358,7 +358,6 @@ class PayToByBlockchainQueue extends BaseQueue {
     } else {
       // no related tx record, create one
       const trx = await this.knex.transaction()
-      let tx
       try {
         tx = await this.paymentService.createTransaction(
           {

--- a/src/connectors/queue/payTo/payToByBlockchain.ts
+++ b/src/connectors/queue/payTo/payToByBlockchain.ts
@@ -302,11 +302,32 @@ class PayToByBlockchainQueue extends BaseQueue {
       fromTokenBaseUnit(event.amount, polygonUSDTContractDecimals)
     )
 
+    let tx
+    // find related tx
     if (blockchainTx.transactionId) {
+      tx = await this.paymentService.baseFindById(blockchainTx.transactionId)
+    } else {
+      tx = await this.atomService.findUnique({
+        table: 'transaction',
+        where: {
+          provider: PAYMENT_PROVIDER.blockchain as string,
+          providerTxId: blockchainTx.id,
+        },
+      })
+      if (tx) {
+        // this blockchainTx data is broken, fix it
+        await this.atomService.update({
+          table: 'blockchain_transaction',
+          where: { id: blockchainTx.id },
+          data: {
+            transactionId: tx.id,
+          },
+        })
+      }
+    }
+
+    if (tx) {
       // this blackchain tx record, related tx record, validate it
-      const tx = await this.paymentService.baseFindById(
-        blockchainTx.transactionId
-      )
       if (
         tx.senderId === curatorUser.id &&
         tx.recipientId === creatorUser.id &&


### PR DESCRIPTION
- fix `findOrCreateTransactionByBlockchainTxHash`  to create correct `blockchain_transaction` data
- handle wrong `blockchain_transaction` data  in  repeat job