### PR TITLE
fix(db-revert): fix last_seen to default null

### DIFF
--- a/db/migrations/20221212123646_alert_user_add_last_seen.js
+++ b/db/migrations/20221212123646_alert_user_add_last_seen.js
@@ -5,7 +5,7 @@ const column = 'last_seen'
 
 exports.up = async (knex) => {
   await knex.schema.table(table, (t) => {
-    t.timestamp(column).defaultTo(knex.fn.now())
+    t.timestamp(column) // default to NULL // .defaultTo(knex.fn.now())
   })
 }
 

--- a/src/connectors/__test__/userService.test.ts
+++ b/src/connectors/__test__/userService.test.ts
@@ -218,13 +218,14 @@ describe('updateLastSeen', () => {
       .select('last_seen')
       .where({ id })
       .first()
+    expect(last).toStrictEqual(null)
     await userService.updateLastSeen(id)
-    const { lastSeen: now } = await userService
+    const { lastSeen: last2 } = await userService
       .knex('public.user')
       .select('last_seen')
       .where({ id })
       .first()
-    expect(last).toStrictEqual(now)
+    expect(last2).not.toStrictEqual(null)
     await userService.updateLastSeen(id)
   })
   test('update beyond threshold', async () => {


### PR DESCRIPTION
within 1 migrate fault and before it reaches production, this migrate file can still be changed; replace closes #3031