### PR TITLE
ci: allow database migration  scripts to be reused by other repos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,26 +33,18 @@ jobs:
         ports:
           - 12111:12111
           - 12112:12112
+      postgres:
+        image: postgres:10-alpine
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_DB: matters-test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
 
     steps:
       - name: Checkout Repo
         uses: actions/checkout@master
-
-      - name: Spawn Postgres DB container (manually)
-        # to mount local source code into the container, can only manually spawn it
-        run: |
-          docker container run -d --name postgres-db --hostname postgres-db \
-            --network ${{ job.container.network }} --network-alias postgres -p 5432:5432 \
-            -e "POSTGRES_DB=matters-test" \
-            -e "POSTGRES_USER=postgres" \
-            -e "POSTGRES_PASSWORD=postgres" \
-            -e GITHUB_ACTIONS=true -e CI=true \
-            -v "postgres_data":"/var/lib/postgresql/data/" \
-            -v "$PWD/db":"/db" \
-            postgres:12-alpine
-          # docker start cff7d3d3876b619bc17ed89fa45b3aae388ebbffa46e4a833c3c453303a76a5f
-          docker container ls -a
-          docker container exec postgres-db sh -xc 'pwd; ls -la; find /db'
 
       - name: Setup Node.js
         uses: actions/setup-node@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
           - 12111:12111
           - 12112:12112
       postgres:
-        image: postgres:10-alpine
+        image: postgres:12-alpine
         ports:
           - 5432:5432
         env:

--- a/db/migrations/20210604103456_fix_circle_subscription_billing_cycle_anchor.js
+++ b/db/migrations/20210604103456_fix_circle_subscription_billing_cycle_anchor.js
@@ -1,4 +1,5 @@
 require('dotenv').config()
+const Stripe = require('stripe')
 
 const circleSubscription = 'circle_subscription'
 
@@ -42,21 +43,15 @@ const getUTCNextMonday = () => {
 }
 
 exports.up = async (knex) => {
-  if (!process.env['MATTERS_ENV']) {
-    console.error('`MATTERS_ENV` are required.')
-    return
-  }
   const isProd = process.env['MATTERS_ENV'] === 'production'
   const secret = process.env['MATTERS_STRIPE_SECRET']
-
-  if (isProd && !secret) {
-    console.error('`MATTERS_STRIPE_SECRET` are required.')
-    return
-  }
-
-  const Stripe = require('stripe')
   const stripeAPI = new Stripe(secret, { apiVersion: '2020-08-27' })
   const envLabel = `[${process.env['MATTERS_ENV']}]`
+
+  if (!process.env['MATTERS_ENV'] || !secret) {
+    console.error('`MATTERS_ENV` and `MATTERS_STRIPE_SECRET` are required.')
+    return
+  }
 
   // retrieve active and trialing subscriptions
   const subs = await knex

--- a/db/migrations/20210604103456_fix_circle_subscription_billing_cycle_anchor.js
+++ b/db/migrations/20210604103456_fix_circle_subscription_billing_cycle_anchor.js
@@ -1,5 +1,4 @@
 require('dotenv').config()
-const Stripe = require('stripe')
 
 const circleSubscription = 'circle_subscription'
 
@@ -43,15 +42,21 @@ const getUTCNextMonday = () => {
 }
 
 exports.up = async (knex) => {
-  const isProd = process.env['MATTERS_ENV'] === 'production'
-  const secret = process.env['MATTERS_STRIPE_SECRET']
-  const stripeAPI = new Stripe(secret, { apiVersion: '2020-08-27' })
-  const envLabel = `[${process.env['MATTERS_ENV']}]`
-
-  if (!process.env['MATTERS_ENV'] || !secret) {
-    console.error('`MATTERS_ENV` and `MATTERS_STRIPE_SECRET` are required.')
+  if (!process.env['MATTERS_ENV']) {
+    console.error('`MATTERS_ENV` are required.')
     return
   }
+  const isProd = process.env['MATTERS_ENV'] === 'production'
+  const secret = process.env['MATTERS_STRIPE_SECRET']
+
+  if (isProd && !secret) {
+    console.error('`MATTERS_STRIPE_SECRET` are required.')
+    return
+  }
+
+  const Stripe = require('stripe')
+  const stripeAPI = new Stripe(secret, { apiVersion: '2020-08-27' })
+  const envLabel = `[${process.env['MATTERS_ENV']}]`
 
   // retrieve active and trialing subscriptions
   const subs = await knex

--- a/db/testSetup.js
+++ b/db/testSetup.js
@@ -43,14 +43,16 @@ module.exports = async () => {
 
   await rollbackAllMigrations()
   await knex.migrate.latest()
+  // print migration status
+  console.log(JSON.stringify(await knex.migrate.list(), null, 4))
   await knex.seed.run()
 
-  const matty = await knex('user')
-    .select('id')
-    .where({ email: 'hi@matters.news', role: 'admin', state: 'active' })
-    .first()
-  const count = await knex('user').count().first()
-  console.log(new Date(), 'got matty?', { matty, count })
+  // const matty = await knex('user')
+  //   .select('id')
+  //   .where({ email: 'hi@matters.news', role: 'admin', state: 'active' })
+  //   .first()
+  // const count = await knex('user').count().first()
+  // console.log(new Date(), 'got matty?', { matty, count })
 
   // re-run specific migrations after seeding
   const tasks = [
@@ -65,8 +67,8 @@ module.exports = async () => {
   // connect postgres container to run PSQL scripts
   await runShellDBRollup()
 
-  //const tables = await knex('information_schema.tables').select()
-  //console.log(new Date(), `currently having ${tables.length} tables:`, tables)
+  // const tables = await knex('information_schema.tables').select()
+  // console.log(new Date(), `currently having ${tables.length} tables:`, tables)
 }
 
 async function runShellDBRollup() {

--- a/db/testSetup.js
+++ b/db/testSetup.js
@@ -43,16 +43,7 @@ module.exports = async () => {
 
   await rollbackAllMigrations()
   await knex.migrate.latest()
-  // print migration status
-  console.log(JSON.stringify(await knex.migrate.list(), null, 4))
   await knex.seed.run()
-
-  // const matty = await knex('user')
-  //   .select('id')
-  //   .where({ email: 'hi@matters.news', role: 'admin', state: 'active' })
-  //   .first()
-  // const count = await knex('user').count().first()
-  // console.log(new Date(), 'got matty?', { matty, count })
 
   // re-run specific migrations after seeding
   const tasks = [
@@ -67,8 +58,6 @@ module.exports = async () => {
   // connect postgres container to run PSQL scripts
   await runShellDBRollup()
 
-  // const tables = await knex('information_schema.tables').select()
-  // console.log(new Date(), `currently having ${tables.length} tables:`, tables)
 }
 
 async function runShellDBRollup() {

--- a/db/testSetup.js
+++ b/db/testSetup.js
@@ -57,27 +57,14 @@ module.exports = async () => {
 
   // connect postgres container to run PSQL scripts
   await runShellDBRollup()
-
 }
 
 async function runShellDBRollup() {
   const dbPath = __dirname // '{project-root}/db'
-  exec('pwd; ls -la; docker container ls -a', (error, stdout, stderr) => {
-    if (error) {
-      console.log(`error: ${error.message}`)
-      return
-    }
-    if (stderr) {
-      console.log(`stderr: ${stderr}`)
-      return
-    }
-    console.log(`stdout: ${stdout}`)
-  })
-  const dockerCmd = `docker container exec postgres-db sh -xc 'pwd; ls -la; cd ${dbPath}; env PSQL="psql -U postgres -d ${database} -w" sh -x bin/refresh-lasts.sh; date'`
-  const nativeCmd = `cd ${dbPath}; env PGPASSWORD=${password} PSQL="psql -h ${host} -U ${user} -d ${database} -w" sh -x bin/refresh-lasts.sh; date`
+  const cmd = `cd ${dbPath}; env PGPASSWORD=${password} PSQL="psql -h ${host} -U ${user} -d ${database} -w" sh -x bin/refresh-lasts.sh; date`
 
   return new Promise((fulfilled, rejected) => {
-    const sh = spawn('sh', ['-xc', dockerCmd + ' || ' + nativeCmd])
+    const sh = spawn('sh', ['-xc', cmd])
 
     sh.stdout.on('data', (data) => {
       console.log(`stdout: ${data}`)

--- a/db/testSetup.js
+++ b/db/testSetup.js
@@ -66,7 +66,7 @@ module.exports = async () => {
   await runShellDBRollup()
 
   const tables = await knex('information_schema.tables').select()
-  console.log(new Date(), `currently having ${tables.length} tables:`, tables)
+  // console.log(new Date(), `currently having ${tables.length} tables:`, tables)
 }
 
 async function runShellDBRollup() {

--- a/db/testSetup.js
+++ b/db/testSetup.js
@@ -66,7 +66,7 @@ module.exports = async () => {
   await runShellDBRollup()
 
   const tables = await knex('information_schema.tables').select()
-  // console.log(new Date(), `currently having ${tables.length} tables:`, tables)
+  console.log(new Date(), `currently having ${tables.length} tables:`, tables)
 }
 
 async function runShellDBRollup() {

--- a/db/testSetup.js
+++ b/db/testSetup.js
@@ -65,11 +65,12 @@ module.exports = async () => {
   // connect postgres container to run PSQL scripts
   await runShellDBRollup()
 
-  const tables = await knex('information_schema.tables').select()
-  // console.log(new Date(), `currently having ${tables.length} tables:`, tables)
+  //const tables = await knex('information_schema.tables').select()
+  //console.log(new Date(), `currently having ${tables.length} tables:`, tables)
 }
 
 async function runShellDBRollup() {
+  const dbPath = __dirname // '{project-root}/db'
   exec('pwd; ls -la; docker container ls -a', (error, stdout, stderr) => {
     if (error) {
       console.log(`error: ${error.message}`)
@@ -81,8 +82,8 @@ async function runShellDBRollup() {
     }
     console.log(`stdout: ${stdout}`)
   })
-  const dockerCmd = `docker container exec postgres-db sh -xc 'pwd; ls -la; cd /db; env PSQL="psql -U postgres -d ${database} -w" sh -x bin/refresh-lasts.sh; date'`
-  const nativeCmd = `cd db; env PGPASSWORD=${password} PSQL="psql -h ${host} -U ${user} -d ${database} -w" sh -x bin/refresh-lasts.sh; date`
+  const dockerCmd = `docker container exec postgres-db sh -xc 'pwd; ls -la; cd ${dbPath}; env PSQL="psql -U postgres -d ${database} -w" sh -x bin/refresh-lasts.sh; date'`
+  const nativeCmd = `cd ${dbPath}; env PGPASSWORD=${password} PSQL="psql -h ${host} -U ${user} -d ${database} -w" sh -x bin/refresh-lasts.sh; date`
 
   return new Promise((fulfilled, rejected) => {
     const sh = spawn('sh', ['-xc', dockerCmd + ' || ' + nativeCmd])

--- a/knexfile.js
+++ b/knexfile.js
@@ -11,10 +11,10 @@ const baseConfig = {
   },
   migrations: {
     tableName: 'knex_migrations',
-    directory: './db/migrations',
+    directory: __dirname + '/db/migrations',
   },
   seeds: {
-    directory: './db/seeds',
+    directory: __dirname + '/db/seeds',
   },
 }
 


### PR DESCRIPTION
- allow database migration  scripts to be reuse by other repos
- simplify github action config
- remove dead code