### PR TITLE
feat(pg-search-by-score): tag & user full text search first order by …

### DIFF
--- a/src/connectors/userService.ts
+++ b/src/connectors/userService.ts
@@ -692,9 +692,11 @@ export class UserService extends BaseService {
         builder
           .whereLike('user_name', `%${strippedName}%`)
           .orWhereLike('display_name', `%${strippedName}%`)
-          .orWhereRaw('display_name_ts @@ query')
+
         if (!quicksearch) {
-          builder.orWhereRaw('description_ts @@ query')
+          builder
+            .orWhereRaw('display_name_ts @@ query')
+            .orWhereRaw('description_ts @@ query')
         }
       })
 
@@ -849,10 +851,11 @@ export class UserService extends BaseService {
         builder
           .whereLike('user_name', `%${strippedName}%`)
           .orWhereLike('display_name', `%${strippedName}%`)
-          .orWhereRaw('display_name_jieba_ts @@ query')
 
         if (!quicksearch) {
-          builder.orWhereRaw('description_jieba_ts @@ query')
+          builder
+            .orWhereRaw('display_name_jieba_ts @@ query')
+            .orWhereRaw('description_jieba_ts @@ query')
         }
       })
 


### PR DESCRIPTION
…score

- instead of exact matches first
- article search add title_like_rank [0,1]
- quick search skip all tsvector match
- try catch wrap when es.client.search fail, call the slower tag content ilike to get some fallback