### PR TITLE
feat(pg-search-renames): columns renamed title_ts_rank & text_cd_rank

### DIFF
--- a/src/connectors/articleService.ts
+++ b/src/connectors/articleService.ts
@@ -1116,9 +1116,8 @@ export class ArticleService extends BaseService {
           )
           .as('t1')
       )
-      .where('title_rank', '>=', SEARCH_TITLE_RANK_THRESHOLD)
-      // .orWhere('summary_rank', '>=', SEARCH_DEFAULT_TEXT_RANK_THRESHOLD)
-      .orWhere('text_rank', '>=', SEARCH_DEFAULT_TEXT_RANK_THRESHOLD)
+      .where('title_ts_rank', '>=', SEARCH_TITLE_RANK_THRESHOLD)
+      .orWhere('text_cd_rank', '>=', SEARCH_DEFAULT_TEXT_RANK_THRESHOLD)
       .as('base')
 
     const articleIds = await // Promise.all([
@@ -1277,9 +1276,8 @@ export class ArticleService extends BaseService {
           )
           .as('t1')
       )
-      .where('title_rank', '>=', SEARCH_TITLE_RANK_THRESHOLD)
-      // .orWhere('summary_rank', '>=', SEARCH_DEFAULT_TEXT_RANK_THRESHOLD)
-      .orWhere('text_rank', '>=', SEARCH_DEFAULT_TEXT_RANK_THRESHOLD)
+      .where('title_ts_rank', '>=', SEARCH_TITLE_RANK_THRESHOLD)
+      .orWhere('text_cd_rank', '>=', SEARCH_DEFAULT_TEXT_RANK_THRESHOLD)
       .as('base')
 
     const articleIds = await // Promise.all([

--- a/src/connectors/tagService.ts
+++ b/src/connectors/tagService.ts
@@ -646,8 +646,10 @@ export class TagService extends BaseService {
           'num_articles',
           'num_authors',
           'created_at',
-          this.knex.raw('(content = ? DESC) AS content_equal_rank', [_key]),
-          this.knex.raw('(content ILIKE ? DESC) AS content_ilike_rank', [_key]),
+          this.knex.raw('(content = ?) AS content_equal_rank', [_key]),
+          this.knex.raw('(content ILIKE ?) AS content_ilike_rank', [
+            `%${_key}%`,
+          ]),
           this.knex.raw('COUNT(id) OVER() AS total_count')
         )
         .from(VIEW.tags_lasts_view)
@@ -659,7 +661,7 @@ export class TagService extends BaseService {
 
           if (totalCount === 0) {
             // otherwise if es client got nothing, try some slower ilike match, better than nothing
-            builder.whereILike('content', _key)
+            builder.whereILike('content', [`%${_key}%`])
           }
         })
         .andWhere((builder: Knex.QueryBuilder) => {


### PR DESCRIPTION
- tag V0 search call ES and fallback to DB ilike search