### PR TITLE
fix(wallet): sign in with Ethereum

### DIFF
--- a/src/mutations/user/generateSigningMessage.ts
+++ b/src/mutations/user/generateSigningMessage.ts
@@ -27,7 +27,7 @@ const resolver: MutationToGenerateSigningMessageResolver = async (
   const expiredAt = new Date(+createdAt + 10 * 60e3) // 10 minutes
 
   // create the message to be sign'ed
-  const signingMessage = `Matters.News wants you to sign in with your Ethereum account:
+  const signingMessage = `matters.news wants you to sign in with your Ethereum account:
 ${address}
 
 I accept the Matters.News Terms of Service: https://matters.news/tos


### PR DESCRIPTION
The latest metamask-extension [implementation](https://github.com/MetaMask/metamask-extension/pull/14438/files#diff-bc1a0ee9f48af11e3d6e254efa7d9b109b4dda9128745873d94f29d2603e98abR48) of [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361#informal-message-template) may require *case-sensitive* matching domain. It is likely an inappropriate implementation, for the fact that [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#section-6.2.2.1) requires the host to be case-insensitive.

However, it has affected all users signing with MetaMask browser extension, showing phishing alert.

I have tested with Proxyman to show this solution should eliminate false phishing alert.