### PR TITLE
feat(csrf): enable ApolloServer `csrfPrevention`

### DIFF
--- a/src/routes/graphql.ts
+++ b/src/routes/graphql.ts
@@ -154,6 +154,7 @@ const server = new ProtectedApolloServer({
     }),
   ],
   introspection: true,
+  csrfPrevention: true,
 })
 
 export const graphql = async (app: Express) => {


### PR DESCRIPTION
 We  use `graphql-upload` package to implement file-uploading, In this case apollographql advise to enable `csrfPrevention`  for safe,  see https://www.apollographql.com/docs/apollo-server/v3/data/file-uploads/