### PR TITLE
fix(editor): fix backward compatibility issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@graphql-tools/utils": "^7.10.0",
         "@matters/apollo-response-cache": "^1.4.0-rc.0",
         "@matters/ipns-site-generator": "^0.1.2",
-        "@matters/matters-editor": "^0.2.0-alpha.45",
+        "@matters/matters-editor": "^0.2.0-alpha.46",
         "@matters/passport-likecoin": "^1.0.0",
         "@matters/slugify": "^0.7.3",
         "@sendgrid/mail": "^7.7.0",
@@ -3356,9 +3356,9 @@
       }
     },
     "node_modules/@matters/matters-editor": {
-      "version": "0.2.0-alpha.45",
-      "resolved": "https://registry.npmjs.org/@matters/matters-editor/-/matters-editor-0.2.0-alpha.45.tgz",
-      "integrity": "sha512-f4wldvpEWalYW8H4ZnTyxGSOQR9SXfYkyt8eR7rEXPUHZeqMn1Y7SrQkE6lyABXfomHnl+nMKL80sKkap0Y7tA==",
+      "version": "0.2.0-alpha.46",
+      "resolved": "https://registry.npmjs.org/@matters/matters-editor/-/matters-editor-0.2.0-alpha.46.tgz",
+      "integrity": "sha512-dKlzoRxuOuK2l8Z1NtJsxbzTYSnAjbkhzu4z45qLopkbu9xyDw00QbpeHsBjyHjq+j3Y9DQ4MgQ8PJyvn7jeKQ==",
       "dependencies": {
         "@tiptap/core": "2.0.0-beta.220",
         "@tiptap/extension-blockquote": "2.0.0-beta.220",
@@ -21976,9 +21976,9 @@
       }
     },
     "@matters/matters-editor": {
-      "version": "0.2.0-alpha.45",
-      "resolved": "https://registry.npmjs.org/@matters/matters-editor/-/matters-editor-0.2.0-alpha.45.tgz",
-      "integrity": "sha512-f4wldvpEWalYW8H4ZnTyxGSOQR9SXfYkyt8eR7rEXPUHZeqMn1Y7SrQkE6lyABXfomHnl+nMKL80sKkap0Y7tA==",
+      "version": "0.2.0-alpha.46",
+      "resolved": "https://registry.npmjs.org/@matters/matters-editor/-/matters-editor-0.2.0-alpha.46.tgz",
+      "integrity": "sha512-dKlzoRxuOuK2l8Z1NtJsxbzTYSnAjbkhzu4z45qLopkbu9xyDw00QbpeHsBjyHjq+j3Y9DQ4MgQ8PJyvn7jeKQ==",
       "requires": {
         "@tiptap/core": "2.0.0-beta.220",
         "@tiptap/extension-blockquote": "2.0.0-beta.220",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@graphql-tools/utils": "^7.10.0",
     "@matters/apollo-response-cache": "^1.4.0-rc.0",
     "@matters/ipns-site-generator": "^0.1.2",
-    "@matters/matters-editor": "^0.2.0-alpha.45",
+    "@matters/matters-editor": "^0.2.0-alpha.46",
     "@matters/passport-likecoin": "^1.0.0",
     "@matters/slugify": "^0.7.3",
     "@sendgrid/mail": "^7.7.0",


### PR DESCRIPTION
The client is still using the legacy editor which cannot parse new HTML attributes and tags correctly, e.g.

For video figure,

```html
<figure class="embed-video">...</figure>

<!-- previous version will be normalized to -->
<figure class="embed">...</figure>

<!-- now -->
<figure class="embed embed-video">...</figure>
```

For code figure,

```html
<figure class="embed-code">...</figure>

<!-- previous version will be normalized to -->
<figure class="embed">...</figure>

<!-- now -->
<figure class="embed embed-code">...</figure>
```


For audio figure,

```html
<figure class="audio" data-file-name="xxxx">...</figure>

<!-- previous version will be normalized to -->
<figure class="audio">...</figure>

<!-- now -->
<figure class="audio" data-file-name="xxxx">...</figure>
```


### Ref 
* https://github.com/thematters/matters-editor/pull/425/commits/441b15be44e7510da8d01f7f36e491ec8a552c7a

