### PR TITLE
feat: disable helmet.crossOriginOpenerPolicy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matters-server",
-  "version": "4.20.1",
+  "version": "4.20.2",
   "description": "Matters Server",
   "author": "Matters <hi@matters.news>",
   "main": "build/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,12 @@ import * as routes from './routes'
     contextStorage.enterWith(context)
     next()
   })
-  app.use(helmet({ contentSecurityPolicy: false }) as RequestHandler)
+  app.use(
+    helmet({
+      contentSecurityPolicy: false,
+      crossOriginOpenerPolicy: false,
+    }) as RequestHandler
+  )
   app.use(requestIp.mw())
   app.use(cors(CORS_OPTIONS))
 


### PR DESCRIPTION
Helmet `crossOriginOpenerPolicy` was changed to enable by default at [5.0.0](https://github.com/helmetjs/helmet/blob/main/CHANGELOG.md#500---2022-01-02), which might break the LikeCoin OAuth flow