### PR TITLE
fix: likecoin upgrade broke cosmos tx endpoint

### DIFF
--- a/src/connectors/likecoin/index.ts
+++ b/src/connectors/likecoin/index.ts
@@ -83,7 +83,7 @@ const ENDPOINTS = {
   rate: '/misc/price',
   superlike: '/like/share',
   iscnPublish: '/iscn/new?claim=1',
-  cosmosTx: '/cosmos/lcd/txs',
+  cosmosTx: '/cosmos/lcd/cosmos/tx/v1beta1/txs',
 }
 
 /**
@@ -631,9 +631,13 @@ export class LikeCoin {
     if (!data) {
       throw result
     }
-    const msg = _.get(data, 'tx.value.msg')
-    const msgSend = _.find(msg, { type: 'cosmos-sdk/MsgSend' })
-    const amount = _.get(msgSend, 'value.amount[0].amount')
+    const code = _.get(data, 'tx_response.code')
+    if (code) {
+      throw code
+    }
+    const msg = _.get(data, 'tx.body.messages')
+    const msgSend = _.find(msg, { '@type': '/cosmos.bank.v1beta1.MsgSend' })
+    const amount = _.get(msgSend, 'amount[0].amount')
     return { amount }
   }
 


### PR DESCRIPTION
likecoin chain upgrade v4.0.0 uses cosmos-sdk 0.46, which removed legacy `/txs` endpoint
the new txs endpoint is at `/cosmos/tx/v1beta1/txs` with slightly different formatting
sample tx:
https://mainnet-node.like.co/cosmos/tx/v1beta1/txs/014BB68CADC5B1F129E41D8CE6D5CA96236A2F04FE1FAF92D047EAC7B5C24625