### PR TITLE
feat(cfsvc): cloudflare direct image uploading: Implementation

### DIFF
--- a/src/connectors/cloudflare/index.ts
+++ b/src/connectors/cloudflare/index.ts
@@ -148,7 +148,10 @@ export class CloudflareService {
       const resData = await res.json()
       logger.info('direct upload image: %j', resData)
       if (resData?.success) {
-        return resData.result as { id: string; uploadURL: string }
+        return {
+          key,
+          ...(resData.result as { id: string; uploadURL: string }),
+        }
       }
     } catch (err) {
       logger.error(

--- a/src/mutations/system/directImageUpload.ts
+++ b/src/mutations/system/directImageUpload.ts
@@ -64,16 +64,10 @@ const resolver: GQLMutationResolvers['directImageUpload'] = async (
   if (!key) {
     try {
       // @ts-ignore
-      ;({ uploadURL } = (await systemService.cfsvc.directUploadImage(
+      ;({ key, uploadURL } = (await systemService.cfsvc.directUploadImage(
         type,
         uuid
       ))!)
-      // uploadURL is like:
-      // https://upload.imagedelivery.net/Vi7wixxxRG2Us6Q/path/to/custom-id/2cdc28f0-xxx-87056c83901
-      // return uploadURL
-
-      // @ts-ignore
-      key = await systemService.cfsvc.baseUploadFileByUrl(type, uploadURL, uuid)
     } catch (err) {
       logger.error('cloudflare upload image ERROR:', err)
       throw err


### PR DESCRIPTION
resolves #249

Client side has 3 steps to call this API:
1. call `directImageUpload` to get an Asset with direct upload url;
2. post image as file to this direct upload url;
3. (async) post result url to directImageUpload, mark `draft` boolean to false;