### PR TITLE
feat(cfsvc): cloudflare direct image uploading: Implementation

### DIFF
--- a/src/connectors/systemService.ts
+++ b/src/connectors/systemService.ts
@@ -195,7 +195,7 @@ export class SystemService extends BaseService {
       } else {
         if (Object.keys(rest).length > 0) {
           // if rest is not empty
-          asset = this.baseUpdate(asset.id, rest, 'asset', trx)
+          this.baseUpdate(asset.id, rest, 'asset', trx)
         }
       }
 

--- a/src/mutations/system/directImageUpload.ts
+++ b/src/mutations/system/directImageUpload.ts
@@ -60,15 +60,13 @@ const resolver: GQLMutationResolvers['directImageUpload'] = async (
 
   const uuid = v4()
 
-  let uploadURL: string | undefined = undefined
+  let uploadURL: string
   if (!key) {
     try {
       // @ts-ignore
-      ;({ key, uploadURL } = (await systemService.cfsvc.directUploadImage(
-        type,
-        uuid
-      ))!)
-      logger.info('got cloudflare image uploadURL: %o', { key, uploadURL })
+      const result = await systemService.cfsvc.directUploadImage(type, uuid)!
+      logger.info('got cloudflare image uploadURL: %o', result)
+      ;({ key, uploadURL } = result)
     } catch (err) {
       logger.error('cloudflare upload image ERROR:', err)
       throw err
@@ -89,6 +87,8 @@ const resolver: GQLMutationResolvers['directImageUpload'] = async (
     entityTypeId,
     relatedEntityId
   )
+
+  logger.info('return cloudflare image uploadURL: %o', { key, uploadURL })
 
   return {
     ...newAsset,


### PR DESCRIPTION
resolves #249

Client side has 3 steps to call this API:
1. call `directImageUpload` to get an Asset with direct upload url;
2. post image as file to this direct upload url;
3. (async) post result url to directImageUpload, mark `draft` boolean to false;