### PR TITLE
feat(cfsvc): cloudflare direct image uploading: Implementation

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1920,7 +1920,7 @@ type Asset {
   """Link of this asset."""
   path: String!
   draft: Boolean
-  uploadUrl: String
+  uploadURL: String
 
   """Time of this asset was created."""
   createdAt: DateTime!

--- a/src/connectors/cloudflare/index.ts
+++ b/src/connectors/cloudflare/index.ts
@@ -148,7 +148,10 @@ export class CloudflareService {
       const resData = await res.json()
       logger.info('direct upload image: %j', resData)
       if (resData?.success) {
-        return resData.result as { id: string; uploadURL: string }
+        return {
+          key,
+          ...(resData.result as { id: string; uploadURL: string }),
+        }
       }
     } catch (err) {
       logger.error(

--- a/src/connectors/systemService.ts
+++ b/src/connectors/systemService.ts
@@ -184,6 +184,7 @@ export class SystemService extends BaseService {
         .select()
         .where({ path, type, authorId })
         .first()
+      let updatedAsset
       if (!asset) {
         ;[asset] = await trx
           .insert({
@@ -195,7 +196,7 @@ export class SystemService extends BaseService {
       } else {
         if (Object.keys(rest).length > 0) {
           // if rest is not empty
-          asset = this.baseUpdate(asset.id, rest, undefined, trx)
+          updatedAsset = this.baseUpdate(asset.id, rest, 'asset', trx)
         }
       }
 
@@ -213,7 +214,7 @@ export class SystemService extends BaseService {
         await trx.insert(assetMData).into('asset_map')
       }
 
-      return asset
+      return updatedAsset ?? asset
     })
 
   /**

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -495,7 +495,7 @@ export type GQLAsset = {
   path: Scalars['String']['output']
   /** Types of this asset. */
   type: GQLAssetType
-  uploadUrl?: Maybe<Scalars['String']['output']>
+  uploadURL?: Maybe<Scalars['String']['output']>
 }
 
 /** Enums for asset types. */
@@ -5515,7 +5515,7 @@ export type GQLAssetResolvers<
   id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
   path?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
   type?: Resolver<GQLResolversTypes['AssetType'], ParentType, ContextType>
-  uploadUrl?: Resolver<
+  uploadURL?: Resolver<
     Maybe<GQLResolversTypes['String']>,
     ParentType,
     ContextType

--- a/src/mutations/system/directImageUpload.ts
+++ b/src/mutations/system/directImageUpload.ts
@@ -64,16 +64,9 @@ const resolver: GQLMutationResolvers['directImageUpload'] = async (
   if (!key) {
     try {
       // @ts-ignore
-      ;({ uploadURL } = (await systemService.cfsvc.directUploadImage(
-        type,
-        uuid
-      ))!)
-      // uploadURL is like:
-      // https://upload.imagedelivery.net/Vi7wixxxRG2Us6Q/path/to/custom-id/2cdc28f0-xxx-87056c83901
-      // return uploadURL
-
-      // @ts-ignore
-      key = await systemService.cfsvc.baseUploadFileByUrl(type, uploadURL, uuid)
+      const result = (await systemService.cfsvc.directUploadImage(type, uuid))!
+      logger.info('got cloudflare image uploadURL: %o', result)
+      ;({ key, uploadURL } = result)
     } catch (err) {
       logger.error('cloudflare upload image ERROR:', err)
       throw err
@@ -94,6 +87,8 @@ const resolver: GQLMutationResolvers['directImageUpload'] = async (
     entityTypeId,
     relatedEntityId
   )
+
+  logger.info('return cloudflare image uploadURL: %o', { key, uploadURL })
 
   return {
     ...newAsset,

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -146,7 +146,7 @@ export default /* GraphQL */ `
     path: String!
 
     draft: Boolean
-    uploadUrl: String
+    uploadURL: String
 
     "Time of this asset was created."
     createdAt: DateTime!


### PR DESCRIPTION
resolves #249

Client side has 3 steps to call this API:
1. call `directImageUpload` to get an Asset with direct upload url;
2. post image as file to this direct upload url;
3. (async) post result url to directImageUpload, mark `draft` boolean to false;