### PR TITLE
feat(cfsvc): cloudflare direct image uploading: Implementation

### DIFF
--- a/src/connectors/systemService.ts
+++ b/src/connectors/systemService.ts
@@ -6,6 +6,7 @@ import type {
 } from 'definitions'
 
 import { Knex } from 'knex'
+// import _isEmpty from 'lodash/isEmpty'
 import { v4 } from 'uuid'
 
 import {
@@ -199,7 +200,7 @@ export class SystemService extends BaseService {
       } else {
         if (Object.keys(rest).length > 0) {
           // if rest is not empty
-          updatedAsset = this.baseUpdate(asset.id, rest, 'asset', trx)
+          updatedAsset = await this.baseUpdate(asset.id, rest, 'asset', trx)
         }
       }
 

--- a/src/mutations/system/directImageUpload.ts
+++ b/src/mutations/system/directImageUpload.ts
@@ -8,7 +8,7 @@ import { AssetNotFoundError, UserInputError } from 'common/errors'
 import { getLogger } from 'common/logger'
 import { fromGlobalId } from 'common/utils'
 
-const logger = getLogger('mutation-upload')
+const logger = getLogger('direct-image-upload')
 
 const resolver: GQLMutationResolvers['directImageUpload'] = async (
   _,
@@ -52,8 +52,6 @@ const resolver: GQLMutationResolvers['directImageUpload'] = async (
   let key: string | undefined = undefined
 
   if (url && draft != null) {
-    // if (isImageType) {
-    // call cloudflare uploadFileByUrl, handle both direct upload, & any other url upload
     // @ts-ignore
     key = await systemService.cfsvc.baseUploadFileByUrl(type, url)
 
@@ -69,9 +67,10 @@ const resolver: GQLMutationResolvers['directImageUpload'] = async (
   if (!key) {
     try {
       // @ts-ignore
-      const result = (await systemService.cfsvc.directUploadImage(type, uuid))!
-      logger.info('got cloudflare image uploadURL: %o', result)
-      ;({ key, uploadURL } = result)
+      ;({ key, uploadURL } = (await systemService.cfsvc.directUploadImage(
+        type,
+        uuid
+      ))!)
     } catch (err) {
       logger.error('cloudflare upload image ERROR:', err)
       throw err
@@ -87,13 +86,12 @@ const resolver: GQLMutationResolvers['directImageUpload'] = async (
   }
 
   const newAsset = await systemService.findAssetOrCreateByPath(
-    // createAssetAndAssetMap(
     asset,
     entityTypeId,
     relatedEntityId
   )
 
-  logger.info('return cloudflare image uploadURL: %o', { key, uploadURL })
+  // logger.info('return cloudflare image uploadURL: %o', { key, uploadURL })
 
   return {
     ...newAsset,


### PR DESCRIPTION
resolves #249

Client side has 3 steps to call this API:
1. call `directImageUpload` to get an Asset with direct upload url;
2. post image as file to this direct upload url;
3. (async) post result url to directImageUpload, mark `draft` boolean to false;