### PR TITLE
feat(cfsvc): cloudflare direct image uploading: Implementation

### DIFF
--- a/src/connectors/cloudflare/index.ts
+++ b/src/connectors/cloudflare/index.ts
@@ -20,7 +20,7 @@ export class CloudflareService {
   baseUploadFileByUrl = async (
     folder: GQLAssetType,
     url: string,
-    uuid: string
+    uuid?: string
   ): Promise<string | never> => {
     if (url.startsWith(CLOUDFLARE_IMAGE_ENDPOINT)) {
       // handle urls like: 'https://imagedelivery.net/kDRxxxm-pYA/non-prod/cover/uuid-or-path-to-image.jpeg/public' or another variant
@@ -28,33 +28,10 @@ export class CloudflareService {
       // strip /public, /1280w etc.
       const lastIdx = url.lastIndexOf('/')
 
-      // logger.info('get key id from full cloudflare image url: %o', {url, lastIdx, CLOUDFLARE_IMAGE_ENDPOINT,})
-
-      // check & confirm `draft: true` disappear
-      /* {
-  "result": {
-    "id": "non-prod/wiepefkwef-another-2.jpeg",
-    "filename": null,
-    "meta": {
-      ...
-    },
-    "uploaded": "2023-09-05T20:45:32.499Z",
-    "requireSignedURLs": false,
-    "variants": [
-      "https://imagedelivery.net/kDRxxx-pYA/non-prod/wiepefkwef-another-2.jpeg/1280w",
-      // ...
-    ],
-    "draft": true            <= draft flag will exist ephemerally till expired or confirmed
-  },
-  "success": true,
-  "errors": [],
-  "messages": []
-}
- **/
       return url.substring(CLOUDFLARE_IMAGE_ENDPOINT.length + 1, lastIdx)
     }
 
-    const key = this.genKey(folder, uuid, path.extname(url).toLowerCase())
+    const key = this.genKey(folder, uuid!, path.extname(url).toLowerCase())
 
     const formData = new FormData()
     formData.append('url', url)

--- a/src/connectors/systemService.ts
+++ b/src/connectors/systemService.ts
@@ -171,6 +171,9 @@ export class SystemService extends BaseService {
   public findAssetByUUID = async (uuid: string) =>
     this.baseFindByUUID(uuid, 'asset')
 
+  public findAssetByPath = async (path: string) =>
+    this.knex('asset').where('path', path).first()
+
   public findAssetOrCreateByPath = async (
     // path: string,
     data: ItemData,

--- a/src/mutations/system/directImageUpload.ts
+++ b/src/mutations/system/directImageUpload.ts
@@ -4,7 +4,7 @@ import type { ItemData, GQLMutationResolvers } from 'definitions'
 import { v4 } from 'uuid'
 
 import { IMAGE_ASSET_TYPE } from 'common/enums'
-import { UserInputError } from 'common/errors'
+import { AssetNotFoundError, UserInputError } from 'common/errors'
 import { getLogger } from 'common/logger'
 import { fromGlobalId } from 'common/utils'
 
@@ -55,7 +55,12 @@ const resolver: GQLMutationResolvers['directImageUpload'] = async (
     // if (isImageType) {
     // call cloudflare uploadFileByUrl, handle both direct upload, & any other url upload
     // @ts-ignore
-    key = await systemService.cfsvc.baseUploadFileByUrl(type, url, 'uuid')
+    key = await systemService.cfsvc.baseUploadFileByUrl(type, url)
+
+    const ast = await systemService.findAssetByPath(key)
+    if (!(ast?.authorId === viewer.id)) {
+      throw new AssetNotFoundError(`Asset by given path does not exists`)
+    }
   }
 
   const uuid = v4()


### PR DESCRIPTION
resolves #249

Client side has 3 steps to call this API:
1. call `directImageUpload` to get an Asset with direct upload url;
2. post image as file to this direct upload url;
3. (async) post result url to directImageUpload, mark `draft` boolean to false;