### PR TITLE
fix: dev container config file updates

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,68 +1,63 @@
 // For format details, see https://aka.ms/devcontainer.json.
-// This is a fork from https://github.com/microsoft/vscode-dev-containers/blob/v0.177.0/containers/codespaces-linux/.devcontainer/
-
+// This is a fork from https://github.com/microsoft/vscode-dev-containers/blob/v0.245.2/containers/codespaces-linux/.devcontainer/
 {
   "name": "Matters Codespaces",
-
   "build": {
     "dockerfile": "Dockerfile"
   },
-
-  "runArgs": ["--init", "--privileged"],
-  "mounts": ["source=dind-var-lib-docker,target=/var/lib/docker,type=volume"],
+  "runArgs": [
+    "--init",
+    "--privileged"
+  ],
+  "mounts": [
+    "source=dind-var-lib-docker,target=/var/lib/docker,type=volume"
+  ],
   "overrideCommand": false,
-
   // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "node",
-
-  // Use this environment variable if you need to bind mount your local source code into a new container.
-  // Set *default* container specific settings.json values on container create.
-  "settings": {
-    "terminal.integrated.shell.linux": "/bin/bash"
+  "customizations": {
+    "vscode": {
+      // Use this environment variable if you need to bind mount your local source code into a new container.
+      // Set *default* container specific settings.json values on container create.
+      "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+      },
+      // Add the IDs of extensions you want installed when the container is created.
+      "extensions": [
+        "ms-azuretools.vscode-docker",
+        "GitHub.vscode-pull-request-github",
+        // linting & formatting
+        "ms-vscode.vscode-typescript-tslint-plugin",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "stylelint.vscode-stylelint",
+        // highlighting
+        "blanu.vscode-styled-jsx",
+        "tobermory.es6-string-html",
+        "apollographql.vscode-apollo",
+        "graphql.vscode-graphql",
+        "editorconfig.editorconfig",
+        // styling
+        "coenraads.bracket-pair-colorizer",
+        "ricard.postcss",
+        "wayou.vscode-todo-highlight",
+        "mikestead.dotenv",
+        "naumovs.color-highlight",
+        "oderwat.indent-rainbow",
+        // themes
+        "github.github-vscode-theme",
+        "linusu.auto-dark-mode",
+        "qinjia.seti-icons",
+        // info
+        "wix.vscode-import-cost"
+      ]
+    }
   },
-
-  // Add the IDs of extensions you want installed when the container is created.
-  "extensions": [
-    "ms-azuretools.vscode-docker",
-    "GitHub.vscode-pull-request-github",
-
-    // linting & formatting
-    "ms-vscode.vscode-typescript-tslint-plugin",
-    "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode",
-    "stylelint.vscode-stylelint",
-
-    // highlighting
-    "blanu.vscode-styled-jsx",
-    "tobermory.es6-string-html",
-    "apollographql.vscode-apollo",
-    "graphql.vscode-graphql",
-    "editorconfig.editorconfig",
-
-    // styling
-    "coenraads.bracket-pair-colorizer",
-    "ricard.postcss",
-    "wayou.vscode-todo-highlight",
-    "mikestead.dotenv",
-    "naumovs.color-highlight",
-    "oderwat.indent-rainbow",
-
-    // themes
-    "github.github-vscode-theme",
-    "linusu.auto-dark-mode",
-    "qinjia.seti-icons",
-
-    // info
-    "wix.vscode-import-cost"
-  ],
-
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [3000, 4000, 4569, 6379],
-
   // Use 'postCreateCommand' to run commands after the container is created.
   // "oryx build" will automatically install your dependencies and attempt to build your project
   // "postCreateCommand": "oryx build -p virtualenv_name=.venv --log-file /tmp/oryx-build.log || echo 'Could not auto-build. Skipping.'",
-
   "containerEnv": {
     "EDITOR": "vim",
     "VISUAL": "vim"

--- a/.devcontainer/library-scripts/docker-in-docker-debian.sh
+++ b/.devcontainer/library-scripts/docker-in-docker-debian.sh
@@ -7,21 +7,34 @@
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker-in-docker.md
 # Maintainer: The VS Code and Codespaces Teams
 #
-# Syntax: ./docker-in-docker-debian.sh [enable non-root docker access flag] [non-root user] [use moby] [Engine/CLI Version]
+# Syntax: ./docker-in-docker-debian.sh [enable non-root docker access flag] [non-root user] [use moby] [Engine/CLI Version] [Major version for docker-compose]
 
 ENABLE_NONROOT_DOCKER=${1:-"true"}
 USERNAME=${2:-"automatic"}
 USE_MOBY=${3:-"true"}
 DOCKER_VERSION=${4:-"latest"} # The Docker/Moby Engine + CLI should match in version
+DOCKER_DASH_COMPOSE_VERSION=${5:-"v1"} # v1 or v2
 MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc"
-DOCKER_DASH_COMPOSE_VERSION="1"
+DOCKER_MOBY_ARCHIVE_VERSION_CODENAMES="buster bullseye bionic focal jammy"
+DOCKER_LICENSED_ARCHIVE_VERSION_CODENAMES="buster bullseye bionic focal hirsute impish jammy"
 
+# Default: Exit on any failure.
 set -e
 
+# Setup STDERR.
+err() {
+    echo "(!) $*" >&2
+}
+
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    err 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
+
+###################
+# Helper Functions
+# See: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/shared/utils.sh
+###################
 
 # Determine the appropriate non-root user
 if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
@@ -97,22 +110,52 @@ find_version_from_git_tags() {
             declare -g ${variable_name}="$(echo "${version_list}" | head -n 1)"
         else
             set +e
-            declare -g ${variable_name}="$(echo "${version_list}" | grep -E -m 1 "^${requested_version//./\\.}([\\.\\s]|$)")"
+                declare -g ${variable_name}="$(echo "${version_list}" | grep -E -m 1 "^${requested_version//./\\.}([\\.\\s]|$)")"
             set -e
         fi
     fi
     if [ -z "${!variable_name}" ] || ! echo "${version_list}" | grep "^${!variable_name//./\\.}$" > /dev/null 2>&1; then
-        echo -e "Invalid ${variable_name} value: ${requested_version}\nValid values:\n${version_list}" >&2
+        err "Invalid ${variable_name} value: ${requested_version}\nValid values:\n${version_list}" >&2
         exit 1
     fi
     echo "${variable_name}=${!variable_name}"
 }
 
+###########################################
+# Start docker-in-docker installation
+###########################################
+
 # Ensure apt is in non-interactive to avoid prompts
 export DEBIAN_FRONTEND=noninteractive
 
+
+# Source /etc/os-release to get OS info
+. /etc/os-release
+# Fetch host/container arch.
+architecture="$(dpkg --print-architecture)"
+
+# Check if distro is suppported
+if [ "${USE_MOBY}" = "true" ]; then
+    # 'get_common_setting' allows attribute to be updated remotely
+    get_common_setting DOCKER_MOBY_ARCHIVE_VERSION_CODENAMES
+    if [[ "${DOCKER_MOBY_ARCHIVE_VERSION_CODENAMES}" != *"${VERSION_CODENAME}"* ]]; then
+        err "Unsupported  distribution version '${VERSION_CODENAME}'. To resolve, either: (1) set feature option '\"moby\": false' , or (2) choose a compatible OS distribution"
+        err "Support distributions include:  ${DOCKER_MOBY_ARCHIVE_VERSION_CODENAMES}"
+        exit 1
+    fi
+    echo "Distro codename  '${VERSION_CODENAME}'  matched filter  '${DOCKER_MOBY_ARCHIVE_VERSION_CODENAMES}'"
+else
+    get_common_setting DOCKER_LICENSED_ARCHIVE_VERSION_CODENAMES
+    if [[ "${DOCKER_LICENSED_ARCHIVE_VERSION_CODENAMES}" != *"${VERSION_CODENAME}"* ]]; then
+        err "Unsupported distribution version '${VERSION_CODENAME}'. To resolve, please choose a compatible OS distribution"
+        err "Support distributions include:  ${DOCKER_LICENSED_ARCHIVE_VERSION_CODENAMES}"
+        exit 1
+    fi
+    echo "Distro codename  '${VERSION_CODENAME}'  matched filter  '${DOCKER_LICENSED_ARCHIVE_VERSION_CODENAMES}'"
+fi
+
 # Install dependencies
-check_packages apt-transport-https curl ca-certificates lxc pigz iptables gnupg2 dirmngr
+check_packages apt-transport-https curl ca-certificates pigz iptables gnupg2 dirmngr
 if ! type git > /dev/null 2>&1; then
     apt_get_update_if_needed
     apt-get -y install git
@@ -124,10 +167,7 @@ if type iptables-legacy > /dev/null 2>&1; then
     update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 fi
 
-# Source /etc/os-release to get OS info
-. /etc/os-release
-# Fetch host/container arch.
-architecture="$(dpkg --print-architecture)"
+
 
 # Set up the necessary apt repos (either Microsoft's or Docker's)
 if [ "${USE_MOBY}" = "true" ]; then
@@ -165,11 +205,11 @@ else
     # Regex needs to handle debian package version number format: https://www.systutorials.com/docs/linux/man/5-deb-version/
     docker_version_regex="^(.+:)?${docker_version_dot_plus_escaped}([\\.\\+ ~:-]|$)"
     set +e # Don't exit if finding version fails - will handle gracefully
-    cli_version_suffix="=$(apt-cache madison ${cli_package_name} | awk -F"|" '{print $2}' | sed -e 's/^[ \t]*//' | grep -E -m 1 "${docker_version_regex}")"
-    engine_version_suffix="=$(apt-cache madison ${engine_package_name} | awk -F"|" '{print $2}' | sed -e 's/^[ \t]*//' | grep -E -m 1 "${docker_version_regex}")"
+        cli_version_suffix="=$(apt-cache madison ${cli_package_name} | awk -F"|" '{print $2}' | sed -e 's/^[ \t]*//' | grep -E -m 1 "${docker_version_regex}")"
+        engine_version_suffix="=$(apt-cache madison ${engine_package_name} | awk -F"|" '{print $2}' | sed -e 's/^[ \t]*//' | grep -E -m 1 "${docker_version_regex}")"
     set -e
     if [ -z "${engine_version_suffix}" ] || [ "${engine_version_suffix}" = "=" ] || [ -z "${cli_version_suffix}" ] || [ "${cli_version_suffix}" = "=" ] ; then
-        echo "(!) No full or partial Docker / Moby version match found for \"${DOCKER_VERSION}\" on OS ${ID} ${VERSION_CODENAME} (${architecture}). Available versions:"
+        err "No full or partial Docker / Moby version match found for \"${DOCKER_VERSION}\" on OS ${ID} ${VERSION_CODENAME} (${architecture}). Available versions:"
         apt-cache madison ${cli_package_name} | awk -F"|" '{print $2}' | grep -oP '^(.+:)?\K.+'
         exit 1
     fi
@@ -182,10 +222,21 @@ if type docker > /dev/null 2>&1 && type dockerd > /dev/null 2>&1; then
     echo "Docker / Moby CLI and Engine already installed."
 else
     if [ "${USE_MOBY}" = "true" ]; then
-        apt-get -y install --no-install-recommends moby-cli${cli_version_suffix} moby-buildx moby-engine${engine_version_suffix}
-        apt-get -y install --no-install-recommends moby-compose || echo "(*) Package moby-compose (Docker Compose v2) not available for OS ${ID} ${VERSION_CODENAME} (${architecture}). Skipping."
+        # Install engine
+        set +e # Handle error gracefully
+            apt-get -y install --no-install-recommends moby-cli${cli_version_suffix} moby-buildx moby-engine${engine_version_suffix}
+            if [ $? -ne 0 ]; then
+                err "Packages for moby not available in OS ${ID} ${VERSION_CODENAME} (${architecture}). To resolve, either: (1) set feature option '\"moby\": false' , or (2) choose a compatible OS version (eg: 'ubuntu-20.04')."
+                exit 1
+            fi
+        set -e
+
+        # Install compose
+        apt-get -y install --no-install-recommends moby-compose || err "Package moby-compose (Docker Compose v2) not available for OS ${ID} ${VERSION_CODENAME} (${architecture}). Skipping."
     else
         apt-get -y install --no-install-recommends docker-ce-cli${cli_version_suffix} docker-ce${engine_version_suffix}
+        # Install compose
+        apt-get -y install --no-install-recommends docker-compose-plugin || echo "(*) Package docker-compose-plugin (Docker Compose v2) not available for OS ${ID} ${VERSION_CODENAME} (${architecture}). Skipping."
     fi
 fi
 
@@ -193,14 +244,14 @@ echo "Finished installing docker / moby!"
 
 # Install Docker Compose if not already installed and is on a supported architecture
 if type docker-compose > /dev/null 2>&1; then
-    echo "Docker Compose already installed."
+    echo "Docker Compose v1 already installed."
 else
     target_compose_arch="${architecture}"
     if [ "${target_compose_arch}" = "amd64" ]; then
         target_compose_arch="x86_64"
     fi
     if [ "${target_compose_arch}" != "x86_64" ]; then
-        # Use pip to get a version that runns on this architecture
+        # Use pip to get a version that runs on this architecture
         if ! dpkg -s python3-minimal python3-pip libffi-dev python3-venv > /dev/null 2>&1; then
             apt_get_update_if_needed
             apt-get -y install python3-minimal python3-pip libffi-dev python3-venv
@@ -212,18 +263,40 @@ else
         export PIP_CACHE_DIR=/tmp/pip-tmp/cache
         pipx_bin=pipx
         if ! type pipx > /dev/null 2>&1; then
-            pip3 install --disable-pip-version-check --no-warn-script-location  --no-cache-dir --user pipx
+            pip3 install --disable-pip-version-check --no-cache-dir --user pipx
             pipx_bin=/tmp/pip-tmp/bin/pipx
         fi
-        ${pipx_bin} install --system-site-packages --pip-args '--no-cache-dir --force-reinstall' docker-compose
+        ${pipx_bin} install --pip-args '--no-cache-dir --force-reinstall' docker-compose
         rm -rf /tmp/pip-tmp
     else
-        # Only supports docker-compose v1
-        find_version_from_git_tags DOCKER_DASH_COMPOSE_VERSION "https://github.com/docker/compose" "tags/"
-        echo "(*) Installing docker-compose ${DOCKER_DASH_COMPOSE_VERSION}..."
-        curl -fsSL "https://github.com/docker/compose/releases/download/${DOCKER_DASH_COMPOSE_VERSION}/docker-compose-Linux-x86_64" -o /usr/local/bin/docker-compose
+        compose_v1_version="1"
+        find_version_from_git_tags compose_v1_version "https://github.com/docker/compose" "tags/"
+        echo "(*) Installing docker-compose ${compose_v1_version}..."
+        curl -fsSL "https://github.com/docker/compose/releases/download/${compose_v1_version}/docker-compose-Linux-x86_64" -o /usr/local/bin/docker-compose
         chmod +x /usr/local/bin/docker-compose
     fi
+fi
+
+# Install docker-compose switch if not already installed - https://github.com/docker/compose-switch#manual-installation
+current_v1_compose_path="$(which docker-compose)"
+target_v1_compose_path="$(dirname "${current_v1_compose_path}")/docker-compose-v1"
+if ! type compose-switch > /dev/null 2>&1; then
+    echo "(*) Installing compose-switch..."
+    compose_switch_version="latest"
+    find_version_from_git_tags compose_switch_version "https://github.com/docker/compose-switch"
+    curl -fsSL "https://github.com/docker/compose-switch/releases/download/v${compose_switch_version}/docker-compose-linux-${architecture}" -o /usr/local/bin/compose-switch
+    chmod +x /usr/local/bin/compose-switch
+    # TODO: Verify checksum once available: https://github.com/docker/compose-switch/issues/11
+
+    # Setup v1 CLI as alternative in addition to compose-switch (which maps to v2)
+    mv "${current_v1_compose_path}" "${target_v1_compose_path}"
+    update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/compose-switch 99
+    update-alternatives --install /usr/local/bin/docker-compose docker-compose "${target_v1_compose_path}" 1
+fi
+if [ "${DOCKER_DASH_COMPOSE_VERSION}" = "v1" ]; then
+    update-alternatives --set docker-compose "${target_v1_compose_path}"
+else
+    update-alternatives --set docker-compose /usr/local/bin/compose-switch
 fi
 
 # If init file already exists, exit
@@ -244,63 +317,77 @@ fi
 
 tee /usr/local/share/docker-init.sh > /dev/null \
 << 'EOF'
-#!/usr/bin/env bash
+#!/bin/sh
 #-------------------------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
-sudoIf()
-{
-    if [ "$(id -u)" -ne 0 ]; then
-        sudo "$@"
-    else
-        "$@"
+
+set -e
+
+dockerd_start="$(cat << 'INNEREOF'
+    # explicitly remove dockerd and containerd PID file to ensure that it can start properly if it was stopped uncleanly
+    # ie: docker kill <ID>
+    find /run /var/run -iname 'docker*.pid' -delete || :
+    find /run /var/run -iname 'container*.pid' -delete || :
+
+    ## Dind wrapper script from docker team, adapted to a function
+    # Maintained: https://github.com/moby/moby/blob/master/hack/dind
+
+    export container=docker
+
+    if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security; then
+        mount -t securityfs none /sys/kernel/security || {
+            echo >&2 'Could not mount /sys/kernel/security.'
+            echo >&2 'AppArmor detection and --privileged mode might break.'
+        }
     fi
-}
-# explicitly remove dockerd and containerd PID file to ensure that it can start properly if it was stopped uncleanly
-# ie: docker kill <ID>
-sudoIf find /run /var/run -iname 'docker*.pid' -delete || :
-sudoIf find /run /var/run -iname 'container*.pid' -delete || :
-set -e
-## Dind wrapper script from docker team
-# Maintained: https://github.com/moby/moby/blob/master/hack/dind
-export container=docker
-if [ -d /sys/kernel/security ] && ! sudoIf mountpoint -q /sys/kernel/security; then
-	sudoIf mount -t securityfs none /sys/kernel/security || {
-		echo >&2 'Could not mount /sys/kernel/security.'
-		echo >&2 'AppArmor detection and --privileged mode might break.'
-	}
-fi
-# Mount /tmp (conditionally)
-if ! sudoIf mountpoint -q /tmp; then
-	sudoIf mount -t tmpfs none /tmp
-fi
-# cgroup v2: enable nesting
-if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
-	# move the init process (PID 1) from the root group to the /init group,
-	# otherwise writing subtree_control fails with EBUSY.
-	sudoIf mkdir -p /sys/fs/cgroup/init
-	sudoIf echo 1 > /sys/fs/cgroup/init/cgroup.procs
-	# enable controllers
-	sudoIf sed -e 's/ / +/g' -e 's/^/+/' < /sys/fs/cgroup/cgroup.controllers \
-		> /sys/fs/cgroup/cgroup.subtree_control
-fi
-## Dind wrapper over.
-# Handle DNS
-set +e
-cat /etc/resolv.conf | grep -i 'internal.cloudapp.net'
-if [ $? -eq 0 ]
-then
-  echo "Setting dockerd Azure DNS."
-  CUSTOMDNS="--dns 168.63.129.16"
+
+    # Mount /tmp (conditionally)
+    if ! mountpoint -q /tmp; then
+        mount -t tmpfs none /tmp
+    fi
+
+    # cgroup v2: enable nesting
+    if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+        # move the processes from the root group to the /init group,
+        # otherwise writing subtree_control fails with EBUSY.
+        # An error during moving non-existent process (i.e., "cat") is ignored.
+        mkdir -p /sys/fs/cgroup/init
+        xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs || :
+        # enable controllers
+        sed -e 's/ / +/g' -e 's/^/+/' < /sys/fs/cgroup/cgroup.controllers \
+            > /sys/fs/cgroup/cgroup.subtree_control
+    fi
+    ## Dind wrapper over.
+
+    # Handle DNS
+    set +e
+    cat /etc/resolv.conf | grep -i 'internal.cloudapp.net'
+    if [ $? -eq 0 ]
+    then
+        echo "Setting dockerd Azure DNS."
+        CUSTOMDNS="--dns 168.63.129.16"
+    else
+        echo "Not setting dockerd DNS manually."
+        CUSTOMDNS=""
+    fi
+    set -e
+
+    # Start docker/moby engine
+    ( dockerd $CUSTOMDNS > /tmp/dockerd.log 2>&1 ) &
+INNEREOF
+)"
+
+# Start using sudo if not invoked as root
+if [ "$(id -u)" -ne 0 ]; then
+    sudo /bin/sh -c "${dockerd_start}"
 else
-  echo "Not setting dockerd DNS manually."
-  CUSTOMDNS=""
+    eval "${dockerd_start}"
 fi
-set -e
-# Start docker/moby engine
-( sudoIf dockerd $CUSTOMDNS > /tmp/dockerd.log 2>&1 ) &
+
 set +e
+
 # Execute whatever commands were passed in (if any). This allows us
 # to set this script to ENTRYPOINT while still executing the default CMD.
 exec "$@"
@@ -308,3 +395,5 @@ EOF
 
 chmod +x /usr/local/share/docker-init.sh
 chown ${USERNAME}:root /usr/local/share/docker-init.sh
+
+echo 'docker-in-docker-debian script has completed!'

--- a/.devcontainer/library-scripts/node-debian.sh
+++ b/.devcontainer/library-scripts/node-debian.sh
@@ -126,6 +126,7 @@ su ${USERNAME} -c "$(cat << EOF
     umask 0002
     # Do not update profile - we'll do this manually
     export PROFILE=/dev/null
+    ls -lah /home/${USERNAME}/.nvs || :
     curl -so- https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh | bash
     source ${NVM_DIR}/nvm.sh
     if [ "${NODE_VERSION}" != "" ]; then


### PR DESCRIPTION
The devcontainer config file was a bit outdated, and a lot of configuration/scripts have changed since then. I was unable to start a new dev container in vscode, so I forked over the latest scripts and updated the configurations so that it runs with the [0.309.0](https://github.com/microsoft/vscode-remote-release/issues/9060#issuecomment-1747811300) version of the devcontainer vscode extension.

Feel free to crosscheck the config files with the latest release 0.245.2 [here](https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/codespaces-linux/.devcontainer).

no related PRs