### PR TITLE
feat(node-v20): Bump deps: Node.js 20.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,17 +39,10 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@master
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
-          node-version: '16'
-
-      - name: Cache NPM dependencies
-        uses: actions/cache@v3
-        id: node_modules_cache
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-npm-v3-${{ hashFiles('package-lock.json') }}
+          node-version: 20
+          cache: 'npm'
 
       - name: Install Dependencies
         if: steps.node_modules_cache.outputs.cache-hit != 'true'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:20
 
 # install os level packages
 RUN apt-get update && apt-get -y install curl \


### PR DESCRIPTION
call actions/setup-node@v4 with npm cache builtin, no need to call another caching layer;

resolves #3622