### PR TITLE
feat(collection-log): add audit logger for collection operations

### DIFF
--- a/src/common/enums/logging.ts
+++ b/src/common/enums/logging.ts
@@ -36,6 +36,10 @@ export const AUDIT_LOG_ACTION = {
   emailSignupOTP: 'email_signup_otp',
   walletLogin: 'wallet_login',
   walletSignup: 'wallet_signup',
+  createCollection: 'create_collection',
+  removeCollection: 'remove_collection',
+  addArticleIntoCollection: 'add_article_into_collection',
+  removeArticleFromCollection: 'remove_article_from_collection',
 } as const
 
 export const AUDIT_LOG_STATUS = {

--- a/src/mutations/collection/addCollectionsArticles.ts
+++ b/src/mutations/collection/addCollectionsArticles.ts
@@ -2,6 +2,8 @@ import type { GQLMutationResolvers } from 'definitions'
 
 import {
   ARTICLE_STATE,
+  AUDIT_LOG_ACTION,
+  AUDIT_LOG_STATUS,
   NODE_TYPES,
   MAX_ARTICLES_PER_COLLECTION_LIMIT,
 } from 'common/enums'
@@ -12,6 +14,7 @@ import {
   ArticleNotFoundError,
   ActionLimitExceededError,
 } from 'common/errors'
+import { auditLog } from 'common/logger'
 import { fromGlobalId } from 'common/utils'
 
 const resolver: GQLMutationResolvers['addCollectionsArticles'] = async (
@@ -94,6 +97,17 @@ const resolver: GQLMutationResolvers['addCollectionsArticles'] = async (
   for (const collectionId of collectionIds) {
     if (articles.length > 0) {
       await collectionService.addArticles(collectionId, articleIds)
+
+      articleIds.map((articleId) =>
+        auditLog({
+          actorId: viewer.id,
+          action: AUDIT_LOG_ACTION.addArticleIntoCollection,
+          entity: 'collection',
+          entityId: collectionId,
+          newValue: articleId,
+          status: AUDIT_LOG_STATUS.succeeded,
+        })
+      )
     }
   }
 

--- a/src/mutations/collection/deleteCollectionArticles.ts
+++ b/src/mutations/collection/deleteCollectionArticles.ts
@@ -1,11 +1,17 @@
 import type { GQLMutationResolvers } from 'definitions'
 
-import { NODE_TYPES, GRAPHQL_INPUT_LENGTH_LIMIT } from 'common/enums'
+import {
+  AUDIT_LOG_ACTION,
+  AUDIT_LOG_STATUS,
+  NODE_TYPES,
+  GRAPHQL_INPUT_LENGTH_LIMIT,
+} from 'common/enums'
 import {
   ForbiddenError,
   UserInputError,
   ActionLimitExceededError,
 } from 'common/errors'
+import { auditLog } from 'common/logger'
 import { fromGlobalId } from 'common/utils'
 
 const resolver: GQLMutationResolvers['deleteCollectionArticles'] = async (
@@ -46,6 +52,18 @@ const resolver: GQLMutationResolvers['deleteCollectionArticles'] = async (
     collectionId,
     articles.map((id) => fromGlobalId(id).id)
   )
+
+  articles.map((id) =>
+    auditLog({
+      actorId: viewer.id,
+      action: AUDIT_LOG_ACTION.removeArticleFromCollection,
+      entity: 'collection',
+      entityId: collectionId,
+      oldValue: fromGlobalId(id).id,
+      status: AUDIT_LOG_STATUS.succeeded,
+    })
+  )
+
   return collection
 }
 

--- a/src/mutations/collection/deleteCollections.ts
+++ b/src/mutations/collection/deleteCollections.ts
@@ -2,8 +2,9 @@ import type { GQLMutationResolvers } from 'definitions'
 
 import { invalidateFQC } from '@matters/apollo-response-cache'
 
-import { NODE_TYPES } from 'common/enums'
+import { AUDIT_LOG_ACTION, AUDIT_LOG_STATUS, NODE_TYPES } from 'common/enums'
 import { ForbiddenError, UserInputError } from 'common/errors'
+import { auditLog } from 'common/logger'
 import { fromGlobalId } from 'common/utils'
 
 const resolver: GQLMutationResolvers['deleteCollections'] = async (
@@ -39,6 +40,13 @@ const resolver: GQLMutationResolvers['deleteCollections'] = async (
   )
   for (const id of collectionIds) {
     invalidateFQC({ node: { type: NODE_TYPES.Collection, id }, redis })
+    auditLog({
+      actorId: viewer.id,
+      action: AUDIT_LOG_ACTION.removeCollection,
+      entity: 'collection',
+      entityId: id,
+      status: AUDIT_LOG_STATUS.succeeded,
+    })
   }
   await invalidateFQC({
     node: { type: NODE_TYPES.User, id: viewer.id },

--- a/src/mutations/collection/putCollection.ts
+++ b/src/mutations/collection/putCollection.ts
@@ -5,6 +5,8 @@ import { validate as validateUUID } from 'uuid'
 
 import {
   ASSET_TYPE,
+  AUDIT_LOG_ACTION,
+  AUDIT_LOG_STATUS,
   MAX_COLLECTION_TITLE_LENGTH,
   MAX_COLLECTION_DESCRIPTION_LENGTH,
   NODE_TYPES,
@@ -15,6 +17,7 @@ import {
   UserInputError,
   AssetNotFoundError,
 } from 'common/errors'
+import { auditLog } from 'common/logger'
 import { fromGlobalId } from 'common/utils'
 
 const resolver: GQLMutationResolvers['putCollection'] = async (
@@ -107,6 +110,13 @@ const resolver: GQLMutationResolvers['putCollection'] = async (
     await invalidateFQC({
       node: { type: NODE_TYPES.User, id: collection.authorId },
       redis,
+    })
+    auditLog({
+      actorId: viewer.id,
+      action: AUDIT_LOG_ACTION.createCollection,
+      entity: 'collection',
+      entityId: collection.id,
+      status: AUDIT_LOG_STATUS.succeeded,
     })
     return collection
   }


### PR DESCRIPTION
Add audit logger for collection operations:
- Create collection
- Remove collection
- Add articles into a collection
- Remove articles from a collection