### PR TITLE
feat(responses):  filter comments in backend

### DIFF
--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -32,6 +32,12 @@ export class UserInputError extends GraphQLError {
   }
 }
 
+export class InvalidCursorError extends GraphQLError {
+  public constructor(message: string) {
+    super(message, { extensions: { code: 'INVALID_CURSOR_ERROR' } })
+  }
+}
+
 export class ActionLimitExceededError extends GraphQLError {
   public constructor(message: string) {
     super(message, { extensions: { code: 'ACTION_LIMIT_EXCEEDED' } })

--- a/src/common/utils/connections.ts
+++ b/src/common/utils/connections.ts
@@ -38,9 +38,6 @@ export interface PageInfo {
 
 const PREFIX = 'arrayconnection'
 
-export const cursorToOffset = (cursor: ConnectionCursor | undefined): number =>
-  cursor ? parseInt(Base64.decode(cursor).split(':')[1], 10) : -1
-
 export const cursorToIndex = (cursor: ConnectionCursor | undefined): number =>
   cursor ? parseInt(Base64.decode(cursor).split(':')[1], 10) : -1
 

--- a/src/connectors/__test__/articleService.test.ts
+++ b/src/connectors/__test__/articleService.test.ts
@@ -1,16 +1,21 @@
 import type { Connections } from 'definitions'
 
-import { ArticleService, UserService } from 'connectors'
+import { v4 } from 'uuid'
+
+import { COMMENT_STATE, NODE_TYPES } from 'common/enums'
+import { ArticleService, UserService, AtomService } from 'connectors'
 
 import { genConnections, closeConnections, createArticle } from './utils'
 
 let articleId: string
 let connections: Connections
 let articleService: ArticleService
+let atomService: AtomService
 
 beforeAll(async () => {
   connections = await genConnections()
   articleService = new ArticleService(connections)
+  atomService = new AtomService(connections)
 }, 50000)
 
 afterAll(async () => {
@@ -275,9 +280,64 @@ test('latestArticles', async () => {
   expect(articles.length).toBeGreaterThan(0)
 })
 
-describe.only('findResponses', () => {
-  test('find responses', async () => {
+describe('findResponses', () => {
+  const createComment = async (
+    state?: keyof typeof COMMENT_STATE,
+    parentCommentId?: string
+  ) => {
+    return atomService.create({
+      table: 'comment',
+      data: {
+        uuid: v4(),
+        content: 'test',
+        authorId: '1',
+        targetId: '1',
+        targetTypeId: '4',
+        type: 'article',
+        parentCommentId,
+        state: state ?? COMMENT_STATE.active,
+      },
+    })
+  }
+  test('do not return archived comment not have any not-archived child comments', async () => {
+    const res1 = await articleService.findResponses({ id: '1' })
+    expect(res1.length).toBeGreaterThan(0)
+
+    // active comment will be returned
+    await createComment()
+    const res2 = await articleService.findResponses({ id: '1' })
+    expect(res2.length).toBe(res1.length + 1)
+
+    // archived comment will not be returned
+    const comment = await createComment(COMMENT_STATE.archived)
+    const res3 = await articleService.findResponses({ id: '1' })
+    expect(res3.length).toBe(res2.length)
+
+    // archived comment w/o not-archived child comments will be returned
+    await createComment(COMMENT_STATE.archived, comment.id)
+    const res4 = await articleService.findResponses({ id: '1' })
+    expect(res4.length).toBe(res3.length)
+
+    // archived comment w not-archived child comments will be returned
+    await createComment(COMMENT_STATE.active, comment.id)
+    const res5 = await articleService.findResponses({ id: '1' })
+    expect(res5.length).toBe(res4.length + 1)
+  })
+  test('count is right', async () => {
     const res = await articleService.findResponses({ id: '1' })
-    expect(res.length).toBeGreaterThan(0)
+    expect(+res[0].totalCount).toBe(res.length)
+
+    const res1 = await articleService.findResponses({ id: '1', first: 1 })
+    expect(+res1[0].totalCount).toBe(res.length)
+  })
+
+  test('cursor works', async () => {
+    const res = await articleService.findResponses({ id: '1' })
+    const res1 = await articleService.findResponses({
+      id: '1',
+      after: { type: NODE_TYPES.Comment, id: res[0].entityId },
+    })
+    expect(res1.length).toBe(res.length - 1)
+    expect(+res1[0].totalCount).toBe(res.length)
   })
 })

--- a/src/connectors/__test__/articleService.test.ts
+++ b/src/connectors/__test__/articleService.test.ts
@@ -274,3 +274,8 @@ test('latestArticles', async () => {
   })
   expect(articles.length).toBeGreaterThan(0)
 })
+
+test('findResponses', async () => {
+  const res = await articleService.findResponses({ id: '1' })
+  console.log(res)
+})

--- a/src/connectors/__test__/articleService.test.ts
+++ b/src/connectors/__test__/articleService.test.ts
@@ -299,7 +299,7 @@ describe('findResponses', () => {
       },
     })
   }
-  test('do not return archived comment not have any not-archived child comments', async () => {
+  test('do not return archived comment not having any not-archived child comments', async () => {
     const res1 = await articleService.findResponses({ id: '1' })
     expect(res1.length).toBeGreaterThan(0)
 
@@ -313,7 +313,7 @@ describe('findResponses', () => {
     const res3 = await articleService.findResponses({ id: '1' })
     expect(res3.length).toBe(res2.length)
 
-    // archived comment w/o not-archived child comments will be returned
+    // archived comment w/o not-archived child comments will not be returned
     await createComment(COMMENT_STATE.archived, comment.id)
     const res4 = await articleService.findResponses({ id: '1' })
     expect(res4.length).toBe(res3.length)

--- a/src/connectors/__test__/articleService.test.ts
+++ b/src/connectors/__test__/articleService.test.ts
@@ -275,7 +275,9 @@ test('latestArticles', async () => {
   expect(articles.length).toBeGreaterThan(0)
 })
 
-test('findResponses', async () => {
-  const res = await articleService.findResponses({ id: '1' })
-  console.log(res)
+describe.only('findResponses', () => {
+  test('find responses', async () => {
+    const res = await articleService.findResponses({ id: '1' })
+    expect(res.length).toBeGreaterThan(0)
+  })
 })

--- a/src/connectors/articleService.ts
+++ b/src/connectors/articleService.ts
@@ -31,6 +31,7 @@ import {
   MAX_PINNED_WORKS_LIMIT,
   USER_ACTION,
   USER_STATE,
+  NODE_TYPES,
 } from 'common/enums'
 import { environment } from 'common/environment'
 import {
@@ -38,6 +39,7 @@ import {
   ServerError,
   ForbiddenError,
   ActionLimitExceededError,
+  InvalidCursorError,
 } from 'common/errors'
 import { getLogger } from 'common/logger'
 import { s2tConverter, t2sConverter, normalizeSearchKey } from 'common/utils'
@@ -1305,95 +1307,10 @@ export class ArticleService extends BaseService {
    *           Response            *
    *                               *
    *********************************/
-  private makeResponseQuery = ({
-    id,
-    order,
-    state,
-    fields = '*',
-    articleOnly = false,
-  }: {
-    id: string
-    order: string
-    state?: string
-    fields?: string
-    articleOnly?: boolean
-  }) =>
-    this.knex.select(fields).from((wrapper: Knex) => {
-      wrapper
-        .select(
-          this.knex.raw('row_number() over (order by created_at) as seq, *')
-        )
-        .from((knex: Knex) => {
-          const source = knex.union((operator: any) => {
-            operator
-              .select(
-                this.knex.raw(
-                  "'Article' as type, entrance_id as entity_id, article_connection.created_at"
-                )
-              )
-              .from('article_connection')
-              .rightJoin(
-                'article',
-                'article_connection.entrance_id',
-                'article.id'
-              )
-              .where({
-                'article_connection.article_id': id,
-                'article.state': state,
-              })
-          })
-
-          if (articleOnly !== true) {
-            source.union((operator: any) => {
-              operator
-                .select(
-                  this.knex.raw(
-                    "'Comment' as type, id as entity_id, created_at"
-                  )
-                )
-                .from('comment')
-                .where({
-                  targetId: id,
-                  parentCommentId: null,
-                  type: COMMENT_TYPE.article,
-                })
-            })
-          }
-
-          source.as('base_sources')
-          return source
-        })
-        .orderBy('created_at', order)
-        .as('sources')
-    })
-
-  private makeResponseFilterQuery = ({
-    id,
-    entityId,
-    order,
-    state,
-    articleOnly,
-  }: {
-    id: string
-    entityId: string
-    order: string
-    state?: string
-    articleOnly?: boolean
-  }) => {
-    const query = this.makeResponseQuery({
-      id,
-      order,
-      state,
-      fields: 'seq',
-      articleOnly,
-    })
-    return query.where({ entityId }).first()
-  }
-
   public findResponses = ({
     id,
     order = 'desc',
-    state = ARTICLE_STATE.active,
+    articleState = ARTICLE_STATE.active,
     after,
     before,
     first,
@@ -1403,68 +1320,89 @@ export class ArticleService extends BaseService {
   }: {
     id: string
     order?: string
-    state?: string
-    after?: string
-    before?: string
+    articleState?: keyof typeof ARTICLE_STATE
+    after?: { type: NODE_TYPES; id: string }
+    before?: { type: NODE_TYPES; id: string }
     first?: number
     includeAfter?: boolean
     includeBefore?: boolean
     articleOnly?: boolean
   }) => {
-    const query = this.makeResponseQuery({ id, order, state, articleOnly })
+    const query = this.knexRO
+      .select(
+        this.knexRO.raw('COUNT(1) OVER() AS total_count'),
+        this.knexRO.raw('MIN(created_at) OVER() AS min_cursor'),
+        this.knexRO.raw('MAX(created_at) OVER() AS max_cursor'),
+        '*'
+      )
+      .from(
+        this.knexRO
+          .select(
+            this.knex.raw(
+              "'Article' as type, entrance_id as entity_id, article_connection.created_at"
+            )
+          )
+          .from('article_connection')
+          .rightJoin('article', 'article_connection.entrance_id', 'article.id')
+          .where({
+            'article_connection.article_id': id,
+            'article.state': articleState,
+          })
+          .modify((builder: Knex.QueryBuilder) => {
+            if (articleOnly !== true) {
+              builder.union(
+                this.knexRO
+                  .select(
+                    this.knex.raw(
+                      "'Comment' as type, id as entity_id, created_at"
+                    )
+                  )
+                  .from('comment')
+                  .where({
+                    targetId: id,
+                    parentCommentId: null,
+                    type: COMMENT_TYPE.article,
+                  })
+              )
+            }
+          })
+          .orderBy('created_at', order)
+          .as('t')
+      )
+
+    const validTypes = [NODE_TYPES.Comment, NODE_TYPES.Article]
     if (after) {
-      const subQuery = this.makeResponseFilterQuery({
-        id,
-        order,
-        state,
-        entityId: after,
-        articleOnly,
-      })
+      if (!validTypes.includes(after.type)) {
+        throw new InvalidCursorError('after is invalid cursor')
+      }
+      const cursor = this.knexRO(after.type.toLowerCase())
+        .select('created_at')
+        .where({ id: after.id })
+        .first()
       if (includeAfter) {
-        query.andWhere('seq', order === 'asc' ? '>=' : '<=', subQuery)
+        query.andWhere('created_at', order === 'asc' ? '>=' : '<=', cursor)
       } else {
-        query.andWhere('seq', order === 'asc' ? '>' : '<', subQuery)
+        query.andWhere('created_at', order === 'asc' ? '>' : '<', cursor)
       }
     }
     if (before) {
-      const subQuery = this.makeResponseFilterQuery({
-        id,
-        order,
-        state,
-        entityId: before,
-      })
+      if (!validTypes.includes(before.type)) {
+        throw new InvalidCursorError('before is invalid cursor')
+      }
+      const cursor = this.knexRO(before.type.toLowerCase())
+        .select('created_at')
+        .where({ id: before.id })
+        .first()
       if (includeBefore) {
-        query.andWhere('seq', order === 'asc' ? '<=' : '>=', subQuery)
+        query.andWhere('created_at', order === 'asc' ? '<=' : '>=', cursor)
       } else {
-        query.andWhere('seq', order === 'asc' ? '<' : '>', subQuery)
+        query.andWhere('created_at', order === 'asc' ? '<' : '>', cursor)
       }
     }
     if (first) {
       query.limit(first)
     }
     return query
-  }
-
-  public responseRange = async ({
-    id,
-    order,
-    state,
-  }: {
-    id: string
-    order: string
-    state: string
-  }) => {
-    const query = this.makeResponseQuery({ id, order, state, fields: '' })
-    const { count, max, min } = (await query
-      .max('seq')
-      .min('seq')
-      .count()
-      .first()) as Record<string, any>
-    return {
-      count: parseInt(count, 10),
-      max: parseInt(max, 10),
-      min: parseInt(min, 10),
-    }
   }
 
   /*********************************

--- a/src/connectors/articleService.ts
+++ b/src/connectors/articleService.ts
@@ -1336,7 +1336,7 @@ export class ArticleService extends BaseService {
       .from(
         this.knexRO
           .select(
-            this.knex.raw(
+            this.knexRO.raw(
               "'Article' as type, entrance_id as entity_id, article_connection.created_at"
             )
           )
@@ -1351,7 +1351,7 @@ export class ArticleService extends BaseService {
               builder.union(
                 this.knexRO
                   .select(
-                    this.knex.raw(
+                    this.knexRO.raw(
                       "'Comment' as type, id as entity_id, created_at"
                     )
                   )

--- a/src/connectors/articleService.ts
+++ b/src/connectors/articleService.ts
@@ -1326,7 +1326,7 @@ export class ArticleService extends BaseService {
     includeBefore?: boolean
     articleOnly?: boolean
   }) => {
-    const query = this.knexRO
+    const subQuery = this.knexRO
       .select(
         this.knexRO.raw('COUNT(1) OVER() AS total_count'),
         this.knexRO.raw('MIN(created_at) OVER() AS min_cursor'),
@@ -1383,6 +1383,8 @@ export class ArticleService extends BaseService {
           .orderBy('created_at', order)
           .as('source')
       )
+
+    const query = this.knexRO.from(subQuery.as('t1'))
 
     const validTypes = [NODE_TYPES.Comment, NODE_TYPES.Article]
     if (after) {

--- a/src/connectors/articleService.ts
+++ b/src/connectors/articleService.ts
@@ -1318,12 +1318,12 @@ export class ArticleService extends BaseService {
     fields?: string
     articleOnly?: boolean
   }) =>
-    this.knex.select(fields).from((wrapper: any) => {
+    this.knex.select(fields).from((wrapper: Knex) => {
       wrapper
         .select(
           this.knex.raw('row_number() over (order by created_at) as seq, *')
         )
-        .from((knex: any) => {
+        .from((knex: Knex) => {
           const source = knex.union((operator: any) => {
             operator
               .select(
@@ -1404,8 +1404,8 @@ export class ArticleService extends BaseService {
     id: string
     order?: string
     state?: string
-    after?: any
-    before?: any
+    after?: string
+    before?: string
     first?: number
     includeAfter?: boolean
     includeBefore?: boolean

--- a/src/definitions/index.d.ts
+++ b/src/definitions/index.d.ts
@@ -1,6 +1,5 @@
 import type { BasedContext } from '@apollo/server'
 import type {
-  Alchemy,
   ArticleService,
   AtomService,
   CommentService,
@@ -36,7 +35,6 @@ import {
   PAYMENT_PROVIDER,
   TRANSACTION_STATE,
   TRANSACTION_PURPOSE,
-  VERIFICATION_CODE_STATUS,
 } from 'common/enums'
 
 export * from './user'

--- a/src/mutations/comment/putComment.ts
+++ b/src/mutations/comment/putComment.ts
@@ -2,6 +2,8 @@ import type {
   GQLMutationResolvers,
   NoticeCircleNewBroadcastCommentsParams,
   NoticeCircleNewDiscussionCommentsParams,
+  Article,
+  Circle,
 } from 'definitions'
 
 import {
@@ -77,9 +79,9 @@ const resolver: GQLMutationResolvers['putComment'] = async (
   /**
    * check target
    */
-  let article: any
-  let circle: any
-  let targetAuthor: any
+  let article: Article | undefined
+  let circle: Circle | undefined
+  let targetAuthor: string | undefined
   if (articleId) {
     const { id: articleDbId } = fromGlobalId(articleId)
     article = await atomService.findFirst({
@@ -100,7 +102,7 @@ const resolver: GQLMutationResolvers['putComment'] = async (
     targetAuthor = article.authorId
   } else if (circleId) {
     const { id: circleDbId } = fromGlobalId(circleId)
-    circle = await atomService.circleIdLoader.load(circleDbId)
+    circle = (await atomService.circleIdLoader.load(circleDbId)) as Circle
 
     if (!circle) {
       throw new CircleNotFoundError('target circle does not exists')
@@ -508,7 +510,7 @@ const resolver: GQLMutationResolvers['putComment'] = async (
     parentComment ? { id: parentComment.id, type: NODE_TYPES.Comment } : {},
     replyToComment ? { id: replyToComment.id, type: NODE_TYPES.Comment } : {},
     {
-      id: article ? article.id : circle.id,
+      id: article ? article.id : circle?.id,
       type: article ? NODE_TYPES.Article : NODE_TYPES.Circle,
     },
   ]

--- a/src/queries/response/article/responses.ts
+++ b/src/queries/response/article/responses.ts
@@ -60,7 +60,7 @@ const resolver: GQLArticleResolvers['responses'] = async (
   )
 
   // re-process edges
-  const isDraft = (item: Draft | Comment): item is Draft => 'articleId' in item
+  const isDraft = (item: Draft | Comment): item is Draft => 'title' in item
   const edges = items.map((item) => {
     const type = isDraft(item) ? NODE_TYPES.Article : NODE_TYPES.Comment
     const id = isDraft(item) ? item.articleId : item.id

--- a/src/queries/response/article/responses.ts
+++ b/src/queries/response/article/responses.ts
@@ -60,8 +60,7 @@ const resolver: GQLArticleResolvers['responses'] = async (
   )
 
   // re-process edges
-  const isDraft = (item: Draft | Comment): item is Draft =>
-    Object.prototype.hasOwnProperty.call(item, 'articleId')
+  const isDraft = (item: Draft | Comment): item is Draft => 'articleId' in item
   const edges = items.map((item) => {
     const type = isDraft(item) ? NODE_TYPES.Article : NODE_TYPES.Comment
     const id = isDraft(item) ? item.articleId : item.id

--- a/src/queries/response/article/responses.ts
+++ b/src/queries/response/article/responses.ts
@@ -1,8 +1,9 @@
-import type { GQLArticleResolvers } from 'definitions'
+import type { GQLArticleResolvers, Draft, Comment } from 'definitions'
 
 import _last from 'lodash/last'
 
 import { NODE_TYPES } from 'common/enums'
+import { ServerError } from 'common/errors'
 import { fromGlobalId, toGlobalId } from 'common/utils'
 
 const resolver: GQLArticleResolvers['responses'] = async (
@@ -50,34 +51,41 @@ const resolver: GQLArticleResolvers['responses'] = async (
 
   // fetch responses
   const items = await Promise.all(
-    sources.map((source: { [key: string]: any }) => {
+    sources.map((source: { entityId: string; type: string }) => {
       switch (source.type) {
         case 'Article': {
-          return articleService.draftLoader.load(source.entityId)
+          return articleService.draftLoader.load(
+            source.entityId
+          ) as Promise<Draft>
         }
         case 'Comment': {
-          return commentService.baseFindById(source.entityId)
+          return commentService.loadById(source.entityId)
+        }
+        default: {
+          throw new ServerError(`Unknown response type: ${source.type}`)
         }
       }
     })
   )
 
   // re-process edges
-  const edges = items.map((item: { [key: string]: any }) => {
-    const type = item.title ? NODE_TYPES.Article : NODE_TYPES.Comment
-    const id = type === 'Article' ? item.articleId : item.id
+  const isDraft = (item: Draft | Comment): item is Draft =>
+    Object.prototype.hasOwnProperty.call(item, 'articleId')
+  const edges = items.map((item) => {
+    const type = isDraft(item) ? NODE_TYPES.Article : NODE_TYPES.Comment
+    const id = isDraft(item) ? item.articleId : item.id
 
     return {
       cursor: toGlobalId({ type, id }),
-      node: { __type: type, ...item },
-    } as any
+      node: { __type: type, ...item } as any,
+    }
   })
 
   // handle page info
-  const head = sources[0] as { [key: string]: any }
+  const head = sources[0]
   const headSeq = head && parseInt(head.seq, 10)
 
-  const tail = _last(sources) as { [key: string]: any }
+  const tail = _last(sources)
   const tailSeq = tail && parseInt(tail.seq, 10)
 
   const edgeHead = edges[0]

--- a/src/queries/response/article/responses.ts
+++ b/src/queries/response/article/responses.ts
@@ -12,7 +12,6 @@ const resolver: GQLArticleResolvers['responses'] = async (
   { dataSources: { articleService, commentService } }
 ) => {
   const order = sort === 'oldest' ? 'asc' : 'desc'
-  const articleState = 'active'
 
   // set default first as 10, and use null for querying all.
   if (!restParams.before && typeof first === 'undefined') {
@@ -33,7 +32,6 @@ const resolver: GQLArticleResolvers['responses'] = async (
   const sources = await articleService.findResponses({
     id: articleId,
     order,
-    articleState,
     after,
     before,
     first,

--- a/src/types/__test__/2/comment.test.ts
+++ b/src/types/__test__/2/comment.test.ts
@@ -273,3 +273,43 @@ describe('mutations on comment', () => {
     expect(_get(data, 'togglePinComment.pinned')).toBe(false)
   })
 })
+
+describe('query responses list on article', () => {
+  const GET_ARTILCE_RESPONSES = /* GraphQL */ `
+    query ($nodeInput: NodeInput!, $responsesInput: ResponsesInput!) {
+      node(input: $nodeInput) {
+        ... on Article {
+          id
+          responses(input: $responsesInput) {
+            edges {
+              node {
+                __typename
+                ... on Comment {
+                  id
+                  content
+                  state
+                }
+                ... on Article {
+                  id
+                  title
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `
+  test('query responses', async () => {
+    const server = await testClient({ isAuth: true, connections })
+    const { data, errors } = await server.executeOperation({
+      query: GET_ARTILCE_RESPONSES,
+      variables: {
+        nodeInput: { id: ARTICLE_ID },
+        responsesInput: {},
+      },
+    })
+    expect(data).toBeDefined()
+    expect(errors).toBeUndefined()
+  })
+})


### PR DESCRIPTION
- use `created_at` as cursor directly instead of `row_number`
- combine 2  db querying into one
- re https://github.com/thematters/matters-server/issues/3165
- refactor