### PR TITLE
feat: revise `Article.transactionsReceivedBy` to return users with anonymous

### DIFF
--- a/src/connectors/blockchain/curation.ts
+++ b/src/connectors/blockchain/curation.ts
@@ -26,6 +26,9 @@ export interface CurationTxReceipt {
   events: CurationEvent[]
   txHash: string
   reverted: boolean
+  from: Address
+  to: Address | null
+  blockNumber: number
 }
 
 // constants
@@ -168,6 +171,9 @@ export class CurationContract extends BaseContract {
     return {
       txHash,
       reverted: txReceipt.status === 'reverted',
+      from: txReceipt.from,
+      to: txReceipt.to,
+      blockNumber: Number(txReceipt.blockNumber),
       events: targets
         .map((log) =>
           decodeEventLog({

--- a/src/connectors/queue/payTo/blockchain.ts
+++ b/src/connectors/queue/payTo/blockchain.ts
@@ -143,8 +143,19 @@ export class PayToByBlockchainQueue extends BaseQueue {
     const curation = new CurationContract(chainId, contractAddress)
     const txReceipt = await curation.fetchTxReceipt(blockchainTx.txHash)
 
-    // skip if tx is not mined
-    if (!txReceipt) {
+    // update metadata blockchain tx
+    if (txReceipt) {
+      await atomService.update({
+        table: 'blockchain_transaction',
+        where: { id: blockchainTx.id },
+        data: {
+          from: txReceipt.from,
+          to: txReceipt.to,
+          blockNumber: txReceipt.blockNumber,
+        },
+      })
+    } else {
+      // skip if tx is not mined
       throw new PaymentQueueJobDataError('blockchain transaction not mined')
     }
 
@@ -203,8 +214,13 @@ export class PayToByBlockchainQueue extends BaseQueue {
     // success both tx and blockchain tx if it's valid
     await this.succeedBothTxAndBlockchainTx(txId, blockchainTx.id)
 
-    // notify sender and recipient
-    await paymentService.notifyDonation({ tx, sender, recipient, article })
+    // notify recipient and sender (if needed)
+    await paymentService.notifyDonation({
+      tx,
+      sender: isSenderMatched ? sender : undefined,
+      recipient,
+      article,
+    })
 
     await this.invalidCache(tx.targetType, tx.targetId, userService)
     job.progress(100)


### PR DESCRIPTION
* update metadata to `blockchain_transaction` on fetch tx receipt;
* skip sending mail to sender if address is not matched;