### PR TITLE
feat(node-v18): Bump deps: Node.js 18.x

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,8 @@ FROM node:18
 RUN apt-get update && apt-get -y install curl \
   postgresql-client \
   vim \
-  wget
+  wget \
+  python-is-python3
 
 # install dependencies
 WORKDIR /var/app


### PR DESCRIPTION
add python3 for building opencc; it might be builtin in `node:16` image but `node:18` image needs it explicitly

resolves #3622