### PR TITLE
fix: avoid modifing object returned by dataloader

### DIFF
--- a/src/connectors/articleService.ts
+++ b/src/connectors/articleService.ts
@@ -243,7 +243,7 @@ export class ArticleService extends BaseService<Article> {
       throw new ActionFailedError('newData is empty')
     }
     const lastData = await this.latestArticleVersionLoader.load(articleId)
-    let data = lastData as Partial<ArticleVersion>
+    let data = { ...lastData } as Partial<ArticleVersion>
     delete data.id
     delete data.description
     delete data.createdAt

--- a/src/connectors/atomService.ts
+++ b/src/connectors/atomService.ts
@@ -395,7 +395,7 @@ export class AtomService {
   /**
    * Find multiple records by given clauses.
    *
-   * A Prisma like mehtod for fetching records.
+   * A Prisma like method for fetching records.
    */
   public findMany: FindManyFn = async ({
     table,

--- a/src/mutations/article/editArticle.ts
+++ b/src/mutations/article/editArticle.ts
@@ -303,7 +303,7 @@ const resolver: GQLMutationResolvers['editArticle'] = async (
     })
   }
 
-  // fetch lastest article data
+  // fetch latest article data
   const node = await atomService.findUnique({
     table: 'article',
     where: { id: dbId },


### PR DESCRIPTION
dataloader return same objects in memory for same identifiers:

```javascript
const object =  await dataloader.load(1)   // object {id: 1,   content: 'test'}

delete object.id   // object now  {content: 'test'}

// code in other files
const object1 = await  dataloader.load(1)  // object1  {content: 'test'}


```