### PR TITLE
[hotfix-master] fix(oss): fix to throw errors when visitor querying oss info

### DIFF
--- a/src/types/__test__/2/auth.test.ts
+++ b/src/types/__test__/2/auth.test.ts
@@ -1169,3 +1169,41 @@ describe('add social accounts', () => {
     expect(data?.addSocialLogin.info.email).toBe(null)
   })
 })
+
+describe('oss', () => {
+  const GET_OSS_INFO = /* GraphQL */ `
+    query {
+      oss {
+        comments(input: { first: 10 }) {
+          totalCount
+        }
+      }
+    }
+  `
+  test('only admin can view info in oss', async () => {
+    const serverVisitor = await testClient({ connections })
+    const { errors: errorsVisitor, data: dataVisitor } =
+      await serverVisitor.executeOperation({
+        query: GET_OSS_INFO,
+      })
+    expect(errorsVisitor?.[0].extensions.code).toBe('FORBIDDEN')
+    expect(dataVisitor).toBe(null)
+    const serverUser = await testClient({ connections, isAuth: true })
+    const { errors: errorsUser, data: dataUser } =
+      await serverUser.executeOperation({
+        query: GET_OSS_INFO,
+      })
+    expect(errorsUser?.[0].extensions.code).toBe('FORBIDDEN')
+    expect(dataUser).toBe(null)
+    const serverAdmin = await testClient({
+      connections,
+      isAuth: true,
+      isAdmin: true,
+    })
+    const { errors, data } = await serverAdmin.executeOperation({
+      query: GET_OSS_INFO,
+    })
+    expect(errors).toBeUndefined()
+    expect(data).toBeDefined()
+  })
+})

--- a/src/types/directives/auth.ts
+++ b/src/types/directives/auth.ts
@@ -30,7 +30,7 @@ export const authDirective = (directiveName = 'auth') => ({
              */
             if (isQuery) {
               // "visitor" can only access anonymous' fields
-              if (!viewer.id && isSelf) {
+              if (!viewer.id && isSelf && !nodes.includes('oss')) {
                 return await resolve(root, args, context, info)
               }
 


### PR DESCRIPTION
(cherry picked from commit b8266792d9f940c0f34b26882067979942df2e5b)