### PR TITLE
fix(related-articles): fix relatedArticle resolver that return only 1 article in some case

### DIFF
--- a/src/queries/article/relatedArticles.ts
+++ b/src/queries/article/relatedArticles.ts
@@ -61,7 +61,9 @@ const resolver: GQLArticleResolvers['relatedArticles'] = async (
 
   // fall back to author
   if (articles.length < take + buffer) {
-    const articlesFromAuthor = await articleService.findByAuthor(authorId)
+    const articlesFromAuthor = await articleService.findByAuthor(authorId, {
+      columns: ['id', 'draft_id'],
+    })
     // logger.info(`[recommendation] article ${articleId}, title ${title}, author result ${articlesFromAuthor.map(({ id: aid }: { id: string }) => aid)} `)
     articles = addRec(articles, articlesFromAuthor)
   }


### PR DESCRIPTION
objects returned by `findByAuthor` should contain `id`,  as inside the helper function `addRec`,  `_.uniqBy(..., 'id')` is called, passing objects w/o `id` field will filter and return only one object, which is the cause some articles' return only 1 related article.