### PR TITLE
feat(draft): temporarily use article version as draft in article drafts API

### DIFF
--- a/src/queries/draft/article/drafts.ts
+++ b/src/queries/draft/article/drafts.ts
@@ -1,14 +1,32 @@
 import type { GQLArticleResolvers } from 'definitions'
 
 const resolver: GQLArticleResolvers['drafts'] = async (
-  { id: articleId },
+  { id: articleId, authorId },
   _,
   { dataSources: { atomService } }
-) =>
-  atomService.findMany({
-    table: 'draft',
+) => {
+  const versions = await atomService.findMany({
+    table: 'article_version',
     where: { articleId },
     orderBy: [{ column: 'created_at', order: 'desc' }],
   })
+  return versions.map(async (version) => {
+    return {
+      ...version,
+      authorId,
+      content: (
+        await atomService.articleContentIdLoader.load(version.contentId)
+      ).content,
+      publishState: 'published',
+      // unused fields in front-end
+      contentMd: '',
+      iscnPublish: false,
+      collection: null,
+      remark: null,
+      archived: false,
+      language: null,
+    }
+  })
+}
 
 export default resolver

--- a/src/queries/draft/article/newestPublishedDraft.ts
+++ b/src/queries/draft/article/newestPublishedDraft.ts
@@ -1,18 +1,29 @@
 import type { GQLArticleResolvers } from 'definitions'
 
-import { PUBLISH_STATE } from 'common/enums'
-
 const resolver: GQLArticleResolvers['newestPublishedDraft'] = async (
-  { id: articleId },
+  { id: articleId, authorId },
   _,
   { dataSources: { atomService } }
 ) => {
-  const draft = await atomService.findFirst({
-    table: 'draft',
-    where: { articleId, publishState: PUBLISH_STATE.published },
+  const version = await atomService.findFirst({
+    table: 'article_version',
+    where: { articleId },
     orderBy: [{ column: 'created_at', order: 'desc' }],
   })
-  return draft
+  return {
+    ...version,
+    authorId,
+    content: (await atomService.articleContentIdLoader.load(version.contentId))
+      .content,
+    publishState: 'published',
+    // unused fields in front-end
+    contentMd: '',
+    iscnPublish: false,
+    collection: null,
+    remark: null,
+    archived: false,
+    language: null,
+  }
 }
 
 export default resolver


### PR DESCRIPTION
matters-web 4.30.2 (prod) still relies on those APIs for article revision, but server does not create new drafts but article-versions, we temporarily fake the APIs to fix the problem