### PR TITLE
fix(like): skip calling likecoin api when sender and author is same

### DIFF
--- a/src/mutations/article/appreciateArticle.ts
+++ b/src/mutations/article/appreciateArticle.ts
@@ -105,7 +105,7 @@ const resolver: GQLMutationResolvers['appreciateArticle'] = async (
 
   // insert record to LikeCoin
   const likecoin = new LikeCoin(connections)
-  if (author.likerId && sender.likerId) {
+  if (author.likerId && sender.likerId && author.likerId !== sender.likerId) {
     likecoin.like({
       likerId: sender.likerId,
       likerIp: viewer.ip,


### PR DESCRIPTION
likecoin doesn't allow self-like