### PR TITLE
feat(donation): add `PayToInput.id` to settle draft tx

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -3573,6 +3573,7 @@ input PayToInput {
   """for ERC20/native token payment"""
   chain: Chain
   txHash: String
+  id: ID
 }
 
 input PayoutInput {

--- a/src/connectors/paymentService.ts
+++ b/src/connectors/paymentService.ts
@@ -289,6 +289,7 @@ export class PaymentService extends BaseService<Transaction> {
   public findOrCreateTransactionByBlockchainTxHash = async ({
     chainId,
     txHash,
+    txId,
 
     amount,
     fee,
@@ -306,6 +307,7 @@ export class PaymentService extends BaseService<Transaction> {
   }: {
     chainId: string
     txHash: string
+    txId?: string
 
     amount: number
     fee?: number
@@ -322,6 +324,7 @@ export class PaymentService extends BaseService<Transaction> {
     remark?: string
   }) => {
     const trx = await this.knex.transaction()
+
     try {
       const blockchainTx = await this.findOrCreateBlockchainTransaction(
         { chainId, txHash },
@@ -333,11 +336,15 @@ export class PaymentService extends BaseService<Transaction> {
       const providerTxId = blockchainTx.id
 
       let tx
-      tx = await trx
-        .select()
-        .from(this.table)
-        .where({ providerTxId, provider })
-        .first()
+      if (txId) {
+        // correct the providerTxId
+        ;[tx] = await trx
+          .where({ id: txId })
+          .update({ providerTxId })
+          .into(this.table)
+          .returning('*')
+          .transacting(trx)
+      }
 
       if (!tx) {
         tx = await this.createTransaction(
@@ -357,11 +364,13 @@ export class PaymentService extends BaseService<Transaction> {
           },
           trx
         )
-        await trx('blockchain_transaction')
-          .where({ id: blockchainTx.id })
-          .update({ transactionId: tx.id })
-          .transacting(trx)
       }
+
+      await trx('blockchain_transaction')
+        .where({ id: blockchainTx.id })
+        .update({ transactionId: tx.id })
+        .transacting(trx)
+
       await trx.commit()
       return tx
     } catch (error) {

--- a/src/connectors/paymentService.ts
+++ b/src/connectors/paymentService.ts
@@ -345,6 +345,12 @@ export class PaymentService extends BaseService<Transaction> {
           .into(this.table)
           .returning('*')
           .transacting(trx)
+      } else {
+        tx = await trx
+          .select()
+          .from(this.table)
+          .where({ providerTxId, provider })
+          .first()
       }
 
       // or create a new transaction with the blockchainTx

--- a/src/connectors/paymentService.ts
+++ b/src/connectors/paymentService.ts
@@ -336,8 +336,9 @@ export class PaymentService extends BaseService<Transaction> {
       const providerTxId = blockchainTx.id
 
       let tx
+
+      // correct an existing transaction with the blockchainTx
       if (txId) {
-        // correct the providerTxId
         ;[tx] = await trx
           .where({ id: txId })
           .update({ providerTxId })
@@ -346,6 +347,7 @@ export class PaymentService extends BaseService<Transaction> {
           .transacting(trx)
       }
 
+      // or create a new transaction with the blockchainTx
       if (!tx) {
         tx = await this.createTransaction(
           {

--- a/src/connectors/queue/payTo/blockchain.ts
+++ b/src/connectors/queue/payTo/blockchain.ts
@@ -425,7 +425,7 @@ export class PayToByBlockchainQueue {
       })
     }
 
-    // can find via `blockchainTx.id`, correct `blockchainTx.transactionId`
+    // can find via `blockchainTx.id`
     // for tx that is created by `payTo` mutation previously
     // but linked to the wrong blockchainTx
     if (!tx) {
@@ -437,6 +437,7 @@ export class PayToByBlockchainQueue {
         },
       })
 
+      // correct `blockchainTx.transactionId`
       if (tx) {
         await atomService.update({
           table: 'blockchain_transaction',
@@ -470,6 +471,22 @@ export class PayToByBlockchainQueue {
           targetId: article.id,
         },
       })
+
+      // correct `blockchainTx.transactionId` and `tx.providerId`
+      if (tx) {
+        await Promise.all([
+          atomService.update({
+            table: 'blockchain_transaction',
+            where: { id: blockchainTx.id },
+            data: { transactionId: tx.id },
+          }),
+          atomService.update({
+            table: 'transaction',
+            where: { id: tx.id },
+            data: { providerTxId: blockchainTx.id },
+          }),
+        ])
+      }
     }
 
     if (tx) {

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -2641,6 +2641,7 @@ export type GQLPayToInput = {
   /** for ERC20/native token payment */
   chain?: InputMaybe<GQLChain>
   currency: GQLTransactionCurrency
+  id?: InputMaybe<Scalars['ID']['input']>
   /** for HKD payment */
   password?: InputMaybe<Scalars['String']['input']>
   purpose: GQLTransactionPurpose

--- a/src/types/__test__/2/payment.test.ts
+++ b/src/types/__test__/2/payment.test.ts
@@ -177,8 +177,7 @@ describe('donation', () => {
     })
     expect(transaction.amount).toBe(amount)
     expect(transaction.state).toBe('pending')
-    expect(transaction.blockchainTx.chain).toBe(chain)
-    expect(transaction.blockchainTx.txHash).toBe(txHash)
+    expect(transaction.blockchainTx).toBe(null)
   })
   test('can call USDT payTo', async () => {
     const server = await testClient({

--- a/src/types/__test__/2/payment.test.ts
+++ b/src/types/__test__/2/payment.test.ts
@@ -110,28 +110,6 @@ describe('donation', () => {
       '`chain` is required if `currency` is `USDT`'
     )
   })
-  test('cannot call USDT payTo without `txHash`', async () => {
-    const server = await testClient({
-      isAuth: true,
-      connections,
-    })
-    const { errors } = await server.executeOperation({
-      query: PAYTO_USDT,
-      variables: {
-        input: {
-          amount,
-          currency,
-          purpose,
-          recipientId,
-          targetId,
-          chain,
-        },
-      },
-    })
-    expect(errors[0]?.message).toBe(
-      '`txHash` is required if `currency` is `USDT`'
-    )
-  })
   test('cannot call USDT payTo with bad `txHash`', async () => {
     const server = await testClient({
       isAuth: true,
@@ -174,6 +152,33 @@ describe('donation', () => {
       },
     })
     expect(errors[0]?.message).toBe('banned user has no permission')
+  })
+  test('can call USDT payTo without `txHash`', async () => {
+    const server = await testClient({
+      isAuth: true,
+      connections,
+    })
+    const {
+      data: {
+        payTo: { transaction },
+      },
+    } = await server.executeOperation({
+      query: PAYTO_USDT,
+      variables: {
+        input: {
+          amount,
+          currency,
+          purpose,
+          recipientId,
+          targetId,
+          chain,
+        },
+      },
+    })
+    expect(transaction.amount).toBe(amount)
+    expect(transaction.state).toBe('pending')
+    expect(transaction.blockchainTx.chain).toBe(chain)
+    expect(transaction.blockchainTx.txHash).toBe(txHash)
   })
   test('can call USDT payTo', async () => {
     const server = await testClient({

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -185,7 +185,8 @@ export default /* GraphQL */ `
 
     "for ERC20/native token payment"
     chain: Chain
-    txHash: String
+    txHash: String # draft tx if not provided or settle tx if provided
+    id: ID # settle tx if provided
   }
 
   input PayoutInput {


### PR DESCRIPTION
* Revise `payTo` mutation and add `id` field to input;
    1. User can call `payTo` with `txHash` as before to settle the tx;
    2. Or user can make a draft (pending) tx w/o `txHash` first, then settle the tx later with transaction `id` and `txHash`;
* Revise `PayToByBlockchainQueue#_handleNewEvent` and support to correct tx that haven't been settled (as `#2` scenario);

resolve https://github.com/thematters/matters-server/issues/3859

