### PR TITLE
build(npm): drop legacy peer deps

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-legacy-peer-deps=true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get -y install curl \
 # install dependencies
 WORKDIR /var/app
 COPY package*.json ./
-RUN npm install --force
+RUN npm install
 
 ENV NODE_OPTIONS="--no-experimental-fetch"
 CMD ["npm", "run", "start"]


### PR DESCRIPTION
Removing the flag doesn't cause any peer dependency issues, so it's safe to drop it now.