### PR TITLE
feat(campaign): add description field to writing challenge input and …

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -35,7 +35,7 @@ export default {
     ...baseConfig,
     // set pool size to 1 to detect db connection acquiring deadlock
     // explained in https://github.com/Vincit/objection.js/issues/1137#issuecomment-561149456
-    pool: { min: 1, max: 1},
+    pool: { min: 1, max: 1 },
     acquireConnectionTimeout: 60000 * 2,
   },
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -806,6 +806,7 @@ input PutWritingChallengeInput {
   id: ID
   name: [TranslationInput!]
   cover: ID
+  description: [TranslationInput!]
   link: String
   announcements: [ID!]
   applicationPeriod: DatetimeRangeInput

--- a/src/connectors/campaignService.ts
+++ b/src/connectors/campaignService.ts
@@ -54,6 +54,7 @@ export class CampaignService {
 
   public createWritingChallenge = async ({
     name,
+    description,
     coverId,
     link,
     applicationPeriod,
@@ -64,6 +65,7 @@ export class CampaignService {
     featuredDescription,
   }: {
     name: string
+    description?: string
     coverId?: string
     link?: string
     applicationPeriod?: readonly [Date, Date]
@@ -79,6 +81,7 @@ export class CampaignService {
         shortHash: shortHash(),
         type: CAMPAIGN_TYPE.writingChallenge,
         name,
+        description,
         link,
         cover: coverId,
         applicationPeriod: applicationPeriod

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -2992,6 +2992,7 @@ export type GQLPutWritingChallengeInput = {
   applicationPeriod?: InputMaybe<GQLDatetimeRangeInput>
   channelEnabled?: InputMaybe<Scalars['Boolean']['input']>
   cover?: InputMaybe<Scalars['ID']['input']>
+  description?: InputMaybe<Array<GQLTranslationInput>>
   featuredDescription?: InputMaybe<Array<GQLTranslationInput>>
   id?: InputMaybe<Scalars['ID']['input']>
   link?: InputMaybe<Scalars['String']['input']>

--- a/src/mutations/campaign/putWritingChallenge.ts
+++ b/src/mutations/campaign/putWritingChallenge.ts
@@ -26,6 +26,7 @@ const resolver: GQLMutationResolvers['putWritingChallenge'] = async (
       id: globalId,
       name,
       cover,
+      description,
       link,
       announcements: announcementGlobalIds,
       applicationPeriod,
@@ -106,6 +107,7 @@ const resolver: GQLMutationResolvers['putWritingChallenge'] = async (
     // create new campaign
     campaign = await campaignService.createWritingChallenge({
       name: name ? name[0].text : '',
+      description: description ? description[0].text : '',
       coverId: _cover?.id,
       link,
       applicationPeriod: applicationPeriod && [
@@ -209,6 +211,18 @@ const resolver: GQLMutationResolvers['putWritingChallenge'] = async (
       await translationService.updateOrCreateTranslation({
         table: 'campaign',
         field: 'name',
+        id: campaign.id,
+        language: trans.language,
+        text: trans.text,
+      })
+    }
+  }
+
+  if (description) {
+    for (const trans of description) {
+      await translationService.updateOrCreateTranslation({
+        table: 'campaign',
+        field: 'description',
         id: campaign.id,
         language: trans.language,
         text: trans.text,

--- a/src/types/__test__/2/campaign/putWritingChallenge.test.ts
+++ b/src/types/__test__/2/campaign/putWritingChallenge.test.ts
@@ -90,6 +90,18 @@ describe('create or update writing challenges', () => {
     { text: 'test featured description ' + LANGUAGE.en, language: LANGUAGE.en },
   ]
 
+  const translationsDescription = [
+    {
+      text: 'test description ' + LANGUAGE.zh_hant,
+      language: LANGUAGE.zh_hant,
+    },
+    {
+      text: 'test description ' + LANGUAGE.zh_hans,
+      language: LANGUAGE.zh_hans,
+    },
+    { text: 'test description ' + LANGUAGE.en, language: LANGUAGE.en },
+  ]
+
   const translationsStageName1 = [
     {
       text: 'test stage 1 ' + LANGUAGE.zh_hant,
@@ -213,6 +225,7 @@ describe('create or update writing challenges', () => {
         input: {
           name,
           cover,
+          description: translationsDescription,
           announcements: [announcementGlobalId],
           writingPeriod,
           stages,
@@ -225,6 +238,7 @@ describe('create or update writing challenges', () => {
     expect(data.putWritingChallenge.announcements[0].id).toBe(
       announcementGlobalId
     )
+    expect(data.putWritingChallenge.description).toContain('test description')
     expect(data.putWritingChallenge.featuredDescription).toContain(
       'test featured description'
     )
@@ -288,6 +302,7 @@ describe('create or update writing challenges', () => {
         input: {
           name,
           cover,
+          description: translationsDescription,
           applicationPeriod,
           writingPeriod,
           stages,
@@ -298,6 +313,10 @@ describe('create or update writing challenges', () => {
     // update campaign
     const newName = Object.keys(LANGUAGE).map((lang) => ({
       text: 'updated ' + lang,
+      language: lang,
+    }))
+    const newDescription = Object.keys(LANGUAGE).map((lang) => ({
+      text: 'updated description ' + lang,
       language: lang,
     }))
     const newStages = [
@@ -315,6 +334,7 @@ describe('create or update writing challenges', () => {
         input: {
           id: data.putWritingChallenge.id,
           name: newName,
+          description: newDescription,
           stages: newStages,
           state: CAMPAIGN_STATE.active,
         },
@@ -322,6 +342,9 @@ describe('create or update writing challenges', () => {
     })
     expect(errors).toBeUndefined()
     expect(updatedData.putWritingChallenge.name).toContain('updated')
+    expect(updatedData.putWritingChallenge.description).toContain(
+      'updated description'
+    )
     expect(updatedData.putWritingChallenge.stages[0].name).toContain('updated')
     expect(updatedData.putWritingChallenge.state).toBe(CAMPAIGN_STATE.active)
 

--- a/src/types/campaign.ts
+++ b/src/types/campaign.ts
@@ -30,6 +30,7 @@ export default /* GraphQL */ `
     id: ID
     name: [TranslationInput!]
     cover: ID
+    description: [TranslationInput!]
     link: String
     announcements: [ID!]
     applicationPeriod: DatetimeRangeInput


### PR DESCRIPTION
…update related logic

- Introduced a new `description` field in the `PutWritingChallengeInput` and corresponding GraphQL schema.
- Updated the `createWritingChallenge` method in `CampaignService` to handle the new description input.
- Enhanced the `putWritingChallenge` mutation resolver to process and store the description translations.
- Added tests to validate the inclusion and functionality of the description field in writing challenges.