### PR TITLE
feat(campaign): add `isManager` field 

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -893,6 +893,7 @@ type WritingChallenge implements Node & Campaign & Channel {
   articles(input: CampaignArticlesInput!): CampaignArticleConnection!
   application: CampaignApplication
   featuredDescription(input: TranslationArgs): String!
+  isManager: Boolean!
   oss: CampaignOSS!
 }
 

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -4398,6 +4398,7 @@ export type GQLWritingChallenge = GQLCampaign &
     description?: Maybe<Scalars['String']['output']>
     featuredDescription: Scalars['String']['output']
     id: Scalars['ID']['output']
+    isManager: Scalars['Boolean']['output']
     link: Scalars['String']['output']
     name: Scalars['String']['output']
     oss: GQLCampaignOss
@@ -10275,6 +10276,7 @@ export type GQLWritingChallengeResolvers<
     Partial<GQLWritingChallengeFeaturedDescriptionArgs>
   >
   id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  isManager?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
   link?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
   name?: Resolver<
     GQLResolversTypes['String'],

--- a/src/queries/campaign/index.ts
+++ b/src/queries/campaign/index.ts
@@ -45,6 +45,8 @@ const schema: GQLResolvers = {
     stages,
     state: ({ state }) => state,
     application,
+    isManager: ({ managerIds }, _, { viewer }) =>
+      managerIds?.includes(viewer.id) ?? false,
     participants,
     articles,
     oss: (root) => root,

--- a/src/types/campaign.ts
+++ b/src/types/campaign.ts
@@ -122,6 +122,8 @@ export default /* GraphQL */ `
 
     featuredDescription(input: TranslationArgs): String!
 
+    isManager: Boolean! @privateCache
+
     oss: CampaignOSS! @auth(mode: "${AUTH_MODE.admin}")
   }
 


### PR DESCRIPTION
- Introduced a new `isManager` field in the `WritingChallenge` GraphQL schema.
- Updated the resolver to determine if the viewer is a manager based on their ID.
- Enhanced tests to validate the functionality of the `isManager` field for different user roles.