### PR TITLE
revert(oss): remove channel filter from OSSArticlesInput and related logic

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -2513,7 +2513,6 @@ input OSSArticlesInput {
 
 input OSSArticlesFilterInput {
   isSpam: Boolean
-  channel: ID
 }
 
 enum CacheControlScope {

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -2709,7 +2709,6 @@ export type GQLOssUsersArgs = {
 }
 
 export type GQLOssArticlesFilterInput = {
-  channel?: InputMaybe<Scalars['ID']['input']>
   isSpam?: InputMaybe<Scalars['Boolean']['input']>
 }
 

--- a/src/queries/system/oss/articles.ts
+++ b/src/queries/system/oss/articles.ts
@@ -1,35 +1,13 @@
 import type { GQLOssResolvers } from '#definitions/index.js'
 
-import {
-  connectionFromQuery,
-  connectionFromArray,
-} from '#common/utils/connections.js'
-import { fromGlobalId } from '#common/utils/index.js'
+import { connectionFromQuery } from '#common/utils/connections.js'
 
 export const articles: GQLOssResolvers['articles'] = async (
   _,
   { input },
-  { dataSources: { articleService, systemService, channelService } }
+  { dataSources: { articleService, systemService } }
 ) => {
   const spamThreshold = await systemService.getSpamThreshold()
-
-  // return channel articles
-  if (input?.filter?.channel) {
-    const { type, id } = fromGlobalId(input.filter.channel)
-    if (type === 'TopicChannel') {
-      const channelQuery = channelService.findTopicChannelArticles(id, {
-        spamThreshold: spamThreshold ?? undefined,
-      })
-      return connectionFromQuery({
-        query: channelQuery,
-        args: input,
-        orderBy: { column: 'order', order: 'asc' },
-        cursorColumn: 'id',
-      })
-    }
-    // return empty array for invalid channel type
-    return connectionFromArray([], input)
-  }
 
   // return spam articles
   if (input?.filter?.isSpam) {

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -580,7 +580,6 @@ export default /* GraphQL */ `
 
   input OSSArticlesFilterInput {
     isSpam: Boolean
-    channel: ID
   }
 
   ####################


### PR DESCRIPTION
- Removed the `channel` field from `OSSArticlesFilterInput` and related types.
- Updated the `articles` resolver to eliminate channel filtering logic.
- Cleaned up tests by removing channel-related test cases.