### PR TITLE
feat(article): add ad marking functionality

### DIFF
--- a/db/migrations/20250507063928_alter_article_add_is_ad.js
+++ b/db/migrations/20250507063928_alter_article_add_is_ad.js
@@ -1,0 +1,15 @@
+const table = 'article'
+
+export const up = async (knex) => {
+  await knex.schema.table(table, (t) => {
+    t.boolean('is_ad').nullable()
+    t.index('is_ad')
+  })
+}
+
+export const down = async (knex) => {
+  await knex.schema.table(table, (t) => {
+    t.dropIndex('is_ad')
+    t.dropColumn('is_ad')
+  })
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -148,6 +148,7 @@ type Mutation {
   putUserFeatureFlags(input: PutUserFeatureFlagsInput!): [User!]!
   putIcymiTopic(input: PutIcymiTopicInput!): IcymiTopic
   setSpamStatus(input: SetSpamStatusInput!): Article!
+  setAdStatus(input: SetAdStatusInput!): Article!
 
   """Send verification code for email."""
   sendVerificationCode(input: SendVerificationCodeInput!): Boolean
@@ -567,6 +568,7 @@ type ArticleOSS {
   inRecommendNewest: Boolean!
   inSearch: Boolean!
   spamStatus: SpamStatus!
+  adStatus: AdStatus!
   topicChannels: [ArticleTopicChannel!]!
 }
 
@@ -578,6 +580,13 @@ type SpamStatus {
   whether this article is labeled as spam by human, null for not labeled yet. 
   """
   isSpam: Boolean
+}
+
+type AdStatus {
+  """
+  whether this article is labeled as ad by human, null for not labeled yet. 
+  """
+  isAd: Boolean
 }
 
 type ArticleTopicChannel {
@@ -2524,6 +2533,11 @@ input PutIcymiTopicInput {
 input SetSpamStatusInput {
   id: ID!
   isSpam: Boolean!
+}
+
+input SetAdStatusInput {
+  id: ID!
+  isAd: Boolean!
 }
 
 input OSSArticlesInput {

--- a/src/definitions/article.d.ts
+++ b/src/definitions/article.d.ts
@@ -18,6 +18,7 @@ export interface Article {
   shortHash: string
   spamScore: number | null
   isSpam: boolean | null
+  isAd: boolean | null
 }
 
 export interface ArticleVersion {

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -79,6 +79,12 @@ export type Scalars = {
   Upload: { input: any; output: any }
 }
 
+export type GQLAdStatus = {
+  __typename?: 'AdStatus'
+  /** whether this article is labeled as ad by human, null for not labeled yet.  */
+  isAd?: Maybe<Scalars['Boolean']['output']>
+}
+
 export type GQLAddCollectionsArticlesInput = {
   articles: Array<Scalars['ID']['input']>
   collections: Array<Scalars['ID']['input']>
@@ -548,6 +554,7 @@ export type GQLArticleNoticeType =
 
 export type GQLArticleOss = {
   __typename?: 'ArticleOSS'
+  adStatus: GQLAdStatus
   boost: Scalars['Float']['output']
   inRecommendHottest: Scalars['Boolean']['output']
   inRecommendIcymi: Scalars['Boolean']['output']
@@ -2044,6 +2051,7 @@ export type GQLMutation = {
   sendCampaignAnnouncement?: Maybe<Scalars['Boolean']['output']>
   /** Send verification code for email. */
   sendVerificationCode?: Maybe<Scalars['Boolean']['output']>
+  setAdStatus: GQLArticle
   setArticleTopicChannels: GQLArticle
   setBoost: GQLNode
   /** Set user currency preference. */
@@ -2378,6 +2386,10 @@ export type GQLMutationSendCampaignAnnouncementArgs = {
 
 export type GQLMutationSendVerificationCodeArgs = {
   input: GQLSendVerificationCodeInput
+}
+
+export type GQLMutationSetAdStatusArgs = {
+  input: GQLSetAdStatusInput
 }
 
 export type GQLMutationSetArticleTopicChannelsArgs = {
@@ -3431,6 +3443,11 @@ export type GQLSendVerificationCodeInput = {
   redirectUrl?: InputMaybe<Scalars['String']['input']>
   token?: InputMaybe<Scalars['String']['input']>
   type: GQLVerificationCodeType
+}
+
+export type GQLSetAdStatusInput = {
+  id: Scalars['ID']['input']
+  isAd: Scalars['Boolean']['input']
 }
 
 export type GQLSetArticleTopicChannelsInput = {
@@ -4762,6 +4779,7 @@ export type GQLResolversInterfaceTypes<
 
 /** Mapping between all available schema types and the resolvers types */
 export type GQLResolversTypes = ResolversObject<{
+  AdStatus: ResolverTypeWrapper<GQLAdStatus>
   AddCollectionsArticlesInput: GQLAddCollectionsArticlesInput
   AddCreditInput: GQLAddCreditInput
   AddCreditResult: ResolverTypeWrapper<
@@ -5292,6 +5310,7 @@ export type GQLResolversTypes = ResolversObject<{
   SearchTypes: GQLSearchTypes
   SendCampaignAnnouncementInput: GQLSendCampaignAnnouncementInput
   SendVerificationCodeInput: GQLSendVerificationCodeInput
+  SetAdStatusInput: GQLSetAdStatusInput
   SetArticleTopicChannelsInput: GQLSetArticleTopicChannelsInput
   SetBoostInput: GQLSetBoostInput
   SetCurrencyInput: GQLSetCurrencyInput
@@ -5490,6 +5509,7 @@ export type GQLResolversTypes = ResolversObject<{
 
 /** Mapping between all available schema types and the resolvers parents */
 export type GQLResolversParentTypes = ResolversObject<{
+  AdStatus: GQLAdStatus
   AddCollectionsArticlesInput: GQLAddCollectionsArticlesInput
   AddCreditInput: GQLAddCreditInput
   AddCreditResult: Omit<GQLAddCreditResult, 'transaction'> & {
@@ -5877,6 +5897,7 @@ export type GQLResolversParentTypes = ResolversObject<{
   }
   SendCampaignAnnouncementInput: GQLSendCampaignAnnouncementInput
   SendVerificationCodeInput: GQLSendVerificationCodeInput
+  SetAdStatusInput: GQLSetAdStatusInput
   SetArticleTopicChannelsInput: GQLSetArticleTopicChannelsInput
   SetBoostInput: GQLSetBoostInput
   SetCurrencyInput: GQLSetCurrencyInput
@@ -6155,6 +6176,14 @@ export type GQLRateLimitDirectiveResolver<
   ContextType = Context,
   Args = GQLRateLimitDirectiveArgs
 > = DirectiveResolverFn<Result, Parent, ContextType, Args>
+
+export type GQLAdStatusResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['AdStatus'] = GQLResolversParentTypes['AdStatus']
+> = ResolversObject<{
+  isAd?: Resolver<Maybe<GQLResolversTypes['Boolean']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
 export type GQLAddCreditResultResolvers<
   ContextType = Context,
@@ -6608,6 +6637,7 @@ export type GQLArticleOssResolvers<
   ContextType = Context,
   ParentType extends GQLResolversParentTypes['ArticleOSS'] = GQLResolversParentTypes['ArticleOSS']
 > = ResolversObject<{
+  adStatus?: Resolver<GQLResolversTypes['AdStatus'], ParentType, ContextType>
   boost?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>
   inRecommendHottest?: Resolver<
     GQLResolversTypes['Boolean'],
@@ -8419,6 +8449,12 @@ export type GQLMutationResolvers<
     ParentType,
     ContextType,
     RequireFields<GQLMutationSendVerificationCodeArgs, 'input'>
+  >
+  setAdStatus?: Resolver<
+    GQLResolversTypes['Article'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationSetAdStatusArgs, 'input'>
   >
   setArticleTopicChannels?: Resolver<
     GQLResolversTypes['Article'],
@@ -10431,6 +10467,7 @@ export type GQLWritingEdgeResolvers<
 }>
 
 export type GQLResolvers<ContextType = Context> = ResolversObject<{
+  AdStatus?: GQLAdStatusResolvers<ContextType>
   AddCreditResult?: GQLAddCreditResultResolvers<ContextType>
   Announcement?: GQLAnnouncementResolvers<ContextType>
   AnnouncementChannel?: GQLAnnouncementChannelResolvers<ContextType>

--- a/src/mutations/system/index.ts
+++ b/src/mutations/system/index.ts
@@ -9,6 +9,7 @@ import putRemark from './putRemark.js'
 import putRestrictedUsers from './putRestrictedUsers.js'
 import putSkippedListItem from './putSkippedListItem.js'
 import putUserFeatureFlags from './putUserFeatureFlags.js'
+import setAdStatus from './setAdStatus.js'
 import setBoost from './setBoost.js'
 import setFeature from './setFeature.js'
 import setSpamStatus from './setSpamStatus.js'
@@ -35,5 +36,6 @@ export default {
     submitReport,
     putIcymiTopic,
     setSpamStatus,
+    setAdStatus,
   },
 }

--- a/src/mutations/system/setAdStatus.ts
+++ b/src/mutations/system/setAdStatus.ts
@@ -1,0 +1,24 @@
+import type { GQLMutationResolvers } from '#definitions/index.js'
+
+import { UserInputError } from '#common/errors.js'
+import { fromGlobalId } from '#common/utils/index.js'
+
+const resolver: GQLMutationResolvers['setAdStatus'] = async (
+  _,
+  { input: { id: globalId, isAd } },
+  { dataSources: { atomService } }
+) => {
+  const id = fromGlobalId(globalId).id
+
+  if (!id) {
+    throw new UserInputError('id is invalid')
+  }
+
+  return atomService.update({
+    table: 'article',
+    where: { id },
+    data: { isAd },
+  })
+}
+
+export default resolver

--- a/src/queries/article/index.ts
+++ b/src/queries/article/index.ts
@@ -162,6 +162,7 @@ const schema: GQLResolvers = {
     inRecommendNewest: articleOSS.inRecommendNewest,
     inSearch: articleOSS.inSearch,
     spamStatus: articleOSS.spamStatus,
+    adStatus: articleOSS.adStatus,
     topicChannels: articleOSS.topicChannels,
   },
   TagOSS: {

--- a/src/queries/article/oss.ts
+++ b/src/queries/article/oss.ts
@@ -98,6 +98,12 @@ export const spamStatus: GQLArticleOssResolvers['spamStatus'] = async (
   return { score: spamScore, isSpam }
 }
 
+export const adStatus: GQLArticleOssResolvers['adStatus'] = async ({
+  isAd,
+}) => {
+  return { isAd }
+}
+
 export const topicChannels: GQLArticleOssResolvers['topicChannels'] = async (
   { id: articleId },
   _,

--- a/src/types/__test__/2/system.test.ts
+++ b/src/types/__test__/2/system.test.ts
@@ -1169,3 +1169,38 @@ describe('setSpamStatus', () => {
     expect(data.setSpamStatus.oss.spamStatus.isSpam).toBe(true)
   })
 })
+
+describe('setAdStatus', () => {
+  const SET_AD_STATUS = /* GraphQL */ `
+    mutation ($input: SetAdStatusInput!) {
+      setAdStatus(input: $input) {
+        id
+        ... on Article {
+          oss {
+            adStatus {
+              isAd
+            }
+          }
+        }
+      }
+    }
+  `
+  test('set ad status successfully', async () => {
+    const server = await testClient({
+      isAuth: true,
+      isAdmin: true,
+      connections,
+    })
+    const { errors, data } = await server.executeOperation({
+      query: SET_AD_STATUS,
+      variables: {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.Article, id: 1 }),
+          isAd: true,
+        },
+      },
+    })
+    expect(errors).toBeUndefined()
+    expect(data.setAdStatus.oss.adStatus.isAd).toBe(true)
+  })
+})

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -316,6 +316,7 @@ export default /* GraphQL */ `
     inRecommendNewest: Boolean! @auth(mode: "${AUTH_MODE.admin}")
     inSearch: Boolean! @auth(mode: "${AUTH_MODE.admin}")
     spamStatus: SpamStatus! @auth(mode: "${AUTH_MODE.admin}")
+    adStatus: AdStatus! @auth(mode: "${AUTH_MODE.admin}")
     topicChannels: [ArticleTopicChannel!]! @auth(mode: "${AUTH_MODE.admin}")
   }
 
@@ -325,6 +326,11 @@ export default /* GraphQL */ `
 
     "whether this article is labeled as spam by human, null for not labeled yet. "
     isSpam: Boolean
+  }
+
+  type AdStatus {
+    "whether this article is labeled as ad by human, null for not labeled yet. "
+    isAd: Boolean
   }
 
   type ArticleTopicChannel {

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -47,7 +47,8 @@ export default /* GraphQL */ `
     putRestrictedUsers(input: PutRestrictedUsersInput!): [User!]! @complexity(value: 1, multipliers: ["input.ids"]) @auth(mode: "${AUTH_MODE.admin}")
     putUserFeatureFlags(input: PutUserFeatureFlagsInput!): [User!]! @complexity(value: 1, multipliers: ["input.ids"]) @auth(mode: "${AUTH_MODE.admin}")
     putIcymiTopic(input: PutIcymiTopicInput!): IcymiTopic @auth(mode: "${AUTH_MODE.admin}")
-    setSpamStatus(input: SetSpamStatusInput!): Article! @auth(mode: "${AUTH_MODE.admin}")
+    setSpamStatus(input: SetSpamStatusInput!): Article! @auth(mode: "${AUTH_MODE.admin}") @purgeCache(type: "${NODE_TYPES.Article}")
+    setAdStatus(input: SetAdStatusInput!): Article! @auth(mode: "${AUTH_MODE.admin}") @purgeCache(type: "${NODE_TYPES.Article}")
   }
 
   input KeywordsInput {
@@ -577,6 +578,11 @@ export default /* GraphQL */ `
   input SetSpamStatusInput {
     id: ID!
     isSpam: Boolean!
+  }
+
+  input SetAdStatusInput {
+    id: ID!
+    isAd: Boolean!
   }
 
   input OSSArticlesInput {


### PR DESCRIPTION
- Introduced `setAdStatus` mutation to update the ad status of articles.
- Added `adStatus` field to the `ArticleOSS` type and corresponding GraphQL schema.
- Created a new migration to add `is_ad` column to the `article` table.
- Updated TypeScript definitions and resolvers to support the new ad status feature.
- Implemented tests to verify the functionality of setting ad status.