### PR TITLE
fix(recommendation): unify `channelId` to be `undefined` for site recommendation

### DIFF
--- a/deployment/lambda/recommendation-cache-ahead.yml
+++ b/deployment/lambda/recommendation-cache-ahead.yml
@@ -95,7 +95,7 @@ Resources:
       ScheduleExpression: "cron(0 * * * ? *)"
       Targets:
         - Arn: !GetAtt Lambda.Arn
-          Id: CronEvent1LambdaTarget
+          Id: CronEvent0LambdaTarget
           Input: |
             {
               "data": {}


### PR DESCRIPTION
There are two different keys for site recommendation in cache now:
- `"cache-recommendation-tags:recommendationTags:{\"channelId\":\"\"}"`
- `"cache-recommendation-tags:recommendationTags:{}"`