### PR TITLE
ci: add envs for `aws-actions/amazon-ecr-login@v2`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,7 +99,7 @@ jobs:
     with:
       environment: 'develop'
     secrets:
-      AWS_REGION: ${{ secrets.AWS_REGION_PROD }}
+      AWS_REGION: ${{ secrets.AWS_REGION_DEV }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}

--- a/.github/workflows/lambda-deploy.yml
+++ b/.github/workflows/lambda-deploy.yml
@@ -18,6 +18,10 @@ on:
         required: true
 
 env:
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+  AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
   ECR_REPOSITORY: lambda-handlers-image
   MATTERS_ENV: ${{ inputs.environment == 'develop' && 'development' || 'production' }}
   SQS_ENV: ${{ inputs.environment == 'develop' && 'dev' || 'prod' }}


### PR DESCRIPTION
`aws-actions/amazon-ecr-login@v2` seems to not be reading credentials from `aws-actions/configure-aws-credentials@v4`