### PR TITLE
fix(feedback): refactor and update auto-resolve logic

### DIFF
--- a/src/connectors/__test__/channelService/feedback.test.ts
+++ b/src/connectors/__test__/channelService/feedback.test.ts
@@ -267,46 +267,6 @@ describe('feedback methods', () => {
   })
 
   describe('acceptFeedback', () => {
-    test('accepts feedback and updates article channels when autoAccept is true and channelIds is empty', async () => {
-      // Create test article channels
-      await atomService.create({
-        table: 'topic_channel_article',
-        data: {
-          articleId: '1',
-          channelId: channel1.id,
-          enabled: true,
-        },
-      })
-
-      // Create feedback
-      const feedback = await atomService.create({
-        table: 'topic_channel_feedback',
-        data: {
-          type: TOPIC_CHANNEL_FEEDBACK_TYPE.NEGATIVE,
-          articleId: '1',
-          userId: '1',
-          state: TOPIC_CHANNEL_FEEDBACK_STATE.PENDING,
-          channelIds: JSON.stringify([]) as unknown as string[],
-        },
-      })
-
-      await channelService.acceptFeedback(feedback, true)
-
-      // Verify feedback state is updated
-      const updatedFeedback = await atomService.findFirst({
-        table: 'topic_channel_feedback',
-        where: { id: feedback.id },
-      })
-      expect(updatedFeedback?.state).toBe(TOPIC_CHANNEL_FEEDBACK_STATE.RESOLVED)
-
-      // Verify article channels are disabled
-      const articleChannels = await atomService.findMany({
-        table: 'topic_channel_article',
-        where: { articleId: '1' },
-      })
-      expect(articleChannels.every((channel) => !channel.enabled)).toBe(true)
-    })
-
     test('accepts feedback and updates article channels with specific channelIds', async () => {
       // Create test article channels
       await atomService.create({
@@ -372,6 +332,451 @@ describe('feedback methods', () => {
     })
   })
 
+  describe('setArticleTopicChannels', () => {
+    test('sets isLabeled to true when setLabeled is true (default)', async () => {
+      await channelService.setArticleTopicChannels({
+        articleId: '1',
+        channelIds: [channel1.id],
+      })
+
+      const articleChannels = await atomService.findMany({
+        table: 'topic_channel_article',
+        where: { articleId: '1' },
+      })
+      expect(articleChannels).toHaveLength(1)
+      expect(articleChannels[0].isLabeled).toBe(true)
+      expect(articleChannels[0].enabled).toBe(true)
+    })
+
+    test('does not set isLabeled when setLabeled is false', async () => {
+      await channelService.setArticleTopicChannels({
+        articleId: '1',
+        channelIds: [channel1.id],
+        setLabeled: false,
+      })
+
+      const articleChannels = await atomService.findMany({
+        table: 'topic_channel_article',
+        where: { articleId: '1' },
+      })
+      expect(articleChannels).toHaveLength(1)
+      expect(articleChannels[0].isLabeled).toBe(false)
+      expect(articleChannels[0].enabled).toBe(true)
+    })
+
+    test('handles removing channels with setLabeled parameter', async () => {
+      // First add a channel
+      await atomService.create({
+        table: 'topic_channel_article',
+        data: {
+          articleId: '1',
+          channelId: channel1.id,
+          enabled: true,
+          isLabeled: false,
+        },
+      })
+
+      // Remove the channel with setLabeled: false
+      await channelService.setArticleTopicChannels({
+        articleId: '1',
+        channelIds: [],
+        setLabeled: false,
+      })
+
+      const articleChannels = await atomService.findMany({
+        table: 'topic_channel_article',
+        where: { articleId: '1' },
+      })
+      expect(articleChannels).toHaveLength(1)
+      expect(articleChannels[0].enabled).toBe(false)
+      expect(articleChannels[0].isLabeled).toBe(false)
+    })
+
+    test('handles removing channels with setLabeled: true', async () => {
+      // First add a channel
+      await atomService.create({
+        table: 'topic_channel_article',
+        data: {
+          articleId: '1',
+          channelId: channel1.id,
+          enabled: true,
+          isLabeled: false,
+        },
+      })
+
+      // Remove the channel with setLabeled: true (default)
+      await channelService.setArticleTopicChannels({
+        articleId: '1',
+        channelIds: [channel2.id],
+      })
+
+      const articleChannels = await atomService.findMany({
+        table: 'topic_channel_article',
+        where: { articleId: '1' },
+      })
+      expect(articleChannels).toHaveLength(2)
+
+      const disabledChannel = articleChannels.find(
+        (c) => c.channelId === channel1.id
+      )
+      const enabledChannel = articleChannels.find(
+        (c) => c.channelId === channel2.id
+      )
+
+      expect(disabledChannel?.enabled).toBe(false)
+      expect(disabledChannel?.isLabeled).toBe(true)
+      expect(enabledChannel?.enabled).toBe(true)
+      expect(enabledChannel?.isLabeled).toBe(true)
+    })
+  })
+
+  describe('canAutoResolveFeedback', () => {
+    test('returns true when all feedback channelIds are in current article channels', async () => {
+      await atomService.create({
+        table: 'topic_channel_article',
+        data: {
+          articleId: '1',
+          channelId: channel1.id,
+          enabled: true,
+        },
+      })
+
+      const canResolve = await channelService.canAutoResolveFeedback({
+        articleId: '1',
+        channelIds: [channel1.id],
+      })
+      expect(canResolve).toBe(true)
+    })
+
+    test('returns true when channelIds is empty and no labeled channels exist', async () => {
+      const canResolve = await channelService.canAutoResolveFeedback({
+        articleId: '1',
+        channelIds: [],
+      })
+      expect(canResolve).toBe(true)
+    })
+
+    test('returns false when channelIds is empty but labeled channels exist', async () => {
+      await atomService.create({
+        table: 'topic_channel_article',
+        data: {
+          articleId: '1',
+          channelId: channel1.id,
+          enabled: true,
+          isLabeled: true,
+        },
+      })
+
+      const canResolve = await channelService.canAutoResolveFeedback({
+        articleId: '1',
+        channelIds: [],
+      })
+      expect(canResolve).toBe(false)
+    })
+
+    test('returns false when some feedback channelIds are not in current article channels', async () => {
+      await atomService.create({
+        table: 'topic_channel_article',
+        data: {
+          articleId: '1',
+          channelId: channel1.id,
+          enabled: true,
+        },
+      })
+
+      const canResolve = await channelService.canAutoResolveFeedback({
+        articleId: '1',
+        channelIds: [channel1.id, channel2.id],
+      })
+      expect(canResolve).toBe(false)
+    })
+
+    test('returns false when none of the feedback channelIds are in current article channels', async () => {
+      await atomService.create({
+        table: 'topic_channel_article',
+        data: {
+          articleId: '1',
+          channelId: channel1.id,
+          enabled: true,
+        },
+      })
+
+      const canResolve = await channelService.canAutoResolveFeedback({
+        articleId: '1',
+        channelIds: [channel2.id],
+      })
+      expect(canResolve).toBe(false)
+    })
+  })
+
+  describe('tryAutoResolveArticleFeedback', () => {
+    test('auto-resolves feedback when conditions are met and preserves labeled channels', async () => {
+      // Create labeled and unlabeled channels
+      await atomService.create({
+        table: 'topic_channel_article',
+        data: {
+          articleId: '1',
+          channelId: channel1.id,
+          enabled: true,
+          isLabeled: true,
+        },
+      })
+      await atomService.create({
+        table: 'topic_channel_article',
+        data: {
+          articleId: '1',
+          channelId: channel2.id,
+          enabled: true,
+          isLabeled: false,
+        },
+      })
+
+      // Create feedback that can be auto-resolved
+      await atomService.create({
+        table: 'topic_channel_feedback',
+        data: {
+          type: TOPIC_CHANNEL_FEEDBACK_TYPE.NEGATIVE,
+          articleId: '1',
+          userId: '1',
+          state: TOPIC_CHANNEL_FEEDBACK_STATE.PENDING,
+          channelIds: JSON.stringify([channel2.id]) as unknown as string[],
+        },
+      })
+
+      const result = await channelService.tryAutoResolveArticleFeedback('1')
+
+      expect(result).toBeDefined()
+      expect(result?.state).toBe(TOPIC_CHANNEL_FEEDBACK_STATE.RESOLVED)
+
+      // Verify labeled channels are preserved
+      const articleChannels = await atomService.findMany({
+        table: 'topic_channel_article',
+        where: { articleId: '1', enabled: true },
+      })
+      expect(articleChannels).toHaveLength(2)
+    })
+
+    test('auto-resolves feedback with empty channelIds when no labeled channels exist', async () => {
+      // Create some existing unlabeled channels
+      await atomService.create({
+        table: 'topic_channel_article',
+        data: {
+          articleId: '1',
+          channelId: channel1.id,
+          enabled: true,
+          isLabeled: false,
+        },
+      })
+
+      // Create feedback with empty channelIds
+      await atomService.create({
+        table: 'topic_channel_feedback',
+        data: {
+          type: TOPIC_CHANNEL_FEEDBACK_TYPE.NEGATIVE,
+          articleId: '1',
+          userId: '1',
+          state: TOPIC_CHANNEL_FEEDBACK_STATE.PENDING,
+          channelIds: JSON.stringify([]) as unknown as string[],
+        },
+      })
+
+      const result = await channelService.tryAutoResolveArticleFeedback('1')
+
+      expect(result).toBeDefined()
+      expect(result?.state).toBe(TOPIC_CHANNEL_FEEDBACK_STATE.RESOLVED)
+
+      // Verify unlabeled channels are disabled
+      const articleChannels = await atomService.findMany({
+        table: 'topic_channel_article',
+        where: { articleId: '1', enabled: true },
+      })
+      expect(articleChannels).toHaveLength(0)
+    })
+
+    test('does not auto-resolve feedback with empty channelIds when labeled channels exist', async () => {
+      // Create some existing labeled channels
+      await atomService.create({
+        table: 'topic_channel_article',
+        data: {
+          articleId: '1',
+          channelId: channel1.id,
+          enabled: true,
+          isLabeled: true,
+        },
+      })
+
+      // Create feedback with empty channelIds
+      const feedback = await atomService.create({
+        table: 'topic_channel_feedback',
+        data: {
+          type: TOPIC_CHANNEL_FEEDBACK_TYPE.NEGATIVE,
+          articleId: '1',
+          userId: '1',
+          state: TOPIC_CHANNEL_FEEDBACK_STATE.PENDING,
+          channelIds: JSON.stringify([]) as unknown as string[],
+        },
+      })
+
+      const result = await channelService.tryAutoResolveArticleFeedback('1')
+
+      expect(result).toBeUndefined()
+
+      // Verify feedback state remains pending
+      const updatedFeedback = await atomService.findFirst({
+        table: 'topic_channel_feedback',
+        where: { id: feedback.id },
+      })
+      expect(updatedFeedback?.state).toBe(TOPIC_CHANNEL_FEEDBACK_STATE.PENDING)
+
+      // Verify labeled channels are preserved
+      const articleChannels = await atomService.findMany({
+        table: 'topic_channel_article',
+        where: { articleId: '1', enabled: true },
+      })
+      expect(articleChannels).toHaveLength(1)
+      expect(articleChannels[0].channelId).toBe(channel1.id)
+      expect(articleChannels[0].isLabeled).toBe(true)
+    })
+
+    test('does not auto-resolve when feedback cannot be resolved', async () => {
+      // Create article channels
+      await atomService.create({
+        table: 'topic_channel_article',
+        data: {
+          articleId: '1',
+          channelId: channel1.id,
+          enabled: true,
+        },
+      })
+
+      // Create feedback that cannot be auto-resolved
+      const feedback = await atomService.create({
+        table: 'topic_channel_feedback',
+        data: {
+          type: TOPIC_CHANNEL_FEEDBACK_TYPE.NEGATIVE,
+          articleId: '1',
+          userId: '1',
+          state: TOPIC_CHANNEL_FEEDBACK_STATE.PENDING,
+          channelIds: JSON.stringify([channel2.id]) as unknown as string[],
+        },
+      })
+
+      const result = await channelService.tryAutoResolveArticleFeedback('1')
+
+      expect(result).toBeUndefined()
+
+      // Verify feedback state remains pending
+      const updatedFeedback = await atomService.findFirst({
+        table: 'topic_channel_feedback',
+        where: { id: feedback.id },
+      })
+      expect(updatedFeedback?.state).toBe(TOPIC_CHANNEL_FEEDBACK_STATE.PENDING)
+    })
+
+    test('does not auto-resolve when feedback state is not pending', async () => {
+      // Create feedback with non-pending state
+      const feedback = await atomService.create({
+        table: 'topic_channel_feedback',
+        data: {
+          type: TOPIC_CHANNEL_FEEDBACK_TYPE.NEGATIVE,
+          articleId: '1',
+          userId: '1',
+          state: TOPIC_CHANNEL_FEEDBACK_STATE.ACCEPTED,
+          channelIds: JSON.stringify([channel1.id]) as unknown as string[],
+        },
+      })
+
+      const result = await channelService.tryAutoResolveArticleFeedback('1')
+
+      expect(result).toBeUndefined()
+
+      // Verify feedback state remains unchanged
+      const updatedFeedback = await atomService.findFirst({
+        table: 'topic_channel_feedback',
+        where: { id: feedback.id },
+      })
+      expect(updatedFeedback?.state).toBe(TOPIC_CHANNEL_FEEDBACK_STATE.ACCEPTED)
+    })
+
+    test('returns undefined when no feedback exists', async () => {
+      const result = await channelService.tryAutoResolveArticleFeedback('1')
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('createNegativeFeedback with auto-resolve', () => {
+    test('auto-resolves immediately when feedback matches current channels', async () => {
+      // Create existing article channels
+      await atomService.create({
+        table: 'topic_channel_article',
+        data: {
+          articleId: '1',
+          channelId: channel1.id,
+          enabled: true,
+        },
+      })
+
+      const feedback = await channelService.createNegativeFeedback({
+        articleId: '1',
+        userId: '1',
+        channelIds: [channel1.id],
+      })
+
+      expect(feedback.state).toBe(TOPIC_CHANNEL_FEEDBACK_STATE.RESOLVED)
+    })
+
+    test('auto-resolves immediately when channelIds is empty and no labeled channels exist', async () => {
+      const feedback = await channelService.createNegativeFeedback({
+        articleId: '1',
+        userId: '1',
+        channelIds: [],
+      })
+
+      expect(feedback.state).toBe(TOPIC_CHANNEL_FEEDBACK_STATE.RESOLVED)
+    })
+
+    test('remains pending when channelIds is empty but labeled channels exist', async () => {
+      // Create existing labeled article channel
+      await atomService.create({
+        table: 'topic_channel_article',
+        data: {
+          articleId: '1',
+          channelId: channel1.id,
+          enabled: true,
+          isLabeled: true,
+        },
+      })
+
+      const feedback = await channelService.createNegativeFeedback({
+        articleId: '1',
+        userId: '1',
+        channelIds: [],
+      })
+
+      expect(feedback.state).toBe(TOPIC_CHANNEL_FEEDBACK_STATE.PENDING)
+    })
+
+    test('remains pending when feedback does not match current channels', async () => {
+      // Create existing article channels
+      await atomService.create({
+        table: 'topic_channel_article',
+        data: {
+          articleId: '1',
+          channelId: channel1.id,
+          enabled: true,
+        },
+      })
+
+      const feedback = await channelService.createNegativeFeedback({
+        articleId: '1',
+        userId: '1',
+        channelIds: [channel2.id],
+      })
+
+      expect(feedback.state).toBe(TOPIC_CHANNEL_FEEDBACK_STATE.PENDING)
+    })
+  })
+
   describe('resolveArticleFeedback', () => {
     test('resolves feedback when conditions are met', async () => {
       // Create test article channels
@@ -396,7 +801,7 @@ describe('feedback methods', () => {
         },
       })
 
-      await channelService.resolveArticleFeedback('1')
+      await channelService.tryAutoResolveArticleFeedback('1')
 
       // Verify feedback state is updated
       const updatedFeedback = await atomService.findFirst({
@@ -419,7 +824,7 @@ describe('feedback methods', () => {
         },
       })
 
-      await channelService.resolveArticleFeedback('1')
+      await channelService.tryAutoResolveArticleFeedback('1')
 
       // Verify feedback state remains unchanged
       const updatedFeedback = await atomService.findFirst({
@@ -430,7 +835,7 @@ describe('feedback methods', () => {
     })
 
     test('does not resolve feedback when feedback is not found', async () => {
-      await channelService.resolveArticleFeedback('2')
+      await channelService.tryAutoResolveArticleFeedback('2')
       // No feedback should be created or updated
       const feedbacks = await atomService.findMany({
         table: 'topic_channel_feedback',

--- a/src/connectors/channel/channelService.ts
+++ b/src/connectors/channel/channelService.ts
@@ -208,9 +208,11 @@ export class ChannelService {
   public setArticleTopicChannels = async ({
     articleId,
     channelIds,
+    setLabeled = true,
   }: {
     articleId: string
     channelIds: string[]
+    setLabeled?: boolean
   }) => {
     // Get existing channels
     const existingChannels = await this.models.findMany({
@@ -241,12 +243,20 @@ export class ChannelService {
       })
       await this.models.upsertOnConflict({
         table: 'topic_channel_article',
-        data: toAdd.map((channelId) => ({
-          articleId,
-          channelId,
-          enabled: true,
-          isLabeled: true,
-        })),
+        data: toAdd.map((channelId) =>
+          setLabeled
+            ? {
+                articleId,
+                channelId,
+                enabled: true,
+                isLabeled: true,
+              }
+            : {
+                articleId,
+                channelId,
+                enabled: true,
+              }
+        ),
         onConflict: ['articleId', 'channelId'],
       })
     }
@@ -257,7 +267,9 @@ export class ChannelService {
         table: 'topic_channel_article',
         where: { articleId },
         whereIn: ['channelId', toRemove],
-        data: { enabled: false, isLabeled: true, updatedAt: new Date() },
+        data: setLabeled
+          ? { enabled: false, isLabeled: true, updatedAt: new Date() }
+          : { enabled: false, updatedAt: new Date() },
       })
     }
   }
@@ -764,18 +776,8 @@ export class ChannelService {
         state: TOPIC_CHANNEL_FEEDBACK_STATE.PENDING,
       },
     })
-
-    // auto accept feedback if it is remove all channels or in line with current classification
-    if (
-      feedback.channelIds.length === 0 ||
-      (await this.isFeedbackResolved({
-        articleId,
-        channelIds: feedback.channelIds,
-      }))
-    ) {
-      return this.acceptFeedback(feedback, true)
-    }
-    return feedback
+    const autoResolved = await this.tryAutoResolveArticleFeedback(articleId)
+    return autoResolved || feedback
   }
 
   public findFeedbacks = ({
@@ -806,69 +808,8 @@ export class ChannelService {
     return query
   }
 
-  public acceptFeedback = async (
-    feedback: TopicChannelFeedback,
-    autoResolve: boolean = false
-  ) => {
+  public acceptFeedback = async (feedback: TopicChannelFeedback) => {
     const notificationService = new NotificationService(this.connections)
-    // will not set isLabeled to true if autoResolve is true
-    if (feedback.channelIds.length === 0 && autoResolve) {
-      await this.models.updateMany({
-        table: 'topic_channel_article',
-        where: { articleId: feedback.articleId },
-        data: { enabled: false },
-      })
-      const autoResolved = await this.models.update({
-        table: 'topic_channel_feedback',
-        where: { id: feedback.id },
-        data: { state: TOPIC_CHANNEL_FEEDBACK_STATE.RESOLVED },
-      })
-      await invalidateFQC({
-        node: { type: NODE_TYPES.Article, id: autoResolved.articleId },
-        redis: this.connections.redis,
-      })
-      notificationService.trigger({
-        event: NOTICE_TYPE.topic_channel_feedback_accepted,
-        recipientId: feedback.userId,
-        entities: [
-          {
-            type: 'target',
-            entityTable: 'article',
-            entity: await this.models.articleIdLoader.load(feedback.articleId),
-          },
-        ],
-      })
-      return autoResolved
-    }
-    if (
-      await this.isFeedbackResolved({
-        articleId: feedback.articleId,
-        channelIds: feedback.channelIds,
-      })
-    ) {
-      const resolved = await this.models.update({
-        table: 'topic_channel_feedback',
-        where: { id: feedback.id },
-        data: { state: TOPIC_CHANNEL_FEEDBACK_STATE.RESOLVED },
-      })
-      await invalidateFQC({
-        node: { type: NODE_TYPES.Article, id: resolved.articleId },
-        redis: this.connections.redis,
-      })
-      notificationService.trigger({
-        event: NOTICE_TYPE.topic_channel_feedback_accepted,
-        recipientId: feedback.userId,
-        entities: [
-          {
-            type: 'target',
-            entityTable: 'article',
-            entity: await this.models.articleIdLoader.load(feedback.articleId),
-          },
-        ],
-      })
-      return resolved
-    }
-
     await this.setArticleTopicChannels({
       articleId: feedback.articleId,
       channelIds: feedback.channelIds,
@@ -909,7 +850,9 @@ export class ChannelService {
     return updated
   }
 
-  public resolveArticleFeedback = async (articleId: string) => {
+  public tryAutoResolveArticleFeedback = async (
+    articleId: string
+  ): Promise<TopicChannelFeedback | undefined> => {
     const feedback = await this.models.findFirst({
       table: 'topic_channel_feedback',
       where: { articleId },
@@ -917,11 +860,24 @@ export class ChannelService {
     if (
       feedback &&
       feedback.state === TOPIC_CHANNEL_FEEDBACK_STATE.PENDING &&
-      (await this.isFeedbackResolved({
+      (await this.canAutoResolveFeedback({
         articleId,
         channelIds: feedback.channelIds,
       }))
     ) {
+      const labeledChannels = await this.models.findMany({
+        table: 'topic_channel_article',
+        where: { articleId, enabled: true, isLabeled: true },
+      })
+      const targetChannelIds = labeledChannels
+        .map((c) => c.channelId)
+        .concat(feedback.channelIds)
+      await this.setArticleTopicChannels({
+        articleId,
+        // auto resolve will not remove labeled channels
+        channelIds: Array.from(new Set(targetChannelIds)),
+        setLabeled: false,
+      })
       const autoResolved = await this.models.update({
         table: 'topic_channel_feedback',
         where: { id: feedback.id },
@@ -943,10 +899,11 @@ export class ChannelService {
           },
         ],
       })
+      return autoResolved
     }
   }
 
-  public isFeedbackResolved = async ({
+  public canAutoResolveFeedback = async ({
     articleId,
     channelIds,
   }: {
@@ -958,10 +915,16 @@ export class ChannelService {
       where: { articleId, enabled: true },
     })
     const currentChannelIds = articleChannels.map((c) => c.channelId)
-    if (channelIds.every((id) => currentChannelIds.includes(id))) {
+    if (
+      channelIds.length > 0 &&
+      channelIds.every((id) => currentChannelIds.includes(id))
+    ) {
       return true
     }
-    if (channelIds.length === 0 && articleChannels.length === 0) {
+    if (
+      channelIds.length === 0 &&
+      articleChannels.filter((c) => c.isLabeled).length === 0
+    ) {
       return true
     }
     return false

--- a/src/mutations/channel/setArticleTopicChannels.ts
+++ b/src/mutations/channel/setArticleTopicChannels.ts
@@ -23,7 +23,7 @@ const resolver: GQLMutationResolvers['setArticleTopicChannels'] = async (
     articleId,
     channelIds,
   })
-  await channelService.resolveArticleFeedback(articleId)
+  await channelService.tryAutoResolveArticleFeedback(articleId)
 
   return article
 }


### PR DESCRIPTION
auto-resolve only removes machine results and keeps labeled channels