### PR TITLE
fix(cache): add keepAlive and timeout configs for Lambda environment

### DIFF
--- a/src/connections.ts
+++ b/src/connections.ts
@@ -24,11 +24,27 @@ const searchKnexDB = knex({
   ...{ connection: environment.searchPgConnectionString },
 })
 
-const cacheRedis = new Redis(environment.cachePort, environment.cacheHost)
+const redisConfig = {
+  keepAlive: 1000,
+  connectTimeout: 10000,
+  commandTimeout: 5000,
+  maxRetriesPerRequest: 3,
+  lazyConnect: true,
+}
+
+const cacheRedis = new Redis(
+  environment.cachePort,
+  environment.cacheHost,
+  redisConfig
+)
 
 const objectCacheRedis =
   environment.objectCachePort && environment.objectCacheHost
-    ? new Redis(environment.objectCachePort, environment.objectCacheHost)
+    ? new Redis(
+        environment.objectCachePort,
+        environment.objectCacheHost,
+        redisConfig
+      )
     : cacheRedis
 
 export const connections = {


### PR DESCRIPTION
- Add keepAlive to prevent connection drops in serverless environment
- Configure connection and command timeouts for better reliability
- Add retry and lazy connection settings optimized for Lambda
- Apply configuration to both cacheRedis and objectCacheRedis instances