### PR TITLE
fix(redis): centralize connection health check and use in handlers

### DIFF
--- a/src/connections.ts
+++ b/src/connections.ts
@@ -59,10 +59,28 @@ if (objectCacheRedis !== cacheRedis) {
   })
 }
 
+const ensureConnected = async () => {
+  try {
+    await cacheRedis.ping()
+  } catch (err: unknown) {
+    console.log(err)
+    await cacheRedis.connect()
+  }
+  if (objectCacheRedis !== cacheRedis) {
+    try {
+      await objectCacheRedis.ping()
+    } catch (err: unknown) {
+      console.log(err)
+      await objectCacheRedis.connect()
+    }
+  }
+}
+
 export const connections = {
   knex: mainKnex,
   knexRO: readonlyKnex,
   knexSearch: searchKnexDB,
   redis: cacheRedis,
   objectCacheRedis,
+  ensureConnected,
 }

--- a/src/connectors/cache/index.ts
+++ b/src/connectors/cache/index.ts
@@ -67,7 +67,6 @@ export class Cache {
     const key = this.genKey(keys)
     const serializedData = JSON.stringify(data)
 
-    await this.ensureConnected()
     return this.redis.set(key, serializedData, 'EX', expire)
   }
 
@@ -100,7 +99,6 @@ export class Cache {
       return false
     }
 
-    await this.ensureConnected()
     const key = this.genKey(keys)
 
     const raw = await this.redis.get(key)
@@ -132,13 +130,5 @@ export class Cache {
   }) => {
     const key = this.genKey(keys)
     await this.redis.del(key)
-  }
-
-  private ensureConnected = async () => {
-    try {
-      await this.redis.ping()
-    } catch {
-      await this.redis.connect()
-    }
   }
 }

--- a/src/handlers/recommendationAuthorsCacheAhead.ts
+++ b/src/handlers/recommendationAuthorsCacheAhead.ts
@@ -11,6 +11,7 @@ type Event = {
 }
 
 export const handler = async (event: Event) => {
+  await connections.ensureConnected()
   const channelId = event?.data?.channelId
   const cache = new Cache(
     CACHE_PREFIX.RECOMMENDATION_AUTHORS,

--- a/src/handlers/recommendationHottestCacheAhead.ts
+++ b/src/handlers/recommendationHottestCacheAhead.ts
@@ -6,6 +6,7 @@ import { RecommendationService } from '#connectors/recommendationService.js'
 import { connections } from '../connections.js'
 
 export const handler = async () => {
+  await connections.ensureConnected()
   const cache = new Cache(
     CACHE_PREFIX.RECOMMENDATION_HOTTEST,
     connections.objectCacheRedis

--- a/src/handlers/recommendationTagsCacheAhead.ts
+++ b/src/handlers/recommendationTagsCacheAhead.ts
@@ -11,6 +11,7 @@ type Event = {
 }
 
 export const handler = async (event: Event) => {
+  await connections.ensureConnected()
   const channelId = event?.data?.channelId
   const cache = new Cache(
     CACHE_PREFIX.RECOMMENDATION_TAGS,

--- a/src/handlers/scheduledPublish.ts
+++ b/src/handlers/scheduledPublish.ts
@@ -3,6 +3,7 @@ import { PublicationService } from '#connectors/article/publicationService.js'
 import { connections } from '../connections.js'
 
 export const handler = async () => {
+  await connections.ensureConnected()
   try {
     const publicationService = new PublicationService(connections)
 


### PR DESCRIPTION
Avoid stale Redis connections in Lambda by exposing connections.ensureConnected() and invoking it in cache-ahead and scheduled publish handlers; remove duplicated ensureConnected from Cache.