### PR TITLE
fix(wallet): handle wallet querying from visitors

### DIFF
--- a/docs/Unittest.md
+++ b/docs/Unittest.md
@@ -7,6 +7,7 @@
 - Name test files with `.test.ts` suffix
 - Group related tests in describe blocks
 - Use clear, descriptive test names
+- All Graphql api tests are placed under `src/types/__test__/`
 - Example: `src/types/__test__/2/channel/articles.test.ts` (related compiled file `build/types/__test__/2/channel/articles.test.js`)
 
 ### Setup and Teardown

--- a/src/queries/user/wallet/balance.ts
+++ b/src/queries/user/wallet/balance.ts
@@ -5,9 +5,9 @@ import { PAYMENT_CURRENCY } from '#common/enums/index.js'
 const resolver: GQLWalletResolvers['balance'] = async (
   { id },
   _,
-  { dataSources: { paymentService } }
+  { viewer, dataSources: { paymentService } }
 ) => {
-  if (id === null) {
+  if (!id || viewer.id !== id) {
     return {
       HKD: 0,
     }

--- a/src/queries/user/wallet/cardLast4.ts
+++ b/src/queries/user/wallet/cardLast4.ts
@@ -5,8 +5,11 @@ import { PAYMENT_PROVIDER } from '#common/enums/index.js'
 const resolver: GQLWalletResolvers['cardLast4'] = async (
   { id },
   _,
-  { dataSources: { atomService } }
+  { viewer, dataSources: { atomService } }
 ) => {
+  if (!id || viewer.id !== id) {
+    return null
+  }
   const customer = (await atomService.findFirst({
     table: 'customer',
     where: { userId: id, provider: PAYMENT_PROVIDER.stripe, archived: false },

--- a/src/queries/user/wallet/customerPortal.ts
+++ b/src/queries/user/wallet/customerPortal.ts
@@ -10,12 +10,17 @@ const resolver: GQLWalletResolvers['customerPortal'] = async (
   { id },
   _,
   {
+    viewer,
     dataSources: {
       paymentService,
       connections: { knex },
     },
   }
 ) => {
+  if (!id || viewer.id !== id) {
+    return null
+  }
+
   const where = {
     'csi.user_id': id,
     'csi.archived': false,

--- a/src/queries/user/wallet/stripeAccount.ts
+++ b/src/queries/user/wallet/stripeAccount.ts
@@ -3,8 +3,12 @@ import type { GQLWalletResolvers } from '#definitions/index.js'
 const resolver: GQLWalletResolvers['stripeAccount'] = async (
   { id },
   _,
-  { dataSources: { atomService } }
+  { viewer, dataSources: { atomService } }
 ) => {
+  if (!id || viewer.id !== id) {
+    return null
+  }
+
   const payoutAccount = await atomService.findFirst({
     table: 'payout_account',
     where: { userId: id, capabilitiesTransfers: true, archived: false },

--- a/src/queries/user/wallet/transactions.ts
+++ b/src/queries/user/wallet/transactions.ts
@@ -23,7 +23,7 @@ const resolver: GQLWalletResolvers['transactions'] = async (
   const { id, states, filter } = input
   const { take, skip } = fromConnectionArgs(input)
 
-  if (!viewer.id) {
+  if (!userId || userId !== viewer.id) {
     return connectionFromArray([], input)
   }
 

--- a/src/types/__test__/2/user/wallet.test.ts
+++ b/src/types/__test__/2/user/wallet.test.ts
@@ -1,0 +1,437 @@
+import type { Connections } from '#definitions/index.js'
+
+import { NODE_TYPES } from '#common/enums/index.js'
+import { toGlobalId } from '#common/utils/index.js'
+
+import { testClient, genConnections, closeConnections } from '../../utils.js'
+
+let connections: Connections
+
+beforeAll(async () => {
+  connections = await genConnections()
+}, 30000)
+
+afterAll(async () => {
+  await closeConnections(connections)
+})
+
+describe('wallet', () => {
+  const GET_BALANCE = /* GraphQL */ `
+    query ($input: NodeInput!) {
+      node(input: $input) {
+        ... on User {
+          wallet {
+            balance {
+              HKD
+            }
+          }
+        }
+      }
+    }
+  `
+  const GET_BALANCE_FROM_VIEWER = /* GraphQL */ `
+    query {
+      viewer {
+        wallet {
+          balance {
+            HKD
+          }
+        }
+      }
+    }
+  `
+
+  test('authenticated user can query their own wallet balance', async () => {
+    const server = await testClient({
+      isAuth: true,
+      connections,
+    })
+    const { data } = await server.executeOperation({
+      query: GET_BALANCE,
+      variables: {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.User, id: 1 }),
+        },
+      },
+    })
+    expect(data?.node.wallet.balance.HKD).toBeDefined()
+
+    const { data: viewerData } = await server.executeOperation({
+      query: GET_BALANCE_FROM_VIEWER,
+    })
+    expect(viewerData?.viewer.wallet.balance.HKD).toBeDefined()
+  })
+
+  test("authenticated user cannot query another user's wallet balance", async () => {
+    const server = await testClient({
+      isAuth: true,
+      connections,
+    })
+    const { errors } = await server.executeOperation({
+      query: GET_BALANCE,
+      variables: {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.User, id: 2 }),
+        },
+      },
+    })
+    expect(errors?.[0].extensions.code).toBe('FORBIDDEN')
+  })
+
+  test('unauthenticated user cannot query any wallet balance', async () => {
+    const server = await testClient({
+      isAuth: false,
+      connections,
+    })
+    const { errors } = await server.executeOperation({
+      query: GET_BALANCE,
+      variables: {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.User, id: 1 }),
+        },
+      },
+    })
+    expect(errors?.[0].extensions.code).toBe('FORBIDDEN')
+
+    const { errors: viewerErrors } = await server.executeOperation({
+      query: GET_BALANCE_FROM_VIEWER,
+    })
+    expect(viewerErrors).toBeUndefined()
+  })
+
+  const GET_CARD_LAST4 = /* GraphQL */ `
+    query ($input: NodeInput!) {
+      node(input: $input) {
+        ... on User {
+          wallet {
+            cardLast4
+          }
+        }
+      }
+    }
+  `
+
+  const GET_CARD_LAST4_FROM_VIEWER = /* GraphQL */ `
+    query {
+      viewer {
+        wallet {
+          cardLast4
+        }
+      }
+    }
+  `
+
+  test("authenticated user can query their own card's last 4 digits", async () => {
+    const server = await testClient({
+      isAuth: true,
+      connections,
+    })
+    const { data } = await server.executeOperation({
+      query: GET_CARD_LAST4,
+      variables: {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.User, id: 1 }),
+        },
+      },
+    })
+    expect(data?.node.wallet.cardLast4).toBeDefined()
+
+    const { data: viewerData } = await server.executeOperation({
+      query: GET_CARD_LAST4_FROM_VIEWER,
+    })
+    expect(viewerData?.viewer.wallet.cardLast4).toBeDefined()
+  })
+
+  test("authenticated user cannot query another user's card's last 4 digits", async () => {
+    const server = await testClient({
+      isAuth: true,
+      connections,
+    })
+    const { errors } = await server.executeOperation({
+      query: GET_CARD_LAST4,
+      variables: {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.User, id: 2 }),
+        },
+      },
+    })
+    expect(errors?.[0].extensions.code).toBe('FORBIDDEN')
+  })
+
+  test("unauthenticated user cannot query any card's last 4 digits", async () => {
+    const server = await testClient({
+      isAuth: false,
+      connections,
+    })
+    const { errors } = await server.executeOperation({
+      query: GET_CARD_LAST4,
+      variables: {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.User, id: 1 }),
+        },
+      },
+    })
+    expect(errors?.[0].extensions.code).toBe('FORBIDDEN')
+
+    const { errors: viewerErrors } = await server.executeOperation({
+      query: GET_CARD_LAST4_FROM_VIEWER,
+    })
+    expect(viewerErrors).toBeUndefined()
+  })
+
+  const GET_CUSTOMER_PORTAL = /* GraphQL */ `
+    query ($input: NodeInput!) {
+      node(input: $input) {
+        ... on User {
+          wallet {
+            customerPortal
+          }
+        }
+      }
+    }
+  `
+
+  const GET_CUSTOMER_PORTAL_FROM_VIEWER = /* GraphQL */ `
+    query {
+      viewer {
+        wallet {
+          customerPortal
+        }
+      }
+    }
+  `
+
+  test('authenticated user can query their own customer portal', async () => {
+    const server = await testClient({
+      isAuth: true,
+      connections,
+    })
+    const { data } = await server.executeOperation({
+      query: GET_CUSTOMER_PORTAL,
+      variables: {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.User, id: 1 }),
+        },
+      },
+    })
+    expect(data?.node.wallet.customerPortal).toBeDefined()
+
+    const { data: viewerData } = await server.executeOperation({
+      query: GET_CUSTOMER_PORTAL_FROM_VIEWER,
+    })
+    expect(viewerData?.viewer.wallet.customerPortal).toBeDefined()
+  })
+
+  test("authenticated user cannot query another user's customer portal", async () => {
+    const server = await testClient({
+      isAuth: true,
+      connections,
+    })
+    const { errors } = await server.executeOperation({
+      query: GET_CUSTOMER_PORTAL,
+      variables: {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.User, id: 2 }),
+        },
+      },
+    })
+    expect(errors?.[0].extensions.code).toBe('FORBIDDEN')
+  })
+
+  test('unauthenticated user cannot query any customer portal', async () => {
+    const server = await testClient({
+      isAuth: false,
+      connections,
+    })
+    const { errors } = await server.executeOperation({
+      query: GET_CUSTOMER_PORTAL,
+      variables: {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.User, id: 1 }),
+        },
+      },
+    })
+    expect(errors?.[0].extensions.code).toBe('FORBIDDEN')
+
+    const { errors: viewerErrors } = await server.executeOperation({
+      query: GET_CUSTOMER_PORTAL_FROM_VIEWER,
+    })
+    expect(viewerErrors).toBeUndefined()
+  })
+
+  const GET_STRIPE_ACCOUNT = /* GraphQL */ `
+    query ($input: NodeInput!) {
+      node(input: $input) {
+        ... on User {
+          wallet {
+            stripeAccount {
+              id
+            }
+          }
+        }
+      }
+    }
+  `
+
+  const GET_STRIPE_ACCOUNT_FROM_VIEWER = /* GraphQL */ `
+    query {
+      viewer {
+        wallet {
+          stripeAccount {
+            id
+          }
+        }
+      }
+    }
+  `
+
+  test('authenticated user can query their own stripe account', async () => {
+    const server = await testClient({
+      isAuth: true,
+      connections,
+    })
+    const { data } = await server.executeOperation({
+      query: GET_STRIPE_ACCOUNT,
+      variables: {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.User, id: 1 }),
+        },
+      },
+    })
+    expect(data?.node.wallet.stripeAccount).toBeDefined()
+
+    const { data: viewerData } = await server.executeOperation({
+      query: GET_STRIPE_ACCOUNT_FROM_VIEWER,
+    })
+    expect(viewerData?.viewer.wallet.stripeAccount).toBeDefined()
+  })
+
+  test("authenticated user cannot query another user's stripe account", async () => {
+    const server = await testClient({
+      isAuth: true,
+      connections,
+    })
+    const { errors } = await server.executeOperation({
+      query: GET_STRIPE_ACCOUNT,
+      variables: {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.User, id: 2 }),
+        },
+      },
+    })
+    expect(errors?.[0].extensions.code).toBe('FORBIDDEN')
+  })
+
+  test('unauthenticated user cannot query any stripe account', async () => {
+    const server = await testClient({
+      isAuth: false,
+      connections,
+    })
+    const { errors } = await server.executeOperation({
+      query: GET_STRIPE_ACCOUNT,
+      variables: {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.User, id: 1 }),
+        },
+      },
+    })
+    expect(errors?.[0].extensions.code).toBe('FORBIDDEN')
+
+    const { errors: viewerErrors } = await server.executeOperation({
+      query: GET_STRIPE_ACCOUNT_FROM_VIEWER,
+    })
+    expect(viewerErrors).toBeUndefined()
+  })
+
+  const GET_TRANSACTIONS = /* GraphQL */ `
+    query ($input: NodeInput!) {
+      node(input: $input) {
+        ... on User {
+          wallet {
+            transactions(input: {}) {
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `
+
+  const GET_TRANSACTIONS_FROM_VIEWER = /* GraphQL */ `
+    query {
+      viewer {
+        wallet {
+          transactions(input: {}) {
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+  `
+
+  test('authenticated user can query their own transactions', async () => {
+    const server = await testClient({
+      isAuth: true,
+      connections,
+    })
+    const { data } = await server.executeOperation({
+      query: GET_TRANSACTIONS,
+      variables: {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.User, id: 1 }),
+        },
+      },
+    })
+    expect(data?.node.wallet.transactions.edges).toBeDefined()
+
+    const { data: viewerData } = await server.executeOperation({
+      query: GET_TRANSACTIONS_FROM_VIEWER,
+    })
+    expect(viewerData?.viewer.wallet.transactions.edges).toBeDefined()
+  })
+
+  test("authenticated user cannot query another user's transactions", async () => {
+    const server = await testClient({
+      isAuth: true,
+      connections,
+    })
+    const { errors } = await server.executeOperation({
+      query: GET_TRANSACTIONS,
+      variables: {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.User, id: 2 }),
+        },
+      },
+    })
+    expect(errors?.[0].extensions.code).toBe('FORBIDDEN')
+  })
+
+  test('unauthenticated user cannot query any transactions', async () => {
+    const server = await testClient({
+      isAuth: false,
+      connections,
+    })
+    const { errors } = await server.executeOperation({
+      query: GET_TRANSACTIONS,
+      variables: {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.User, id: 1 }),
+        },
+      },
+    })
+    expect(errors?.[0].extensions.code).toBe('FORBIDDEN')
+
+    const { errors: viewerErrors } = await server.executeOperation({
+      query: GET_TRANSACTIONS_FROM_VIEWER,
+    })
+    expect(viewerErrors).toBeUndefined()
+  })
+})


### PR DESCRIPTION
`@auth(mode: "oauth")` does not protect querying on `viewer.wallet` from visitors