### PR TITLE
docs: remove IPFS deps from local setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ### Local
 
 - Install dependencies: `npm install`
-- Start Postgres, Redis, stripe-mock, and IPFS daemon
+- Start Postgres, Redis, stripe-mock
 - Setup Environments: `cp .env.example .env`
 - Run all migrations: `npm run db:migrate`
 - Populate all seeds data if needed: `npm run db:seed`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matters-server",
-  "version": "5.21.6",
+  "version": "5.21.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matters-server",
-      "version": "5.21.6",
+      "version": "5.21.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@alchemy/aa-accounts": "^3.19.0",


### PR DESCRIPTION
the codebase no longer depends on a running/self-hosted IPFS node. Instead, it uses two third-party hosted IPFS services:
  1. Storacha (web3.storage) — via the @web3-storage/w3up-client SDK. It authenticates with a private key + delegation proof (fetched from S3) and calls uploadDirectory to pin content.
  2. Pinata — via the pinata-web3 SDK. After uploading to Storacha, it pins the same CID on Pinata for redundancy using pinata.upload.cid(...).

  Both are cloud-hosted IPFS pinning services accessed through their respective SDKs/APIs. The relevant env vars are:
  • MATTERS_STORACHA_PROOF_S3_BUCKET, MATTERS_STORACHA_PROOF_S3_KEY, MATTERS_STORACHA_PRIVATE_KEY — for Storacha
  • MATTERS_PINATA_JWT, MATTERS_PINATA_GATEWAY, MATTERS_PINATA_GROUP_ID — for Pinata