### PR TITLE
Add Community Watch comment removal API

### DIFF
--- a/db/migrations/20260510001000_create_community_watch_action_table.js
+++ b/db/migrations/20260510001000_create_community_watch_action_table.js
@@ -1,0 +1,65 @@
+const table = 'community_watch_action'
+const activeCommentIndex = 'community_watch_action_comment_id_active_unique'
+
+export const up = async (knex) => {
+  await knex('entity_type').insert({ table })
+
+  await knex.schema.createTable(table, (t) => {
+    t.bigIncrements('id').primary()
+    t.uuid('uuid').notNullable().unique()
+    t.bigInteger('comment_id').unsigned().notNullable()
+    t.enu('comment_type', ['article', 'moment']).notNullable()
+    t.enu('target_type', ['article', 'moment']).notNullable()
+    t.bigInteger('target_id').unsigned().notNullable()
+    t.text('target_title')
+    t.string('target_short_hash')
+    t.enu('reason', ['porn_ad', 'spam_ad']).notNullable()
+    t.bigInteger('actor_id').unsigned().notNullable()
+    t.bigInteger('comment_author_id').unsigned()
+    t.text('original_content')
+    t.enu('original_state', [
+      'active',
+      'archived',
+      'banned',
+      'collapsed',
+    ]).notNullable()
+    t.enu('action_state', ['active', 'restored', 'voided'])
+      .notNullable()
+      .defaultTo('active')
+    t.enu('appeal_state', ['none', 'received', 'resolved'])
+      .notNullable()
+      .defaultTo('none')
+    t.enu('review_state', ['pending', 'upheld', 'reversed', 'reason_adjusted'])
+      .notNullable()
+      .defaultTo('pending')
+    t.bigInteger('reviewer_id').unsigned()
+    t.text('review_note')
+    t.timestamp('reviewed_at')
+    t.timestamp('content_expires_at').notNullable()
+    t.timestamp('created_at').defaultTo(knex.fn.now())
+    t.timestamp('updated_at').defaultTo(knex.fn.now())
+
+    t.foreign('comment_id').references('id').inTable('comment')
+    t.foreign('actor_id').references('id').inTable('user')
+    t.foreign('comment_author_id').references('id').inTable('user')
+    t.foreign('reviewer_id').references('id').inTable('user')
+    t.index(['comment_id'])
+    t.index(['created_at'])
+    t.index(['actor_id', 'created_at'])
+    t.index(['reason', 'created_at'])
+    t.index(['review_state', 'created_at'])
+    t.index(['content_expires_at'])
+  })
+
+  await knex.raw(`
+    CREATE UNIQUE INDEX ${activeCommentIndex}
+    ON ${table} (comment_id)
+    WHERE action_state = 'active'
+  `)
+}
+
+export const down = async (knex) => {
+  await knex.raw(`DROP INDEX IF EXISTS ${activeCommentIndex}`)
+  await knex('entity_type').where({ table }).del()
+  await knex.schema.dropTable(table)
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -111,6 +111,9 @@ type Mutation {
   """Update a comments' state."""
   updateCommentsState(input: UpdateCommentsStateInput!): [Comment!]!
 
+  """Remove a spam comment as a Community Watch member."""
+  communityWatchRemoveComment(input: CommunityWatchRemoveCommentInput!): Comment!
+
   """Pin a comment."""
   pinComment(input: PinCommentInput!): Comment!
 
@@ -1722,6 +1725,16 @@ input UnvoteCommentInput {
 input UpdateCommentsStateInput {
   ids: [ID!]!
   state: CommentState!
+}
+
+input CommunityWatchRemoveCommentInput {
+  id: ID!
+  reason: CommunityWatchRemoveCommentReason!
+}
+
+enum CommunityWatchRemoveCommentReason {
+  porn_ad
+  spam_ad
 }
 
 """Enums for vote types."""

--- a/src/common/utils/__test__/communityWatchActionMigration.test.ts
+++ b/src/common/utils/__test__/communityWatchActionMigration.test.ts
@@ -1,0 +1,139 @@
+import { pathToFileURL } from 'url'
+
+type Migration = {
+  up: (knex: MockKnex) => Promise<void>
+  down: (knex: MockKnex) => Promise<void>
+}
+
+type MockKnex = {
+  (table: string): {
+    insert: (data: Record<string, string>) => Promise<void>
+    where: (query: Record<string, string>) => {
+      del: () => Promise<void>
+    }
+  }
+  fn: {
+    now: () => Date
+  }
+  raw: (sql: string) => Promise<void>
+  schema: {
+    createTable: (
+      table: string,
+      callback: (tableBuilder: MockTableBuilder) => void
+    ) => Promise<void>
+    dropTable: (table: string) => Promise<void>
+  }
+}
+
+type MockTableBuilder = Record<string, (...args: any[]) => MockTableBuilder>
+
+const migrationUrl = pathToFileURL(
+  `${process.cwd()}/db/migrations/20260510001000_create_community_watch_action_table.js`
+).href
+
+const createTableBuilder = (calls: string[]) => {
+  const builder = new Proxy(
+    {},
+    {
+      get: (_, prop: string) => {
+        if (prop === 'foreign') {
+          return (column: string) => {
+            calls.push(`foreign:${column}`)
+            return builder
+          }
+        }
+        if (['references', 'inTable', 'notNullable', 'unique'].includes(prop)) {
+          return () => builder
+        }
+        return (...args: any[]) => {
+          calls.push(`${prop}:${args[0] ?? ''}`)
+          return builder
+        }
+      },
+    }
+  )
+  return builder as MockTableBuilder
+}
+
+const createKnex = () => {
+  const entityTypeInserts: Array<Record<string, string>> = []
+  const entityTypeDeletes: Array<Record<string, string>> = []
+  const rawCalls: string[] = []
+  const tableCalls: string[] = []
+  const droppedTables: string[] = []
+
+  const knex = ((table: string) => ({
+    insert: async (data: Record<string, string>) => {
+      entityTypeInserts.push(data)
+    },
+    where: (query: Record<string, string>) => ({
+      del: async () => {
+        entityTypeDeletes.push(query)
+      },
+    }),
+  })) as MockKnex
+
+  knex.fn = { now: () => new Date('2026-05-10T00:00:00.000Z') }
+  knex.raw = async (sql: string) => {
+    rawCalls.push(sql)
+  }
+  knex.schema = {
+    createTable: async (table: string, callback) => {
+      tableCalls.push(`create:${table}`)
+      callback(createTableBuilder(tableCalls))
+    },
+    dropTable: async (table: string) => {
+      droppedTables.push(table)
+    },
+  }
+
+  return {
+    knex,
+    entityTypeInserts,
+    entityTypeDeletes,
+    rawCalls,
+    tableCalls,
+    droppedTables,
+  }
+}
+
+describe('community watch action migration', () => {
+  test('creates audit table, indexes, and active comment uniqueness', async () => {
+    const { up } = (await import(migrationUrl)) as Migration
+    const { knex, entityTypeInserts, rawCalls, tableCalls } = createKnex()
+
+    await up(knex)
+
+    expect(entityTypeInserts).toEqual([{ table: 'community_watch_action' }])
+    expect(tableCalls).toEqual(
+      expect.arrayContaining([
+        'create:community_watch_action',
+        'bigIncrements:id',
+        'uuid:uuid',
+        'enu:reason',
+        'timestamp:content_expires_at',
+        'foreign:comment_id',
+        'foreign:actor_id',
+        'index:comment_id',
+      ])
+    )
+    expect(rawCalls).toEqual([
+      expect.stringContaining(
+        'CREATE UNIQUE INDEX community_watch_action_comment_id_active_unique'
+      ),
+    ])
+  })
+
+  test('drops index, entity type, and audit table on rollback', async () => {
+    const { down } = (await import(migrationUrl)) as Migration
+    const { knex, entityTypeDeletes, rawCalls, droppedTables } = createKnex()
+
+    await down(knex)
+
+    expect(rawCalls).toEqual([
+      'DROP INDEX IF EXISTS community_watch_action_comment_id_active_unique',
+    ])
+    expect(entityTypeDeletes).toEqual([{ table: 'community_watch_action' }])
+    expect(droppedTables).toEqual(['community_watch_action'])
+  })
+})

--- a/src/common/utils/__test__/communityWatchRemoveComment.test.ts
+++ b/src/common/utils/__test__/communityWatchRemoveComment.test.ts
@@ -1,0 +1,329 @@
+import type {
+  Comment,
+  GQLCommunityWatchRemoveCommentReason,
+  GQLMutationResolvers,
+} from '#definitions/index.js'
+
+import { jest } from '@jest/globals'
+
+import {
+  COMMENT_STATE,
+  COMMENT_TYPE,
+  NODE_TYPES,
+  OFFICIAL_NOTICE_EXTEND_TYPE,
+  USER_FEATURE_FLAG_TYPE,
+  USER_STATE,
+} from '#common/enums/index.js'
+import { toGlobalId } from '#common/utils/index.js'
+import communityWatchRemoveComment from '#mutations/comment/communityWatchRemoveComment.js'
+
+const mutation = communityWatchRemoveComment as NonNullable<
+  GQLMutationResolvers['communityWatchRemoveComment']
+>
+
+const baseComment: Comment = {
+  id: '101',
+  uuid: 'comment-uuid',
+  authorId: '1',
+  articleId: null,
+  articleVersionId: null,
+  parentCommentId: null,
+  content: '<p>spam</p>',
+  state: COMMENT_STATE.active,
+  pinned: false,
+  quotationStart: null,
+  quotationEnd: null,
+  quotationContent: null,
+  replyTo: null,
+  remark: null,
+  targetId: '11',
+  targetTypeId: '1',
+  type: COMMENT_TYPE.article,
+  pinnedAt: null,
+  spamScore: null,
+  isSpam: null,
+  createdAt: new Date('2026-05-10T00:00:00.000Z'),
+  updatedAt: new Date('2026-05-10T00:00:00.000Z'),
+}
+
+const createContext = ({
+  comment = baseComment,
+  lockedComment = comment,
+  activeAction,
+  featureFlags = [{ type: USER_FEATURE_FLAG_TYPE.communityWatch }],
+  viewerState = USER_STATE.active,
+}: {
+  comment?: Comment
+  lockedComment?: Comment | null
+  activeAction?: { id: string }
+  featureFlags?: Array<{ type: string }>
+  viewerState?: string
+} = {}) => {
+  const insertedActions: any[] = []
+  const commentUpdates: any[] = []
+  const updatedComment = { ...lockedComment, state: COMMENT_STATE.banned }
+
+  const createBuilder = (table: string) => {
+    const builder: any = {
+      select: () => builder,
+      where: () => builder,
+      forUpdate: () => builder,
+      first: async () => {
+        if (table === 'community_watch_action') {
+          return activeAction
+        }
+        if (table === 'comment') {
+          return lockedComment
+        }
+        return undefined
+      },
+      insert: async (data: any) => {
+        insertedActions.push(data)
+      },
+      update: (data: any) => {
+        commentUpdates.push(data)
+        return builder
+      },
+      returning: async () => [updatedComment],
+    }
+    return builder
+  }
+
+  const trx = ((table: string) => createBuilder(table)) as any
+  const context = {
+    viewer: {
+      id: '2',
+      state: viewerState,
+    },
+    dataSources: {
+      atomService: {
+        commentIdLoader: { load: async () => comment },
+        articleIdLoader: {
+          load: async () => ({
+            id: comment.targetId,
+            shortHash: 'article-hash',
+          }),
+        },
+        momentIdLoader: {
+          load: async () => ({
+            id: comment.targetId,
+            shortHash: 'moment-hash',
+          }),
+        },
+      },
+      articleService: {
+        loadLatestArticleVersion: async () => ({ title: 'Article title' }),
+      },
+      userService: {
+        findFeatureFlags: async () => featureFlags,
+      },
+      notificationService: {
+        trigger: jest.fn(),
+      },
+      connections: {
+        knex: {
+          transaction: async (callback: (trx: any) => Promise<any>) =>
+            callback(trx),
+        },
+        redis: {
+          smembers: async () => [],
+        },
+      },
+    },
+  } as any
+
+  return { context, insertedActions, commentUpdates }
+}
+
+const removeComment = (
+  context: any,
+  id = baseComment.id,
+  reason: GQLCommunityWatchRemoveCommentReason = 'porn_ad'
+) =>
+  mutation(
+    {},
+    {
+      input: {
+        id: toGlobalId({ type: NODE_TYPES.Comment, id }),
+        reason,
+      },
+    },
+    context,
+    {} as any
+  )
+
+describe('communityWatchRemoveComment', () => {
+  test('removes an article comment and writes an audit action', async () => {
+    const { context, insertedActions, commentUpdates } = createContext()
+
+    const result = await mutation(
+      {},
+      {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.Comment, id: baseComment.id }),
+          reason: 'porn_ad',
+        },
+      },
+      context,
+      {} as any
+    )
+
+    expect(result.state).toBe(COMMENT_STATE.banned)
+    expect(commentUpdates).toEqual([
+      expect.objectContaining({ state: COMMENT_STATE.banned }),
+    ])
+    expect(insertedActions[0]).toEqual(
+      expect.objectContaining({
+        commentId: baseComment.id,
+        commentType: COMMENT_TYPE.article,
+        targetType: COMMENT_TYPE.article,
+        targetTitle: 'Article title',
+        targetShortHash: 'article-hash',
+        reason: 'porn_ad',
+        actorId: '2',
+        commentAuthorId: '1',
+        originalContent: '<p>spam</p>',
+        originalState: COMMENT_STATE.active,
+      })
+    )
+    expect(insertedActions[0].contentExpiresAt.getTime()).toBeGreaterThan(
+      insertedActions[0].createdAt.getTime()
+    )
+    expect(
+      context.dataSources.notificationService.trigger
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: OFFICIAL_NOTICE_EXTEND_TYPE.comment_banned,
+        recipientId: baseComment.authorId,
+      })
+    )
+  })
+
+  test('removes a moment comment without an article title', async () => {
+    const comment = {
+      ...baseComment,
+      type: COMMENT_TYPE.moment,
+      targetId: '12',
+    }
+    const { context, insertedActions } = createContext({ comment })
+
+    await mutation(
+      {},
+      {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.Comment, id: comment.id }),
+          reason: 'spam_ad',
+        },
+      },
+      context,
+      {} as any
+    )
+
+    expect(insertedActions[0]).toEqual(
+      expect.objectContaining({
+        commentType: COMMENT_TYPE.moment,
+        targetType: COMMENT_TYPE.moment,
+        targetTitle: null,
+        targetShortHash: 'moment-hash',
+        reason: 'spam_ad',
+      })
+    )
+  })
+
+  test('rejects users without the communityWatch feature flag', async () => {
+    const { context } = createContext({ featureFlags: [] })
+
+    await expect(removeComment(context)).rejects.toHaveProperty(
+      'extensions.code',
+      'FORBIDDEN'
+    )
+  })
+
+  test('rejects archived users before loading the comment', async () => {
+    const { context } = createContext({ viewerState: USER_STATE.archived })
+
+    await expect(removeComment(context)).rejects.toHaveProperty(
+      'extensions.code',
+      'FORBIDDEN_BY_STATE'
+    )
+  })
+
+  test('rejects non-comment targets', async () => {
+    const { context } = createContext()
+
+    await expect(
+      mutation(
+        {},
+        {
+          input: {
+            id: toGlobalId({ type: NODE_TYPES.Article, id: '1' }),
+            reason: 'porn_ad',
+          },
+        },
+        context,
+        {} as any
+      )
+    ).rejects.toHaveProperty('extensions.code', 'BAD_USER_INPUT')
+  })
+
+  test('rejects circle comments before changing state', async () => {
+    const circleComment = {
+      ...baseComment,
+      type: COMMENT_TYPE.circleDiscussion,
+    }
+    const { context, commentUpdates } = createContext({
+      comment: circleComment,
+    })
+
+    await expect(removeComment(context)).rejects.toHaveProperty(
+      'extensions.code',
+      'BAD_USER_INPUT'
+    )
+    expect(commentUpdates).toHaveLength(0)
+  })
+
+  test('rejects comments that already have an active audit action', async () => {
+    const { context } = createContext({ activeAction: { id: '1' } })
+
+    await expect(
+      removeComment(context, baseComment.id, 'spam_ad')
+    ).rejects.toHaveProperty('extensions.code', 'BAD_USER_INPUT')
+  })
+
+  test('rejects comments missing during the locked update', async () => {
+    const { context } = createContext({ lockedComment: null })
+
+    await expect(removeComment(context)).rejects.toHaveProperty(
+      'extensions.code',
+      'COMMENT_NOT_FOUND'
+    )
+  })
+
+  test('rejects unsupported locked comment types', async () => {
+    const { context } = createContext({
+      lockedComment: {
+        ...baseComment,
+        type: COMMENT_TYPE.circleBroadcast,
+      },
+    })
+
+    await expect(removeComment(context)).rejects.toHaveProperty(
+      'extensions.code',
+      'BAD_USER_INPUT'
+    )
+  })
+
+  test('rejects locked comments that are no longer removable', async () => {
+    const { context } = createContext({
+      lockedComment: {
+        ...baseComment,
+        state: COMMENT_STATE.banned,
+      },
+    })
+
+    await expect(removeComment(context)).rejects.toHaveProperty(
+      'extensions.code',
+      'BAD_USER_INPUT'
+    )
+  })
+})

--- a/src/definitions/communityWatch.d.ts
+++ b/src/definitions/communityWatch.d.ts
@@ -1,0 +1,36 @@
+import type { COMMENT_STATE } from '#common/enums/index.js'
+import type { ValueOf } from './generic.js'
+
+export type CommunityWatchActionReason = 'porn_ad' | 'spam_ad'
+export type CommunityWatchActionState = 'active' | 'restored' | 'voided'
+export type CommunityWatchAppealState = 'none' | 'received' | 'resolved'
+export type CommunityWatchReviewState =
+  | 'pending'
+  | 'upheld'
+  | 'reversed'
+  | 'reason_adjusted'
+
+export interface CommunityWatchAction {
+  id: string
+  uuid: string
+  commentId: string
+  commentType: 'article' | 'moment'
+  targetType: 'article' | 'moment'
+  targetId: string
+  targetTitle: string | null
+  targetShortHash: string | null
+  reason: CommunityWatchActionReason
+  actorId: string
+  commentAuthorId: string | null
+  originalContent: string | null
+  originalState: ValueOf<typeof COMMENT_STATE>
+  actionState: CommunityWatchActionState
+  appealState: CommunityWatchAppealState
+  reviewState: CommunityWatchReviewState
+  reviewerId: string | null
+  reviewNote: string | null
+  reviewedAt: Date | null
+  contentExpiresAt: Date
+  createdAt: Date
+  updatedAt: Date
+}

--- a/src/definitions/index.d.ts
+++ b/src/definitions/index.d.ts
@@ -89,6 +89,7 @@ import type {
 } from './circle.js'
 import type { Collection, CollectionArticle } from './collection.js'
 import type { Comment, FeaturedCommentMaterialized } from './comment.js'
+import type { CommunityWatchAction } from './communityWatch.js'
 import type { Draft } from './draft.js'
 import type { TopicChannelFeedback } from './feedback.ts'
 import type {
@@ -149,6 +150,7 @@ export * from './tag.js'
 export * from './circle.js'
 export * from './collection.js'
 export * from './comment.js'
+export * from './communityWatch.js'
 export * from './language.js'
 export * from './notification.js'
 export * from './generic.js'
@@ -264,6 +266,7 @@ export interface TableTypeMap {
   collection: Collection
   collection_article: CollectionArticle
   comment: Comment
+  community_watch_action: CommunityWatchAction
   crypto_wallet: CryptoWallet
   crypto_wallet_signature: CryptoWalletSignature
   customer: Customer

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -1437,6 +1437,13 @@ export type GQLCommentsInput = {
   sort?: InputMaybe<GQLCommentSort>
 }
 
+export type GQLCommunityWatchRemoveCommentInput = {
+  id: Scalars['ID']['input']
+  reason: GQLCommunityWatchRemoveCommentReason
+}
+
+export type GQLCommunityWatchRemoveCommentReason = 'porn_ad' | 'spam_ad'
+
 export type GQLConfirmVerificationCodeInput = {
   code: Scalars['String']['input']
   email: Scalars['String']['input']
@@ -2084,6 +2091,8 @@ export type GQLMutation = {
   clearReadHistory: GQLUser
   /** Clear search history for user. */
   clearSearchHistory?: Maybe<Scalars['Boolean']['output']>
+  /** Remove a spam comment as a Community Watch member. */
+  communityWatchRemoveComment: GQLComment
   /** Confirm verification code from email. */
   confirmVerificationCode: Scalars['ID']['output']
   /** Create Stripe Connect account for Payout */
@@ -2305,6 +2314,10 @@ export type GQLMutationClassifyArticlesChannelsArgs = {
 
 export type GQLMutationClearReadHistoryArgs = {
   input: GQLClearReadHistoryInput
+}
+
+export type GQLMutationCommunityWatchRemoveCommentArgs = {
+  input: GQLCommunityWatchRemoveCommentInput
 }
 
 export type GQLMutationConfirmVerificationCodeArgs = {
@@ -5340,6 +5353,8 @@ export type GQLResolversTypes = ResolversObject<{
   CommentType: GQLCommentType
   CommentsFilter: GQLCommentsFilter
   CommentsInput: GQLCommentsInput
+  CommunityWatchRemoveCommentInput: GQLCommunityWatchRemoveCommentInput
+  CommunityWatchRemoveCommentReason: GQLCommunityWatchRemoveCommentReason
   ConfirmVerificationCodeInput: GQLConfirmVerificationCodeInput
   ConnectStripeAccountInput: GQLConnectStripeAccountInput
   ConnectStripeAccountResult: ResolverTypeWrapper<GQLConnectStripeAccountResult>
@@ -6050,6 +6065,7 @@ export type GQLResolversParentTypes = ResolversObject<{
   CommentNotice: NoticeItemModel
   CommentsFilter: GQLCommentsFilter
   CommentsInput: GQLCommentsInput
+  CommunityWatchRemoveCommentInput: GQLCommunityWatchRemoveCommentInput
   ConfirmVerificationCodeInput: GQLConfirmVerificationCodeInput
   ConnectStripeAccountInput: GQLConnectStripeAccountInput
   ConnectStripeAccountResult: GQLConnectStripeAccountResult
@@ -8678,6 +8694,12 @@ export type GQLMutationResolvers<
     Maybe<GQLResolversTypes['Boolean']>,
     ParentType,
     ContextType
+  >
+  communityWatchRemoveComment?: Resolver<
+    GQLResolversTypes['Comment'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationCommunityWatchRemoveCommentArgs, 'input'>
   >
   confirmVerificationCode?: Resolver<
     GQLResolversTypes['ID'],

--- a/src/mutations/comment/communityWatchRemoveComment.ts
+++ b/src/mutations/comment/communityWatchRemoveComment.ts
@@ -1,0 +1,179 @@
+import type {
+  Comment,
+  Context,
+  GQLMutationResolvers,
+} from '#definitions/index.js'
+import type { GlobalId } from '#definitions/nominal.js'
+import type { Knex } from 'knex'
+
+import {
+  COMMENT_STATE,
+  COMMENT_TYPE,
+  NODE_TYPES,
+  OFFICIAL_NOTICE_EXTEND_TYPE,
+  USER_FEATURE_FLAG_TYPE,
+  USER_STATE,
+} from '#common/enums/index.js'
+import {
+  CommentNotFoundError,
+  ForbiddenByStateError,
+  ForbiddenError,
+  UserInputError,
+} from '#common/errors.js'
+import { fromGlobalId } from '#common/utils/index.js'
+import { invalidateFQC } from '@matters/apollo-response-cache'
+import { v4 } from 'uuid'
+
+const ORIGINAL_CONTENT_RETENTION_DAYS = 7
+
+const allowedCommentStates = [COMMENT_STATE.active, COMMENT_STATE.collapsed]
+const allowedCommentTypes = [COMMENT_TYPE.article, COMMENT_TYPE.moment]
+
+type CommunityWatchRemoveCommentReason = 'porn_ad' | 'spam_ad'
+
+const resolver = async (
+  _: unknown,
+  {
+    input: { id: globalId, reason },
+  }: {
+    input: { id: GlobalId; reason: CommunityWatchRemoveCommentReason }
+  },
+  {
+    viewer,
+    dataSources: {
+      atomService,
+      articleService,
+      userService,
+      notificationService,
+      connections,
+    },
+  }: Context
+) => {
+  if (
+    [USER_STATE.archived, USER_STATE.banned, USER_STATE.frozen].includes(
+      viewer.state
+    )
+  ) {
+    throw new ForbiddenByStateError(`${viewer.state} user has no permission`)
+  }
+
+  const featureFlags = await userService.findFeatureFlags(viewer.id)
+  const isCommunityWatch = featureFlags
+    .map(({ type: featureFlagType }) => featureFlagType)
+    .includes(USER_FEATURE_FLAG_TYPE.communityWatch)
+  if (!isCommunityWatch) {
+    throw new ForbiddenError('viewer is not a Community Watch member')
+  }
+
+  const { type: targetType, id: commentId } = fromGlobalId(globalId)
+  if (targetType !== NODE_TYPES.Comment) {
+    throw new UserInputError('target must be a comment')
+  }
+
+  const comment = await atomService.commentIdLoader.load(commentId)
+  if (!allowedCommentTypes.includes(comment.type)) {
+    throw new UserInputError(
+      'Community Watch can only remove article and moment comments'
+    )
+  }
+
+  const target =
+    comment.type === COMMENT_TYPE.article
+      ? await atomService.articleIdLoader.load(comment.targetId)
+      : await atomService.momentIdLoader.load(comment.targetId)
+  const articleVersion =
+    comment.type === COMMENT_TYPE.article
+      ? await articleService.loadLatestArticleVersion(comment.targetId)
+      : undefined
+
+  const now = new Date()
+  const contentExpiresAt = new Date(now)
+  contentExpiresAt.setDate(
+    contentExpiresAt.getDate() + ORIGINAL_CONTENT_RETENTION_DAYS
+  )
+
+  const updatedComment = await connections.knex.transaction(
+    async (trx: Knex.Transaction) => {
+      const activeAction = await trx('community_watch_action')
+        .select('id')
+        .where({ commentId, actionState: 'active' })
+        .first()
+      if (activeAction) {
+        throw new UserInputError(
+          'comment already has an active Community Watch action'
+        )
+      }
+
+      const freshComment = await trx<Comment>('comment')
+        .select()
+        .where({ id: commentId })
+        .forUpdate()
+        .first()
+      if (!freshComment) {
+        throw new CommentNotFoundError('comment not found')
+      }
+      if (!allowedCommentTypes.includes(freshComment.type)) {
+        throw new UserInputError(
+          'Community Watch can only remove article and moment comments'
+        )
+      }
+      if (!allowedCommentStates.includes(freshComment.state)) {
+        throw new UserInputError('comment is not removable by Community Watch')
+      }
+
+      await trx('community_watch_action').insert({
+        uuid: v4(),
+        commentId: freshComment.id,
+        commentType: freshComment.type,
+        targetType: freshComment.type,
+        targetId: freshComment.targetId,
+        targetTitle:
+          freshComment.type === COMMENT_TYPE.article
+            ? articleVersion?.title || null
+            : null,
+        targetShortHash: 'shortHash' in target ? target.shortHash : null,
+        reason,
+        actorId: viewer.id,
+        commentAuthorId: freshComment.authorId,
+        originalContent: freshComment.content,
+        originalState: freshComment.state,
+        contentExpiresAt,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      const [newComment] = await trx('comment')
+        .where({ id: freshComment.id })
+        .update({
+          state: COMMENT_STATE.banned,
+          updatedAt: now,
+        })
+        .returning('*')
+
+      return newComment
+    }
+  )
+
+  notificationService.trigger({
+    event: OFFICIAL_NOTICE_EXTEND_TYPE.comment_banned,
+    entities: [
+      { type: 'target', entityTable: 'comment', entity: updatedComment },
+    ],
+    recipientId: updatedComment.authorId,
+  })
+
+  await invalidateFQC({
+    node: {
+      id: updatedComment.targetId,
+      type:
+        updatedComment.type === COMMENT_TYPE.article
+          ? NODE_TYPES.Article
+          : NODE_TYPES.Moment,
+    },
+    redis: connections.redis,
+  })
+
+  return updatedComment
+}
+
+export default resolver as GQLMutationResolvers['communityWatchRemoveComment']

--- a/src/mutations/comment/index.ts
+++ b/src/mutations/comment/index.ts
@@ -1,3 +1,4 @@
+import communityWatchRemoveComment from './communityWatchRemoveComment.js'
 import deleteComment from './deleteComment.js'
 import pinComment from './pinComment.js'
 import putComment from './putComment.js'
@@ -17,5 +18,6 @@ export default {
     unvoteComment,
     updateCommentsState,
     togglePinComment,
+    communityWatchRemoveComment,
   },
 }

--- a/src/types/__test__/2/comment.test.ts
+++ b/src/types/__test__/2/comment.test.ts
@@ -4,7 +4,14 @@ import type { Connections } from '#definitions/index.js'
 import _get from 'lodash/get.js'
 import { jest } from '@jest/globals'
 
-import { NODE_TYPES, NOTICE_TYPE, COMMENT_STATE } from '#common/enums/index.js'
+import {
+  COMMENT_STATE,
+  COMMENT_TYPE,
+  NODE_TYPES,
+  NOTICE_TYPE,
+  OFFICIAL_NOTICE_EXTEND_TYPE,
+  USER_FEATURE_FLAG_TYPE,
+} from '#common/enums/index.js'
 import {
   AtomService,
   CommentService,
@@ -58,6 +65,14 @@ const PUT_COMMENT = /* GraphQL */ `
 const DELETE_COMMENT = /* GraphQL */ `
   mutation ($input: DeleteCommentInput!) {
     deleteComment(input: $input) {
+      state
+    }
+  }
+`
+
+const COMMUNITY_WATCH_REMOVE_COMMENT = /* GraphQL */ `
+  mutation ($input: CommunityWatchRemoveCommentInput!) {
+    communityWatchRemoveComment(input: $input) {
       state
     }
   }
@@ -495,6 +510,89 @@ describe('delete commment', () => {
       },
     })
     expect(dataDeleted.deleteComment.state).toBe('archived')
+  })
+})
+
+describe('community watch remove comment', () => {
+  test('remove an article comment and write audit evidence', async () => {
+    const watcher = await userService.create({
+      userName: `watcher${uuidv4().replace(/-/g, '').slice(0, 12)}`,
+    })
+    await atomService.create({
+      table: 'user_feature_flag',
+      data: {
+        userId: watcher.id,
+        type: USER_FEATURE_FLAG_TYPE.communityWatch,
+      },
+    })
+
+    const article = await atomService.articleIdLoader.load('1')
+    const { id: targetTypeId } = await atomService.findFirst({
+      table: 'entity_type',
+      where: { table: 'article' },
+    })
+    const comment = await atomService.create({
+      table: 'comment',
+      data: {
+        uuid: uuidv4(),
+        content: '<p>spam ad</p>',
+        authorId: '2',
+        targetId: article.id,
+        targetTypeId,
+        parentCommentId: null,
+        type: COMMENT_TYPE.article,
+        state: COMMENT_STATE.active,
+      },
+    })
+    const mockTrigger = jest.fn()
+    const server = await testClient({
+      userId: watcher.id,
+      isAuth: true,
+      connections,
+      dataSources: { notificationService: { trigger: mockTrigger } },
+    })
+
+    const { errors, data } = await server.executeOperation({
+      query: COMMUNITY_WATCH_REMOVE_COMMENT,
+      variables: {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.Comment, id: comment.id }),
+          reason: 'spam_ad',
+        },
+      },
+    })
+
+    expect(errors).toBeUndefined()
+    expect(data.communityWatchRemoveComment.state).toBe(COMMENT_STATE.banned)
+
+    const auditAction = await atomService.findFirst({
+      table: 'community_watch_action',
+      where: { commentId: comment.id },
+    })
+    expect(auditAction).toMatchObject({
+      commentId: comment.id,
+      commentType: COMMENT_TYPE.article,
+      targetType: COMMENT_TYPE.article,
+      targetId: article.id,
+      targetShortHash: article.shortHash,
+      reason: 'spam_ad',
+      actorId: watcher.id,
+      commentAuthorId: '2',
+      originalContent: '<p>spam ad</p>',
+      originalState: COMMENT_STATE.active,
+      actionState: 'active',
+      appealState: 'none',
+      reviewState: 'pending',
+    })
+    expect(auditAction.contentExpiresAt.getTime()).toBeGreaterThan(
+      auditAction.createdAt.getTime()
+    )
+    expect(mockTrigger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: OFFICIAL_NOTICE_EXTEND_TYPE.comment_banned,
+        recipientId: '2',
+      })
+    )
   })
 })
 

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -23,6 +23,9 @@ export default /* GraphQL */ `
     "Update a comments' state."
     updateCommentsState(input: UpdateCommentsStateInput!): [Comment!]! @complexity(value: 10, multipliers: ["input.ids"]) @auth(mode: "${AUTH_MODE.oauth}", group: "${SCOPE_GROUP.level2}") @purgeCache(type: "${NODE_TYPES.Comment}")
 
+    "Remove a spam comment as a Community Watch member."
+    communityWatchRemoveComment(input: CommunityWatchRemoveCommentInput!): Comment! @auth(mode: "${AUTH_MODE.oauth}", group: "${SCOPE_GROUP.level2}") @purgeCache(type: "${NODE_TYPES.Comment}")
+
 
     ##############
     # DEPRECATED #
@@ -213,6 +216,16 @@ export default /* GraphQL */ `
   input UpdateCommentsStateInput {
     ids: [ID!]!
     state: CommentState!
+  }
+
+  input CommunityWatchRemoveCommentInput {
+    id: ID!
+    reason: CommunityWatchRemoveCommentReason!
+  }
+
+  enum CommunityWatchRemoveCommentReason {
+    porn_ad
+    spam_ad
   }
 
   "Enums for vote types."


### PR DESCRIPTION
## Summary
- add the `community_watch_action` audit table for Community Watch comment removals, with 7-day `original_content` retention metadata
- add `communityWatchRemoveComment` GraphQL mutation gated by the `communityWatch` feature flag
- limit the mutation to article and moment comments, mark accepted comments as existing `banned` state, write audit evidence, notify the author, and invalidate article/moment cache
- cover migration rollback and resolver success/error paths

## Stack
This is stacked on #4762 / `codex/community-watch-phase1`. Base is `codex/community-watch-phase1` until Phase 1 is merged.

## Verification
- `git diff --check`
- `npm run lint`
- `npm run build`
- `MATTERS_ENV=test node --experimental-vm-modules node_modules/.bin/jest build/common/utils/__test__/communityWatchActionMigration.test.js build/common/utils/__test__/communityWatchRemoveComment.test.js --runInBand --forceExit`

## Notes
- `npm run test:utils` still does not run cleanly in this local Node 24 environment because the repo script passes `--no-experimental-fetch`; running the equivalent targeted Jest command without that flag passes.
- A broader manual `build/common/utils/` Jest run also hits existing local date and DB connection failures outside this patch; the two new Community Watch test suites pass.
