### PR TITLE
Expose Community Watch action on comments

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1606,6 +1606,11 @@ type Comment implements Node {
   """Content of this comment."""
   content: String
 
+  """
+  Community Watch audit action when this comment was removed by Community Watch.
+  """
+  communityWatchAction: CommunityWatchAction
+
   """Author of this comment."""
   author: User!
 
@@ -1735,6 +1740,13 @@ input CommunityWatchRemoveCommentInput {
 enum CommunityWatchRemoveCommentReason {
   porn_ad
   spam_ad
+}
+
+type CommunityWatchAction {
+  """Public identifier used by the Community Watch transparency page."""
+  uuid: ID!
+  reason: CommunityWatchRemoveCommentReason!
+  createdAt: DateTime!
 }
 
 """Enums for vote types."""

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -1301,6 +1301,8 @@ export type GQLComment = GQLNode & {
   author: GQLUser
   /** Descendant comments of this comment. */
   comments: GQLCommentConnection
+  /** Community Watch audit action when this comment was removed by Community Watch. */
+  communityWatchAction?: Maybe<GQLCommunityWatchAction>
   /** Content of this comment. */
   content?: Maybe<Scalars['String']['output']>
   /** Time of this comment was created. */
@@ -1435,6 +1437,14 @@ export type GQLCommentsInput = {
   includeAfter?: InputMaybe<Scalars['Boolean']['input']>
   includeBefore?: InputMaybe<Scalars['Boolean']['input']>
   sort?: InputMaybe<GQLCommentSort>
+}
+
+export type GQLCommunityWatchAction = {
+  __typename?: 'CommunityWatchAction'
+  createdAt: Scalars['DateTime']['output']
+  reason: GQLCommunityWatchRemoveCommentReason
+  /** Public identifier used by the Community Watch transparency page. */
+  uuid: Scalars['ID']['output']
 }
 
 export type GQLCommunityWatchRemoveCommentInput = {
@@ -5353,6 +5363,7 @@ export type GQLResolversTypes = ResolversObject<{
   CommentType: GQLCommentType
   CommentsFilter: GQLCommentsFilter
   CommentsInput: GQLCommentsInput
+  CommunityWatchAction: ResolverTypeWrapper<GQLCommunityWatchAction>
   CommunityWatchRemoveCommentInput: GQLCommunityWatchRemoveCommentInput
   CommunityWatchRemoveCommentReason: GQLCommunityWatchRemoveCommentReason
   ConfirmVerificationCodeInput: GQLConfirmVerificationCodeInput
@@ -6065,6 +6076,7 @@ export type GQLResolversParentTypes = ResolversObject<{
   CommentNotice: NoticeItemModel
   CommentsFilter: GQLCommentsFilter
   CommentsInput: GQLCommentsInput
+  CommunityWatchAction: GQLCommunityWatchAction
   CommunityWatchRemoveCommentInput: GQLCommunityWatchRemoveCommentInput
   ConfirmVerificationCodeInput: GQLConfirmVerificationCodeInput
   ConnectStripeAccountInput: GQLConnectStripeAccountInput
@@ -7861,6 +7873,11 @@ export type GQLCommentResolvers<
     ContextType,
     RequireFields<GQLCommentCommentsArgs, 'input'>
   >
+  communityWatchAction?: Resolver<
+    Maybe<GQLResolversTypes['CommunityWatchAction']>,
+    ParentType,
+    ContextType
+  >
   content?: Resolver<
     Maybe<GQLResolversTypes['String']>,
     ParentType,
@@ -7958,6 +7975,20 @@ export type GQLCommentNoticeResolvers<
     ContextType
   >
   unread?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCommunityWatchActionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CommunityWatchAction'] = GQLResolversParentTypes['CommunityWatchAction']
+> = ResolversObject<{
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  reason?: Resolver<
+    GQLResolversTypes['CommunityWatchRemoveCommentReason'],
+    ParentType,
+    ContextType
+  >
+  uuid?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }>
 
@@ -11293,6 +11324,7 @@ export type GQLResolvers<ContextType = Context> = ResolversObject<{
   CommentConnection?: GQLCommentConnectionResolvers<ContextType>
   CommentEdge?: GQLCommentEdgeResolvers<ContextType>
   CommentNotice?: GQLCommentNoticeResolvers<ContextType>
+  CommunityWatchAction?: GQLCommunityWatchActionResolvers<ContextType>
   ConnectStripeAccountResult?: GQLConnectStripeAccountResultResolvers<ContextType>
   Connection?: GQLConnectionResolvers<ContextType>
   CryptoWallet?: GQLCryptoWalletResolvers<ContextType>

--- a/src/queries/comment/communityWatchAction.ts
+++ b/src/queries/comment/communityWatchAction.ts
@@ -1,0 +1,21 @@
+import type {
+  Comment,
+  Context,
+  GQLCommentResolvers,
+} from '#definitions/index.js'
+
+const resolver: GQLCommentResolvers['communityWatchAction'] = (
+  { id }: Comment,
+  _: unknown,
+  {
+    dataSources: {
+      connections: { knex },
+    },
+  }: Context
+) =>
+  knex('community_watch_action')
+    .select('uuid', 'reason', 'createdAt')
+    .where({ commentId: id, actionState: 'active' })
+    .first()
+
+export default resolver

--- a/src/queries/comment/index.ts
+++ b/src/queries/comment/index.ts
@@ -17,6 +17,7 @@ import circleDiscussionCount from './circle/discussionCount.js'
 import circleDiscussionThreadCount from './circle/discussionThreadCount.js'
 import circlePinnedBroadcast from './circle/pinnedBroadcast.js'
 import comments from './comments.js'
+import communityWatchAction from './communityWatchAction.js'
 import content from './content.js'
 import downvotes from './downvotes.js'
 import fromDonator from './fromDonator.js'
@@ -44,6 +45,7 @@ export default {
     id: ({ id }: { id: string }) =>
       toGlobalId({ type: NODE_TYPES.Comment, id }),
     replyTo,
+    communityWatchAction,
     content,
     author,
     upvotes,

--- a/src/types/__test__/2/comment.test.ts
+++ b/src/types/__test__/2/comment.test.ts
@@ -74,6 +74,11 @@ const COMMUNITY_WATCH_REMOVE_COMMENT = /* GraphQL */ `
   mutation ($input: CommunityWatchRemoveCommentInput!) {
     communityWatchRemoveComment(input: $input) {
       state
+      communityWatchAction {
+        uuid
+        reason
+        createdAt
+      }
     }
   }
 `
@@ -564,11 +569,19 @@ describe('community watch remove comment', () => {
 
     expect(errors).toBeUndefined()
     expect(data.communityWatchRemoveComment.state).toBe(COMMENT_STATE.banned)
+    expect(data.communityWatchRemoveComment.communityWatchAction).toEqual({
+      uuid: expect.any(String),
+      reason: 'spam_ad',
+      createdAt: expect.anything(),
+    })
 
     const auditAction = await atomService.findFirst({
       table: 'community_watch_action',
       where: { commentId: comment.id },
     })
+    expect(data.communityWatchRemoveComment.communityWatchAction.uuid).toBe(
+      auditAction.uuid
+    )
     expect(auditAction).toMatchObject({
       commentId: comment.id,
       commentType: COMMENT_TYPE.article,

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -55,6 +55,9 @@ export default /* GraphQL */ `
     "Content of this comment."
     content: String
 
+    "Community Watch audit action when this comment was removed by Community Watch."
+    communityWatchAction: CommunityWatchAction
+
     "Author of this comment."
     author: User! @logCache(type: "${NODE_TYPES.User}")
 
@@ -226,6 +229,13 @@ export default /* GraphQL */ `
   enum CommunityWatchRemoveCommentReason {
     porn_ad
     spam_ad
+  }
+
+  type CommunityWatchAction {
+    "Public identifier used by the Community Watch transparency page."
+    uuid: ID!
+    reason: CommunityWatchRemoveCommentReason!
+    createdAt: DateTime!
   }
 
   "Enums for vote types."


### PR DESCRIPTION
## Summary
- expose active Community Watch audit action on Comment.communityWatchAction
- return the public audit UUID, reason, and time needed by the web placeholder link
- cover the field in the existing Community Watch mutation GraphQL test

## Verification
- npm run build
- npm run lint
- MATTERS_ENV=test node --experimental-vm-modules node_modules/.bin/jest build/common/utils/__test__/communityWatchActionMigration.test.js build/common/utils/__test__/communityWatchRemoveComment.test.js --runInBand --forceExit

## Stack
- Base: codex/community-watch-phase1, which already contains Phase 2 via #4763.
- Web Phase 3 depends on this schema being available in the GraphQL endpoint used by matters-web codegen.