### PR TITLE
Add Community Watch public audit queries

### DIFF
--- a/codegen.json
+++ b/codegen.json
@@ -33,6 +33,7 @@
           "TagOSS": "./tag.js#Tag",
           "Collection": "./collection.js#Collection",
           "Comment": "./comment.js#Comment",
+          "CommunityWatchAction": "./communityWatch.js#CommunityWatchAction",
           "Article": "./article.js#Article",
           "ArticleAccess": "./article.js#Article",
           "ArticleOSS": "./article.js#Article",

--- a/schema.graphql
+++ b/schema.graphql
@@ -23,6 +23,12 @@ type Query {
   campaigns(input: CampaignsInput!): CampaignConnection!
   campaignOrganizers(input: ConnectionArgs!): UserConnection!
   circle(input: CircleInput!): Circle
+
+  """Recent public Community Watch audit records."""
+  communityWatchActions(input: CommunityWatchActionsInput!): CommunityWatchActionConnection!
+
+  """One public Community Watch audit record."""
+  communityWatchAction(input: CommunityWatchActionInput!): CommunityWatchAction
   node(input: NodeInput!): Node
   nodes(input: NodesInput!): [Node!]
   frequentSearch(input: FrequentSearchInput!): [String!]
@@ -1737,16 +1743,74 @@ input CommunityWatchRemoveCommentInput {
   reason: CommunityWatchRemoveCommentReason!
 }
 
+input CommunityWatchActionsInput {
+  after: String
+  first: Int
+  reason: CommunityWatchRemoveCommentReason
+  actionState: CommunityWatchActionState
+  appealState: CommunityWatchAppealState
+  reviewState: CommunityWatchReviewState
+}
+
+input CommunityWatchActionInput {
+  uuid: ID!
+}
+
 enum CommunityWatchRemoveCommentReason {
   porn_ad
   spam_ad
 }
 
+enum CommunityWatchActionSourceType {
+  article
+  moment
+}
+
+enum CommunityWatchActionState {
+  active
+  restored
+  voided
+}
+
+enum CommunityWatchAppealState {
+  none
+  received
+  resolved
+}
+
+enum CommunityWatchReviewState {
+  pending
+  upheld
+  reversed
+  reason_adjusted
+}
+
 type CommunityWatchAction {
   """Public identifier used by the Community Watch transparency page."""
   uuid: ID!
+  commentId: ID!
+  sourceType: CommunityWatchActionSourceType!
+  sourceTitle: String!
+  sourceId: ID!
+  actorDisplayName: String!
   reason: CommunityWatchRemoveCommentReason!
+  actionState: CommunityWatchActionState!
+  appealState: CommunityWatchAppealState!
+  reviewState: CommunityWatchReviewState!
+  originalContent: String
+  contentCleared: Boolean!
   createdAt: DateTime!
+}
+
+type CommunityWatchActionConnection implements Connection {
+  totalCount: Int!
+  pageInfo: PageInfo!
+  edges: [CommunityWatchActionEdge!]
+}
+
+type CommunityWatchActionEdge {
+  cursor: String!
+  node: CommunityWatchAction!
 }
 
 """Enums for vote types."""

--- a/src/common/utils/__test__/communityWatchPublicQueries.test.ts
+++ b/src/common/utils/__test__/communityWatchPublicQueries.test.ts
@@ -1,0 +1,201 @@
+import type { CommunityWatchAction } from '#definitions/index.js'
+
+import { NODE_TYPES } from '#common/enums/index.js'
+import { toGlobalId } from '#common/utils/index.js'
+import communityWatchActionPublic from '#queries/comment/communityWatchActionPublic.js'
+import communityWatchActionsResolver from '#queries/comment/communityWatchActions.js'
+import rootCommunityWatchActionResolver from '#queries/comment/rootCommunityWatchAction.js'
+
+const communityWatchActions = communityWatchActionsResolver as any
+const rootCommunityWatchAction = rootCommunityWatchActionResolver as any
+
+const actions: CommunityWatchAction[] = [
+  {
+    id: '2',
+    uuid: 'action-2',
+    commentId: '102',
+    commentType: 'moment',
+    targetType: 'moment',
+    targetId: '202',
+    targetTitle: null,
+    targetShortHash: 'moment-hash',
+    reason: 'spam_ad',
+    actorId: '2',
+    commentAuthorId: '8',
+    originalContent: null,
+    originalState: 'active',
+    actionState: 'active',
+    appealState: 'none',
+    reviewState: 'pending',
+    reviewerId: null,
+    reviewNote: null,
+    reviewedAt: null,
+    contentExpiresAt: new Date('2026-05-17T00:00:00.000Z'),
+    createdAt: new Date('2026-05-11T00:00:00.000Z'),
+    updatedAt: new Date('2026-05-11T00:00:00.000Z'),
+  },
+  {
+    id: '1',
+    uuid: 'action-1',
+    commentId: '101',
+    commentType: 'article',
+    targetType: 'article',
+    targetId: '201',
+    targetTitle: 'Article title',
+    targetShortHash: 'article-hash',
+    reason: 'porn_ad',
+    actorId: '1',
+    commentAuthorId: '7',
+    originalContent: '<p>spam</p>',
+    originalState: 'collapsed',
+    actionState: 'active',
+    appealState: 'received',
+    reviewState: 'upheld',
+    reviewerId: '9',
+    reviewNote: null,
+    reviewedAt: new Date('2026-05-12T00:00:00.000Z'),
+    contentExpiresAt: new Date('2026-05-17T00:00:00.000Z'),
+    createdAt: new Date('2026-05-10T00:00:00.000Z'),
+    updatedAt: new Date('2026-05-12T00:00:00.000Z'),
+  },
+]
+
+const createKnex = (rows: CommunityWatchAction[]) => {
+  const createBuilder = (
+    filters: Record<string, string> = {},
+    isCount = false,
+    offset = 0
+  ) => {
+    const filtered = () =>
+      rows.filter((row) =>
+        Object.entries(filters).every(
+          ([key, value]) => row[key as keyof CommunityWatchAction] === value
+        )
+      )
+
+    const builder: any = {
+      select: () => builder,
+      where: (filter: Record<string, string>) => {
+        Object.assign(filters, filter)
+        return builder
+      },
+      clone: () => createBuilder({ ...filters }, isCount, offset),
+      orderBy: () => builder,
+      offset: (value: number) => {
+        offset = value
+        return builder
+      },
+      limit: async (take: number) => filtered().slice(offset, offset + take),
+      count: () => createBuilder({ ...filters }, true, offset),
+      first: async () => {
+        if (isCount) {
+          return { count: filtered().length }
+        }
+        return filtered()[0]
+      },
+    }
+    return builder
+  }
+
+  return (() => createBuilder()) as any
+}
+
+const createContext = () =>
+  ({
+    dataSources: {
+      connections: {
+        knex: createKnex(actions),
+      },
+      atomService: {
+        userIdLoader: {
+          load: async (id: string) => ({
+            id,
+            userName: `user-${id}`,
+            displayName: id === '1' ? '隊員一號' : null,
+          }),
+        },
+      },
+    },
+  } as any)
+
+describe('Community Watch public queries', () => {
+  test('returns filtered public actions as a connection', async () => {
+    const result = await communityWatchActions(
+      {},
+      {
+        input: {
+          first: 1,
+          reason: 'porn_ad',
+          actionState: 'active',
+          appealState: 'received',
+          reviewState: 'upheld',
+        },
+      },
+      createContext(),
+      {} as any
+    )
+
+    expect(result.totalCount).toBe(1)
+    expect(result.edges).toHaveLength(1)
+    expect(result.edges[0].node.uuid).toBe('action-1')
+    expect(result.pageInfo.hasNextPage).toBe(false)
+  })
+
+  test('returns one public action by uuid', async () => {
+    const result = await rootCommunityWatchAction(
+      {},
+      { input: { uuid: 'action-2' } },
+      createContext(),
+      {} as any
+    )
+
+    expect(result?.uuid).toBe('action-2')
+  })
+
+  test('maps public action fields for the transparency page', async () => {
+    const commentId = await communityWatchActionPublic.commentId!(
+      actions[0],
+      {},
+      createContext(),
+      {} as any
+    )
+    const sourceId = await communityWatchActionPublic.sourceId!(
+      actions[0],
+      {},
+      createContext(),
+      {} as any
+    )
+    const sourceType = await communityWatchActionPublic.sourceType!(
+      actions[0],
+      {},
+      createContext(),
+      {} as any
+    )
+    const sourceTitle = await communityWatchActionPublic.sourceTitle!(
+      actions[0],
+      {},
+      createContext(),
+      {} as any
+    )
+    const actorDisplayName =
+      await communityWatchActionPublic.actorDisplayName!(
+        actions[1],
+        {},
+        createContext(),
+        {} as any
+      )
+    const contentCleared = await communityWatchActionPublic.contentCleared!(
+      actions[0],
+      {},
+      createContext(),
+      {} as any
+    )
+
+    expect(commentId).toBe(toGlobalId({ type: NODE_TYPES.Comment, id: '102' }))
+    expect(sourceId).toBe(toGlobalId({ type: NODE_TYPES.Moment, id: '202' }))
+    expect(sourceType).toBe('moment')
+    expect(sourceTitle).toBe('202')
+    expect(actorDisplayName).toBe('隊員一號')
+    expect(contentCleared).toBe(true)
+  })
+})

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -11,6 +11,7 @@ import { ETHWallet as ETHWalletModel } from './wallet.js'
 import { Tag as TagModel } from './tag.js'
 import { Collection as CollectionModel } from './collection.js'
 import { Comment as CommentModel } from './comment.js'
+import { CommunityWatchAction as CommunityWatchActionModel } from './communityWatch.js'
 import {
   Article as ArticleModel,
   ArticleVersion as ArticleVersionModel,
@@ -1441,11 +1442,53 @@ export type GQLCommentsInput = {
 
 export type GQLCommunityWatchAction = {
   __typename?: 'CommunityWatchAction'
+  actionState: GQLCommunityWatchActionState
+  actorDisplayName: Scalars['String']['output']
+  appealState: GQLCommunityWatchAppealState
+  commentId: Scalars['ID']['output']
+  contentCleared: Scalars['Boolean']['output']
   createdAt: Scalars['DateTime']['output']
+  originalContent?: Maybe<Scalars['String']['output']>
   reason: GQLCommunityWatchRemoveCommentReason
+  reviewState: GQLCommunityWatchReviewState
+  sourceId: Scalars['ID']['output']
+  sourceTitle: Scalars['String']['output']
+  sourceType: GQLCommunityWatchActionSourceType
   /** Public identifier used by the Community Watch transparency page. */
   uuid: Scalars['ID']['output']
 }
+
+export type GQLCommunityWatchActionConnection = GQLConnection & {
+  __typename?: 'CommunityWatchActionConnection'
+  edges?: Maybe<Array<GQLCommunityWatchActionEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
+
+export type GQLCommunityWatchActionEdge = {
+  __typename?: 'CommunityWatchActionEdge'
+  cursor: Scalars['String']['output']
+  node: GQLCommunityWatchAction
+}
+
+export type GQLCommunityWatchActionInput = {
+  uuid: Scalars['ID']['input']
+}
+
+export type GQLCommunityWatchActionSourceType = 'article' | 'moment'
+
+export type GQLCommunityWatchActionState = 'active' | 'restored' | 'voided'
+
+export type GQLCommunityWatchActionsInput = {
+  actionState?: InputMaybe<GQLCommunityWatchActionState>
+  after?: InputMaybe<Scalars['String']['input']>
+  appealState?: InputMaybe<GQLCommunityWatchAppealState>
+  first?: InputMaybe<Scalars['Int']['input']>
+  reason?: InputMaybe<GQLCommunityWatchRemoveCommentReason>
+  reviewState?: InputMaybe<GQLCommunityWatchReviewState>
+}
+
+export type GQLCommunityWatchAppealState = 'none' | 'received' | 'resolved'
 
 export type GQLCommunityWatchRemoveCommentInput = {
   id: Scalars['ID']['input']
@@ -1453,6 +1496,12 @@ export type GQLCommunityWatchRemoveCommentInput = {
 }
 
 export type GQLCommunityWatchRemoveCommentReason = 'porn_ad' | 'spam_ad'
+
+export type GQLCommunityWatchReviewState =
+  | 'pending'
+  | 'reason_adjusted'
+  | 'reversed'
+  | 'upheld'
 
 export type GQLConfirmVerificationCodeInput = {
   code: Scalars['String']['input']
@@ -3273,6 +3322,10 @@ export type GQLQuery = {
   channel?: Maybe<GQLChannel>
   channels: Array<GQLChannel>
   circle?: Maybe<GQLCircle>
+  /** One public Community Watch audit record. */
+  communityWatchAction?: Maybe<GQLCommunityWatchAction>
+  /** Recent public Community Watch audit records. */
+  communityWatchActions: GQLCommunityWatchActionConnection
   exchangeRates?: Maybe<Array<GQLExchangeRate>>
   frequentSearch?: Maybe<Array<Scalars['String']['output']>>
   moment?: Maybe<GQLMoment>
@@ -3313,6 +3366,14 @@ export type GQLQueryChannelsArgs = {
 
 export type GQLQueryCircleArgs = {
   input: GQLCircleInput
+}
+
+export type GQLQueryCommunityWatchActionArgs = {
+  input: GQLCommunityWatchActionInput
+}
+
+export type GQLQueryCommunityWatchActionsArgs = {
+  input: GQLCommunityWatchActionsInput
 }
 
 export type GQLQueryExchangeRatesArgs = {
@@ -5027,6 +5088,9 @@ export type GQLResolversInterfaceTypes<
     | (Omit<GQLCommentConnection, 'edges'> & {
         edges?: Maybe<Array<_RefType['CommentEdge']>>
       })
+    | (Omit<GQLCommunityWatchActionConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['CommunityWatchActionEdge']>>
+      })
     | (Omit<GQLDraftConnection, 'edges'> & {
         edges?: Maybe<Array<_RefType['DraftEdge']>>
       })
@@ -5363,9 +5427,25 @@ export type GQLResolversTypes = ResolversObject<{
   CommentType: GQLCommentType
   CommentsFilter: GQLCommentsFilter
   CommentsInput: GQLCommentsInput
-  CommunityWatchAction: ResolverTypeWrapper<GQLCommunityWatchAction>
+  CommunityWatchAction: ResolverTypeWrapper<CommunityWatchActionModel>
+  CommunityWatchActionConnection: ResolverTypeWrapper<
+    Omit<GQLCommunityWatchActionConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['CommunityWatchActionEdge']>>
+    }
+  >
+  CommunityWatchActionEdge: ResolverTypeWrapper<
+    Omit<GQLCommunityWatchActionEdge, 'node'> & {
+      node: GQLResolversTypes['CommunityWatchAction']
+    }
+  >
+  CommunityWatchActionInput: GQLCommunityWatchActionInput
+  CommunityWatchActionSourceType: GQLCommunityWatchActionSourceType
+  CommunityWatchActionState: GQLCommunityWatchActionState
+  CommunityWatchActionsInput: GQLCommunityWatchActionsInput
+  CommunityWatchAppealState: GQLCommunityWatchAppealState
   CommunityWatchRemoveCommentInput: GQLCommunityWatchRemoveCommentInput
   CommunityWatchRemoveCommentReason: GQLCommunityWatchRemoveCommentReason
+  CommunityWatchReviewState: GQLCommunityWatchReviewState
   ConfirmVerificationCodeInput: GQLConfirmVerificationCodeInput
   ConnectStripeAccountInput: GQLConnectStripeAccountInput
   ConnectStripeAccountResult: ResolverTypeWrapper<GQLConnectStripeAccountResult>
@@ -6076,7 +6156,18 @@ export type GQLResolversParentTypes = ResolversObject<{
   CommentNotice: NoticeItemModel
   CommentsFilter: GQLCommentsFilter
   CommentsInput: GQLCommentsInput
-  CommunityWatchAction: GQLCommunityWatchAction
+  CommunityWatchAction: CommunityWatchActionModel
+  CommunityWatchActionConnection: Omit<
+    GQLCommunityWatchActionConnection,
+    'edges'
+  > & {
+    edges?: Maybe<Array<GQLResolversParentTypes['CommunityWatchActionEdge']>>
+  }
+  CommunityWatchActionEdge: Omit<GQLCommunityWatchActionEdge, 'node'> & {
+    node: GQLResolversParentTypes['CommunityWatchAction']
+  }
+  CommunityWatchActionInput: GQLCommunityWatchActionInput
+  CommunityWatchActionsInput: GQLCommunityWatchActionsInput
   CommunityWatchRemoveCommentInput: GQLCommunityWatchRemoveCommentInput
   ConfirmVerificationCodeInput: GQLConfirmVerificationCodeInput
   ConnectStripeAccountInput: GQLConnectStripeAccountInput
@@ -7982,13 +8073,78 @@ export type GQLCommunityWatchActionResolvers<
   ContextType = Context,
   ParentType extends GQLResolversParentTypes['CommunityWatchAction'] = GQLResolversParentTypes['CommunityWatchAction']
 > = ResolversObject<{
+  actionState?: Resolver<
+    GQLResolversTypes['CommunityWatchActionState'],
+    ParentType,
+    ContextType
+  >
+  actorDisplayName?: Resolver<
+    GQLResolversTypes['String'],
+    ParentType,
+    ContextType
+  >
+  appealState?: Resolver<
+    GQLResolversTypes['CommunityWatchAppealState'],
+    ParentType,
+    ContextType
+  >
+  commentId?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  contentCleared?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
   createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  originalContent?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
   reason?: Resolver<
     GQLResolversTypes['CommunityWatchRemoveCommentReason'],
     ParentType,
     ContextType
   >
+  reviewState?: Resolver<
+    GQLResolversTypes['CommunityWatchReviewState'],
+    ParentType,
+    ContextType
+  >
+  sourceId?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  sourceTitle?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  sourceType?: Resolver<
+    GQLResolversTypes['CommunityWatchActionSourceType'],
+    ParentType,
+    ContextType
+  >
   uuid?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCommunityWatchActionConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CommunityWatchActionConnection'] = GQLResolversParentTypes['CommunityWatchActionConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['CommunityWatchActionEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCommunityWatchActionEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CommunityWatchActionEdge'] = GQLResolversParentTypes['CommunityWatchActionEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<
+    GQLResolversTypes['CommunityWatchAction'],
+    ParentType,
+    ContextType
+  >
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }>
 
@@ -8015,6 +8171,7 @@ export type GQLConnectionResolvers<
     | 'CircleConnection'
     | 'CollectionConnection'
     | 'CommentConnection'
+    | 'CommunityWatchActionConnection'
     | 'DraftConnection'
     | 'FollowingActivityConnection'
     | 'IcymiTopicConnection'
@@ -9838,6 +9995,18 @@ export type GQLQueryResolvers<
     ContextType,
     RequireFields<GQLQueryCircleArgs, 'input'>
   >
+  communityWatchAction?: Resolver<
+    Maybe<GQLResolversTypes['CommunityWatchAction']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLQueryCommunityWatchActionArgs, 'input'>
+  >
+  communityWatchActions?: Resolver<
+    GQLResolversTypes['CommunityWatchActionConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLQueryCommunityWatchActionsArgs, 'input'>
+  >
   exchangeRates?: Resolver<
     Maybe<Array<GQLResolversTypes['ExchangeRate']>>,
     ParentType,
@@ -11325,6 +11494,8 @@ export type GQLResolvers<ContextType = Context> = ResolversObject<{
   CommentEdge?: GQLCommentEdgeResolvers<ContextType>
   CommentNotice?: GQLCommentNoticeResolvers<ContextType>
   CommunityWatchAction?: GQLCommunityWatchActionResolvers<ContextType>
+  CommunityWatchActionConnection?: GQLCommunityWatchActionConnectionResolvers<ContextType>
+  CommunityWatchActionEdge?: GQLCommunityWatchActionEdgeResolvers<ContextType>
   ConnectStripeAccountResult?: GQLConnectStripeAccountResultResolvers<ContextType>
   Connection?: GQLConnectionResolvers<ContextType>
   CryptoWallet?: GQLCryptoWalletResolvers<ContextType>

--- a/src/queries/comment/communityWatchActionPublic.ts
+++ b/src/queries/comment/communityWatchActionPublic.ts
@@ -1,0 +1,33 @@
+import type {
+  CommunityWatchAction,
+  Context,
+  GQLCommunityWatchActionResolvers,
+} from '#definitions/index.js'
+
+import { COMMENT_TYPE, NODE_TYPES } from '#common/enums/index.js'
+import { toGlobalId } from '#common/utils/index.js'
+
+const getSourceNodeType = ({ targetType }: CommunityWatchAction) =>
+  targetType === COMMENT_TYPE.article ? NODE_TYPES.Article : NODE_TYPES.Moment
+
+const communityWatchActionPublic: GQLCommunityWatchActionResolvers = {
+  commentId: ({ commentId }: CommunityWatchAction) =>
+    toGlobalId({ type: NODE_TYPES.Comment, id: commentId }),
+  sourceType: ({ targetType }: CommunityWatchAction) => targetType,
+  sourceTitle: ({ targetTitle, targetId }: CommunityWatchAction) =>
+    targetTitle || targetId,
+  sourceId: (action: CommunityWatchAction) =>
+    toGlobalId({ type: getSourceNodeType(action), id: action.targetId }),
+  actorDisplayName: async (
+    { actorId }: CommunityWatchAction,
+    _: unknown,
+    { dataSources: { atomService } }: Context
+  ) => {
+    const actor = await atomService.userIdLoader.load(actorId)
+    return actor.displayName || actor.userName || actor.id
+  },
+  contentCleared: ({ originalContent }: CommunityWatchAction) =>
+    originalContent === null,
+}
+
+export default communityWatchActionPublic

--- a/src/queries/comment/communityWatchActions.ts
+++ b/src/queries/comment/communityWatchActions.ts
@@ -1,0 +1,70 @@
+import type {
+  CommunityWatchAction,
+  Context,
+  GQLQueryResolvers,
+} from '#definitions/index.js'
+
+import { connectionFromArray, fromConnectionArgs } from '#common/utils/index.js'
+
+const MAX_PUBLIC_ACTIONS_PER_PAGE = 50
+
+type CommunityWatchActionsInput = {
+  after?: string
+  first?: number | null
+  reason?: string | null
+  actionState?: string | null
+  appealState?: string | null
+  reviewState?: string | null
+}
+
+const applyFilters = (query: any, input: CommunityWatchActionsInput) => {
+  if (input.reason) {
+    query.where({ reason: input.reason })
+  }
+  if (input.actionState) {
+    query.where({ actionState: input.actionState })
+  }
+  if (input.appealState) {
+    query.where({ appealState: input.appealState })
+  }
+  if (input.reviewState) {
+    query.where({ reviewState: input.reviewState })
+  }
+}
+
+const resolver: GQLQueryResolvers['communityWatchActions'] = async (
+  _: unknown,
+  { input }: { input: CommunityWatchActionsInput },
+  { dataSources: { connections: { knex } } }: Context
+) => {
+  const connectionArgs = {
+    after: input.after || undefined,
+    first: input.first,
+  }
+  const { take, skip } = fromConnectionArgs(connectionArgs, {
+    maxTake: MAX_PUBLIC_ACTIONS_PER_PAGE,
+  })
+
+  const baseQuery = knex('community_watch_action').select()
+  applyFilters(baseQuery, input)
+
+  const [actions, countResult] = await Promise.all([
+    baseQuery
+      .clone()
+      .orderBy('createdAt', 'desc')
+      .orderBy('id', 'desc')
+      .offset(skip)
+      .limit(take),
+    baseQuery.clone().count('*').first(),
+  ])
+
+  const totalCount = Number(countResult?.count || 0)
+
+  return connectionFromArray(
+    actions as CommunityWatchAction[],
+    connectionArgs,
+    totalCount
+  )
+}
+
+export default resolver

--- a/src/queries/comment/index.ts
+++ b/src/queries/comment/index.ts
@@ -18,6 +18,8 @@ import circleDiscussionThreadCount from './circle/discussionThreadCount.js'
 import circlePinnedBroadcast from './circle/pinnedBroadcast.js'
 import comments from './comments.js'
 import communityWatchAction from './communityWatchAction.js'
+import communityWatchActionPublic from './communityWatchActionPublic.js'
+import communityWatchActions from './communityWatchActions.js'
 import content from './content.js'
 import downvotes from './downvotes.js'
 import fromDonator from './fromDonator.js'
@@ -25,11 +27,16 @@ import myVote from './myVote.js'
 import node from './node.js'
 import parentComment from './parentComment.js'
 import replyTo from './replyTo.js'
+import rootCommunityWatchAction from './rootCommunityWatchAction.js'
 import { spamStatus } from './spamStatus.js'
 import upvotes from './upvotes.js'
 import userCommentedArticles from './user/commentedArticles.js'
 
 export default {
+  Query: {
+    communityWatchAction: rootCommunityWatchAction,
+    communityWatchActions,
+  },
   User: {
     commentedArticles: userCommentedArticles,
   },
@@ -58,6 +65,7 @@ export default {
     type: ({ type }: { type: string }) => COMMENT_TYPES_REVERSED[type],
     node,
   },
+  CommunityWatchAction: communityWatchActionPublic,
   Circle: {
     broadcast: circleBroadcast,
     pinnedBroadcast: circlePinnedBroadcast,

--- a/src/queries/comment/rootCommunityWatchAction.ts
+++ b/src/queries/comment/rootCommunityWatchAction.ts
@@ -1,0 +1,16 @@
+import type {
+  Context,
+  GQLQueryResolvers,
+} from '#definitions/index.js'
+
+const resolver: GQLQueryResolvers['communityWatchAction'] = (
+  _: unknown,
+  { input: { uuid } }: { input: { uuid: string } },
+  { dataSources: { connections: { knex } } }: Context
+) =>
+  knex('community_watch_action')
+    .select()
+    .where({ uuid })
+    .first()
+
+export default resolver

--- a/src/types/__test__/2/comment.test.ts
+++ b/src/types/__test__/2/comment.test.ts
@@ -83,6 +83,58 @@ const COMMUNITY_WATCH_REMOVE_COMMENT = /* GraphQL */ `
   }
 `
 
+const COMMUNITY_WATCH_ACTIONS = /* GraphQL */ `
+  query ($input: CommunityWatchActionsInput!) {
+    communityWatchActions(input: $input) {
+      totalCount
+      edges {
+        cursor
+        node {
+          uuid
+          commentId
+          sourceType
+          sourceTitle
+          sourceId
+          actorDisplayName
+          reason
+          actionState
+          appealState
+          reviewState
+          originalContent
+          contentCleared
+          createdAt
+        }
+      }
+      pageInfo {
+        startCursor
+        endCursor
+        hasPreviousPage
+        hasNextPage
+      }
+    }
+  }
+`
+
+const COMMUNITY_WATCH_ACTION = /* GraphQL */ `
+  query ($input: CommunityWatchActionInput!) {
+    communityWatchAction(input: $input) {
+      uuid
+      commentId
+      sourceType
+      sourceTitle
+      sourceId
+      actorDisplayName
+      reason
+      actionState
+      appealState
+      reviewState
+      originalContent
+      contentCleared
+      createdAt
+    }
+  }
+`
+
 describe('query comment list on article', () => {
   const GET_ARTILCE_COMMENTS = /* GraphQL */ `
     query ($nodeInput: NodeInput!, $commentsInput: CommentsInput!) {
@@ -606,6 +658,171 @@ describe('community watch remove comment', () => {
         recipientId: '2',
       })
     )
+  })
+})
+
+describe('community watch public audit queries', () => {
+  const contentExpiresAt = new Date('2026-05-17T00:00:00.000Z')
+
+  test('query audit list with filters', async () => {
+    const actor = await userService.create({
+      userName: `watcher${uuidv4().replace(/-/g, '').slice(0, 12)}`,
+      displayName: 'Community Watcher',
+    })
+    const article = await atomService.articleIdLoader.load('1')
+    const { id: targetTypeId } = await atomService.findFirst({
+      table: 'entity_type',
+      where: { table: 'article' },
+    })
+    const comment = await atomService.create({
+      table: 'comment',
+      data: {
+        uuid: uuidv4(),
+        content: '<p>spam ad</p>',
+        authorId: '2',
+        targetId: article.id,
+        targetTypeId,
+        parentCommentId: null,
+        type: COMMENT_TYPE.article,
+        state: COMMENT_STATE.banned,
+      },
+    })
+    const uuid = uuidv4()
+    await connections.knex('community_watch_action').insert({
+      uuid,
+      commentId: comment.id,
+      commentType: COMMENT_TYPE.article,
+      targetType: COMMENT_TYPE.article,
+      targetId: article.id,
+      targetTitle: 'Public API article',
+      targetShortHash: article.shortHash,
+      reason: 'porn_ad',
+      actorId: actor.id,
+      commentAuthorId: '2',
+      originalContent: '<p>spam ad</p>',
+      originalState: COMMENT_STATE.active,
+      actionState: 'active',
+      appealState: 'received',
+      reviewState: 'upheld',
+      contentExpiresAt,
+    })
+
+    const server = await testClient({ connections })
+    const { errors, data } = await server.executeOperation({
+      query: COMMUNITY_WATCH_ACTIONS,
+      variables: {
+        input: {
+          first: 5,
+          reason: 'porn_ad',
+          actionState: 'active',
+          appealState: 'received',
+          reviewState: 'upheld',
+        },
+      },
+    })
+
+    expect(errors).toBeUndefined()
+    expect(data.communityWatchActions.totalCount).toBe(1)
+    expect(data.communityWatchActions.pageInfo).toMatchObject({
+      hasPreviousPage: false,
+      hasNextPage: false,
+    })
+
+    const node = data.communityWatchActions.edges[0].node
+    expect(node).toMatchObject({
+      uuid,
+      sourceType: COMMENT_TYPE.article,
+      sourceTitle: 'Public API article',
+      actorDisplayName: actor.displayName,
+      reason: 'porn_ad',
+      actionState: 'active',
+      appealState: 'received',
+      reviewState: 'upheld',
+      originalContent: '<p>spam ad</p>',
+      contentCleared: false,
+      createdAt: expect.anything(),
+    })
+    expect(fromGlobalId(node.commentId)).toEqual({
+      type: NODE_TYPES.Comment,
+      id: `${comment.id}`,
+    })
+    expect(fromGlobalId(node.sourceId)).toEqual({
+      type: NODE_TYPES.Article,
+      id: `${article.id}`,
+    })
+  })
+
+  test('query one audit record with cleared content', async () => {
+    const actor = await userService.create({
+      userName: `watcher${uuidv4().replace(/-/g, '').slice(0, 12)}`,
+    })
+    const { id: targetTypeId } = await atomService.findFirst({
+      table: 'entity_type',
+      where: { table: 'moment' },
+    })
+    const comment = await atomService.create({
+      table: 'comment',
+      data: {
+        uuid: uuidv4(),
+        content: '<p>spam ad</p>',
+        authorId: '2',
+        targetId: '1',
+        targetTypeId,
+        parentCommentId: null,
+        type: COMMENT_TYPE.moment,
+        state: COMMENT_STATE.banned,
+      },
+    })
+    const uuid = uuidv4()
+    await connections.knex('community_watch_action').insert({
+      uuid,
+      commentId: comment.id,
+      commentType: COMMENT_TYPE.moment,
+      targetType: COMMENT_TYPE.moment,
+      targetId: '1',
+      targetTitle: null,
+      targetShortHash: null,
+      reason: 'spam_ad',
+      actorId: actor.id,
+      commentAuthorId: '2',
+      originalContent: null,
+      originalState: COMMENT_STATE.active,
+      actionState: 'restored',
+      appealState: 'resolved',
+      reviewState: 'reversed',
+      contentExpiresAt,
+    })
+
+    const server = await testClient({ connections })
+    const { errors, data } = await server.executeOperation({
+      query: COMMUNITY_WATCH_ACTION,
+      variables: {
+        input: { uuid },
+      },
+    })
+
+    expect(errors).toBeUndefined()
+    expect(data.communityWatchAction).toMatchObject({
+      uuid,
+      sourceType: COMMENT_TYPE.moment,
+      sourceTitle: '1',
+      actorDisplayName: actor.userName,
+      reason: 'spam_ad',
+      actionState: 'restored',
+      appealState: 'resolved',
+      reviewState: 'reversed',
+      originalContent: null,
+      contentCleared: true,
+      createdAt: expect.anything(),
+    })
+    expect(fromGlobalId(data.communityWatchAction.commentId)).toEqual({
+      type: NODE_TYPES.Comment,
+      id: `${comment.id}`,
+    })
+    expect(fromGlobalId(data.communityWatchAction.sourceId)).toEqual({
+      type: NODE_TYPES.Moment,
+      id: '1',
+    })
   })
 })
 

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -1,9 +1,22 @@
-import { AUTH_MODE, NODE_TYPES, SCOPE_GROUP } from '#common/enums/index.js'
+import {
+  AUTH_MODE,
+  CACHE_TTL,
+  NODE_TYPES,
+  SCOPE_GROUP,
+} from '#common/enums/index.js'
 import { isProd } from '#common/environment.js'
 
 const PUT_COMMENT_RATE_LIMIT = isProd ? 6 : 1000
 
 export default /* GraphQL */ `
+  extend type Query {
+    "Recent public Community Watch audit records."
+    communityWatchActions(input: CommunityWatchActionsInput!): CommunityWatchActionConnection! @complexity(multipliers: ["input.first"], value: 1) @cacheControl(maxAge: ${CACHE_TTL.SHORT})
+
+    "One public Community Watch audit record."
+    communityWatchAction(input: CommunityWatchActionInput!): CommunityWatchAction @cacheControl(maxAge: ${CACHE_TTL.SHORT})
+  }
+
   extend type Mutation {
     "Publish or update a comment."
     putComment(input: PutCommentInput!): Comment! @auth(mode: "${AUTH_MODE.oauth}", group: "${SCOPE_GROUP.level2}") @purgeCache(type: "${NODE_TYPES.Comment}") @rateLimit(limit: ${PUT_COMMENT_RATE_LIMIT}, period: 60)
@@ -226,16 +239,74 @@ export default /* GraphQL */ `
     reason: CommunityWatchRemoveCommentReason!
   }
 
+  input CommunityWatchActionsInput {
+    after: String
+    first: Int @constraint(min: 0)
+    reason: CommunityWatchRemoveCommentReason
+    actionState: CommunityWatchActionState
+    appealState: CommunityWatchAppealState
+    reviewState: CommunityWatchReviewState
+  }
+
+  input CommunityWatchActionInput {
+    uuid: ID!
+  }
+
   enum CommunityWatchRemoveCommentReason {
     porn_ad
     spam_ad
   }
 
+  enum CommunityWatchActionSourceType {
+    article
+    moment
+  }
+
+  enum CommunityWatchActionState {
+    active
+    restored
+    voided
+  }
+
+  enum CommunityWatchAppealState {
+    none
+    received
+    resolved
+  }
+
+  enum CommunityWatchReviewState {
+    pending
+    upheld
+    reversed
+    reason_adjusted
+  }
+
   type CommunityWatchAction {
     "Public identifier used by the Community Watch transparency page."
     uuid: ID!
+    commentId: ID!
+    sourceType: CommunityWatchActionSourceType!
+    sourceTitle: String!
+    sourceId: ID!
+    actorDisplayName: String!
     reason: CommunityWatchRemoveCommentReason!
+    actionState: CommunityWatchActionState!
+    appealState: CommunityWatchAppealState!
+    reviewState: CommunityWatchReviewState!
+    originalContent: String
+    contentCleared: Boolean!
     createdAt: DateTime!
+  }
+
+  type CommunityWatchActionConnection implements Connection {
+    totalCount: Int!
+    pageInfo: PageInfo!
+    edges: [CommunityWatchActionEdge!]
+  }
+
+  type CommunityWatchActionEdge {
+    cursor: String!
+    node: CommunityWatchAction!
   }
 
   "Enums for vote types."


### PR DESCRIPTION
## Summary
- add public Community Watch audit list/detail queries
- expand CommunityWatchAction with public transparency fields for the community-watch site
- map internal numeric comment/source ids to public GraphQL IDs and expose actor display names only
- add focused unit coverage for list filtering, detail lookup, and public field mapping

## Verification
- npm run build
- npm run lint
- MATTERS_ENV=test node --experimental-vm-modules node_modules/.bin/jest build/common/utils/__test__/communityWatchPublicQueries.test.js --runInBand --forceExit

## Stack
- Base: codex/community-watch-phase3-server / #4764
- This does not change the Community Watch removal mutation; it only adds read-side public API support for Phase 4.