### PR TITLE
[codex] Add federation setting upsert service

### DIFF
--- a/docs/Federation-Export.md
+++ b/docs/Federation-Export.md
@@ -24,6 +24,8 @@ The current pure function is `resolveFederationExportGate` in `src/connectors/ar
 
 The candidate loader can include federation setting joins when strict opt-in input is needed. Without that strict input, the service preserves the public-only preflight boundary.
 
+`FederationExportService` also exposes bounded upsert methods for author and article federation settings. These methods validate allowed states before writing and are intended for future product/admin entry points.
+
 `evaluateFederationExportRows` returns a `decisionReport` with selected, eligible, skipped, and per-article skip reasons. Downstream async workers can persist or log that report without exposing credentials or private content.
 
 ## Durable state scaffold
@@ -35,11 +37,11 @@ The schema scaffold uses two independent tables:
 | `user_federation_setting` | One row per author. `state` is `enabled` or `disabled`; missing rows are treated as disabled by the service contract. |
 | `article_federation_setting` | One row per article. `state` is `inherit`, `enabled`, or `disabled`; missing rows are treated as `inherit`. |
 
-Both tables include `updated_by`, `created_at`, and `updated_at`. The migration is present for branch review, but this slice does not run it against production or wire it to GraphQL.
+Both tables include `updated_by`, `created_at`, and `updated_at`. The migration and service methods are present for branch review and staging validation, but this slice does not run it against production or wire it to GraphQL.
 
 ## Deferred production work
 
-- Add product copy and UI controls.
+- Add product copy, UI controls, and GraphQL/admin entry points.
 - Move bundle generation and file publication to `lambda-handlers`.
 - Wire async export trigger behavior after publishing or editing an eligible article.
 - Add audit logs for export decisions and skipped reasons.

--- a/src/connectors/__test__/federationExportService.test.ts
+++ b/src/connectors/__test__/federationExportService.test.ts
@@ -56,6 +56,21 @@ const createKnexRO = (rows: any[]) => {
   return { knexRO, query }
 }
 
+const createKnexWrite = (rows: any[]) => {
+  const query: any = {
+    insert: jest.fn(() => query),
+    onConflict: jest.fn(() => query),
+    merge: jest.fn(() => query),
+    returning: jest.fn(() => Promise.resolve(rows)),
+  }
+  const knex = jest.fn(() => query) as any
+  knex.fn = {
+    now: jest.fn(() => 'now'),
+  }
+
+  return { knex, query }
+}
+
 describe('federationExportService', () => {
   test('builds canonical Matters article URLs from short hashes', () => {
     expect(
@@ -354,5 +369,103 @@ describe('federationExportService', () => {
       'Explicit articleIds are required'
     )
     expect(knexRO).not.toHaveBeenCalled()
+  })
+
+  test('upserts author federation settings through the write connection', async () => {
+    const { knex, query } = createKnexWrite([
+      {
+        userId: '1',
+        state: FEDERATION_AUTHOR_SETTING.enabled,
+        updatedBy: '99',
+      },
+    ])
+    const service = new FederationExportService({ knex } as any)
+
+    const row = await service.upsertAuthorFederationSetting({
+      userId: '1',
+      state: FEDERATION_AUTHOR_SETTING.enabled,
+      updatedBy: '99',
+    })
+
+    expect(knex).toHaveBeenCalledWith('user_federation_setting')
+    expect(query.insert).toHaveBeenCalledWith({
+      userId: '1',
+      state: FEDERATION_AUTHOR_SETTING.enabled,
+      updatedBy: '99',
+    })
+    expect(query.onConflict).toHaveBeenCalledWith('userId')
+    expect(query.merge).toHaveBeenCalledWith({
+      state: FEDERATION_AUTHOR_SETTING.enabled,
+      updatedBy: '99',
+      updatedAt: 'now',
+    })
+    expect(query.returning).toHaveBeenCalledWith([
+      'userId',
+      'state',
+      'updatedBy',
+    ])
+    expect(row).toEqual({
+      userId: '1',
+      state: FEDERATION_AUTHOR_SETTING.enabled,
+      updatedBy: '99',
+    })
+  })
+
+  test('upserts article federation settings through the write connection', async () => {
+    const { knex, query } = createKnexWrite([
+      {
+        articleId: '101',
+        state: FEDERATION_ARTICLE_SETTING.disabled,
+        updatedBy: null,
+      },
+    ])
+    const service = new FederationExportService({ knex } as any)
+
+    const row = await service.upsertArticleFederationSetting({
+      articleId: '101',
+      state: FEDERATION_ARTICLE_SETTING.disabled,
+    })
+
+    expect(knex).toHaveBeenCalledWith('article_federation_setting')
+    expect(query.insert).toHaveBeenCalledWith({
+      articleId: '101',
+      state: FEDERATION_ARTICLE_SETTING.disabled,
+      updatedBy: null,
+    })
+    expect(query.onConflict).toHaveBeenCalledWith('articleId')
+    expect(query.merge).toHaveBeenCalledWith({
+      state: FEDERATION_ARTICLE_SETTING.disabled,
+      updatedBy: null,
+      updatedAt: 'now',
+    })
+    expect(query.returning).toHaveBeenCalledWith([
+      'articleId',
+      'state',
+      'updatedBy',
+    ])
+    expect(row).toEqual({
+      articleId: '101',
+      state: FEDERATION_ARTICLE_SETTING.disabled,
+      updatedBy: null,
+    })
+  })
+
+  test('rejects invalid federation setting states before writing', async () => {
+    const { knex } = createKnexWrite([])
+    const service = new FederationExportService({ knex } as any)
+
+    await expect(
+      service.upsertAuthorFederationSetting({
+        userId: '1',
+        state: 'inherit' as any,
+      })
+    ).rejects.toThrow('Invalid author federation setting')
+    await expect(
+      service.upsertArticleFederationSetting({
+        articleId: '101',
+        state: 'unknown' as any,
+      })
+    ).rejects.toThrow('Invalid article federation setting')
+    expect(knex).not.toHaveBeenCalled()
   })
 })

--- a/src/connectors/article/federationExportService.ts
+++ b/src/connectors/article/federationExportService.ts
@@ -81,6 +81,18 @@ export type FederationExportDecisionReport = {
   decisions: FederationExportDecision[]
 }
 
+export type FederationAuthorSettingRow = {
+  userId: string
+  state: FederationAuthorSetting
+  updatedBy?: string | null
+}
+
+export type FederationArticleSettingRow = {
+  articleId: string
+  state: FederationArticleSetting
+  updatedBy?: string | null
+}
+
 type ArticleExportQueryRow = {
   articleId: string
   articleState: string
@@ -206,10 +218,56 @@ export const buildMattersArticleUrl = ({
 }) => `https://${siteDomain}/a/${shortHash || articleId}`
 
 export class FederationExportService {
+  private knex: Knex
   private knexRO: Knex
 
   public constructor(connections: Connections) {
+    this.knex = connections.knex
     this.knexRO = connections.knexRO
+  }
+
+  public async upsertAuthorFederationSetting({
+    userId,
+    state,
+    updatedBy = null,
+  }: FederationAuthorSettingRow): Promise<FederationAuthorSettingRow> {
+    if (!Object.values(FEDERATION_AUTHOR_SETTING).includes(state)) {
+      throw new Error(`Invalid author federation setting: ${state}`)
+    }
+
+    const [row] = await this.knex('user_federation_setting')
+      .insert({ userId, state, updatedBy })
+      .onConflict('userId')
+      .merge({
+        state,
+        updatedBy,
+        updatedAt: this.knex.fn.now(),
+      })
+      .returning(['userId', 'state', 'updatedBy'])
+
+    return row
+  }
+
+  public async upsertArticleFederationSetting({
+    articleId,
+    state,
+    updatedBy = null,
+  }: FederationArticleSettingRow): Promise<FederationArticleSettingRow> {
+    if (!Object.values(FEDERATION_ARTICLE_SETTING).includes(state)) {
+      throw new Error(`Invalid article federation setting: ${state}`)
+    }
+
+    const [row] = await this.knex('article_federation_setting')
+      .insert({ articleId, state, updatedBy })
+      .onConflict('articleId')
+      .merge({
+        state,
+        updatedBy,
+        updatedAt: this.knex.fn.now(),
+      })
+      .returning(['articleId', 'state', 'updatedBy'])
+
+    return row
   }
 
   public async loadSelectedArticleRows(


### PR DESCRIPTION
## Summary

Adds a bounded service layer for writing federation opt-in settings in `matters-server`.

- adds `FederationExportService.upsertAuthorFederationSetting`
- adds `FederationExportService.upsertArticleFederationSetting`
- validates allowed setting states before writes
- covers insert/update query shape and invalid-state behavior in tests
- updates the federation export contract doc to clarify this is still a staging/review slice, not a production GraphQL/UI rollout

## Impact

This does not change existing backend request paths by itself. It adds callable service methods for future product/admin entry points, while the current public-only export gate remains unchanged.

## Validation

- `npx -y -p node@18 -p npm@10 npm run build`
- `npx -y -p node@18 node --experimental-vm-modules --no-experimental-fetch node_modules/.bin/jest build/connectors/__test__/federationExportService.test.js --runInBand`
- `npx -y -p node@18 -p npm@10 npm exec -- eslint src/connectors/article/federationExportService.ts src/connectors/__test__/federationExportService.test.ts --ext .ts --quiet`
- `git diff --check`
