### PR TITLE
Add admin federation setting mutations

### DIFF
--- a/docs/Federation-Export.md
+++ b/docs/Federation-Export.md
@@ -13,18 +13,29 @@ This document records the server-side contract for deciding whether selected Mat
 
 The first production-facing contract is intentionally conservative:
 
-| Gate | Rule |
-|---|---|
-| Author setting | Must be explicitly `enabled`. Missing or `disabled` means no federation. |
-| Article setting | `inherit` follows the author setting. `enabled` is allowed only when the author is enabled. `disabled` blocks the article. |
-| Public boundary | Article must still be active, public, and attached to an active author identity. |
-| Non-public override | No setting can override paid, private, archived, missing-identity, or otherwise non-public content. |
+| Gate                | Rule                                                                                                                       |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Author setting      | Must be explicitly `enabled`. Missing or `disabled` means no federation.                                                   |
+| Article setting     | `inherit` follows the author setting. `enabled` is allowed only when the author is enabled. `disabled` blocks the article. |
+| Public boundary     | Article must still be active, public, and attached to an active author identity.                                           |
+| Non-public override | No setting can override paid, private, archived, missing-identity, or otherwise non-public content.                        |
 
 The current pure function is `resolveFederationExportGate` in `src/connectors/article/federationExportService.ts`.
 
 The candidate loader can include federation setting joins when strict opt-in input is needed. Without that strict input, the service preserves the public-only preflight boundary.
 
-`FederationExportService` also exposes bounded upsert methods for author and article federation settings. These methods validate allowed states before writing and are intended for future product/admin entry points.
+`FederationExportService` also exposes bounded upsert methods for author and article federation settings. These methods validate allowed states before writing and are wired to admin-only GraphQL mutations for internal/staging control.
+
+## Internal admin entry points
+
+The current GraphQL surface is intentionally narrow and admin-only:
+
+| Mutation                                            | Purpose                                                              |
+| --------------------------------------------------- | -------------------------------------------------------------------- |
+| `putUserFederationSetting(input: { id, state })`    | Sets an author's federation opt-in state to `enabled` or `disabled`. |
+| `putArticleFederationSetting(input: { id, state })` | Sets an article override to `inherit`, `enabled`, or `disabled`.     |
+
+Both mutations require global GraphQL IDs and record the admin viewer ID in `updated_by`. They do not generate bundles, call IPFS/IPNS, publish ActivityPub, or change article visibility.
 
 `evaluateFederationExportRows` returns a `decisionReport` with selected, eligible, skipped, and per-article skip reasons. Downstream async workers can persist or log that report without exposing credentials or private content.
 
@@ -32,16 +43,16 @@ The candidate loader can include federation setting joins when strict opt-in inp
 
 The schema scaffold uses two independent tables:
 
-| Table | Purpose |
-|---|---|
-| `user_federation_setting` | One row per author. `state` is `enabled` or `disabled`; missing rows are treated as disabled by the service contract. |
-| `article_federation_setting` | One row per article. `state` is `inherit`, `enabled`, or `disabled`; missing rows are treated as `inherit`. |
+| Table                        | Purpose                                                                                                               |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `user_federation_setting`    | One row per author. `state` is `enabled` or `disabled`; missing rows are treated as disabled by the service contract. |
+| `article_federation_setting` | One row per article. `state` is `inherit`, `enabled`, or `disabled`; missing rows are treated as `inherit`.           |
 
-Both tables include `updated_by`, `created_at`, and `updated_at`. The migration and service methods are present for branch review and staging validation, but this slice does not run it against production or wire it to GraphQL.
+Both tables include `updated_by`, `created_at`, and `updated_at`. The migration, service methods, and internal admin GraphQL mutations are present for branch review and staging validation, but this slice does not run it against production or expose user-facing UI.
 
 ## Deferred production work
 
-- Add product copy, UI controls, and GraphQL/admin entry points.
+- Add product copy and UI controls.
 - Move bundle generation and file publication to `lambda-handlers`.
 - Wire async export trigger behavior after publishing or editing an eligible article.
 - Add audit logs for export decisions and skipped reasons.

--- a/schema.graphql
+++ b/schema.graphql
@@ -153,6 +153,8 @@ type Mutation {
   deleteAnnouncements(input: DeleteAnnouncementsInput!): Boolean!
   putRestrictedUsers(input: PutRestrictedUsersInput!): [User!]!
   putUserFeatureFlags(input: PutUserFeatureFlagsInput!): [User!]!
+  putUserFederationSetting(input: PutUserFederationSettingInput!): UserFederationSetting!
+  putArticleFederationSetting(input: PutArticleFederationSettingInput!): ArticleFederationSetting!
   putIcymiTopic(input: PutIcymiTopicInput!): IcymiTopic
   setSpamStatus(input: SetSpamStatusInput!): Writing!
   setAdStatus(input: SetAdStatusInput!): Article!
@@ -2523,6 +2525,16 @@ input PutUserFeatureFlagsInput {
   flags: [UserFeatureFlagType!]!
 }
 
+input PutUserFederationSettingInput {
+  id: ID!
+  state: FederationAuthorSettingState!
+}
+
+input PutArticleFederationSettingInput {
+  id: ID!
+  state: FederationArticleSettingState!
+}
+
 input SubmitReportInput {
   targetId: ID!
   reason: ReportReason!
@@ -2650,6 +2662,29 @@ enum UserFeatureFlagType {
   unlimitedArticleFetch
   readSpamStatus
   communityWatch
+}
+
+enum FederationAuthorSettingState {
+  enabled
+  disabled
+}
+
+enum FederationArticleSettingState {
+  inherit
+  enabled
+  disabled
+}
+
+type UserFederationSetting {
+  userId: ID!
+  state: FederationAuthorSettingState!
+  updatedBy: ID
+}
+
+type ArticleFederationSetting {
+  articleId: ID!
+  state: FederationArticleSettingState!
+  updatedBy: ID
 }
 
 enum ReportReason {

--- a/src/definitions/index.d.ts
+++ b/src/definitions/index.d.ts
@@ -21,6 +21,7 @@ import type {
   ChannelService,
   SearchService,
   PublicationService,
+  FederationExportService,
 } from '#connectors/index.js'
 import type {
   RevisionQueue,
@@ -205,6 +206,7 @@ export interface DataSources {
   translationService: TranslationService
   channelService: ChannelService
   searchService: SearchService
+  federationExportService: FederationExportService
   likecoin: LikeCoin
   exchangeRate: ExchangeRate
   connections: Connections

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -549,6 +549,13 @@ export type GQLArticleEdge = {
   node: GQLArticle
 }
 
+export type GQLArticleFederationSetting = {
+  __typename?: 'ArticleFederationSetting'
+  articleId: Scalars['ID']['output']
+  state: GQLFederationArticleSettingState
+  updatedBy?: Maybe<Scalars['ID']['output']>
+}
+
 export type GQLArticleInput = {
   mediaHash?: InputMaybe<Scalars['String']['input']>
   shortHash?: InputMaybe<Scalars['String']['input']>
@@ -1778,6 +1785,13 @@ export type GQLFeaturedTagsInput = {
   ids: Array<Scalars['ID']['input']>
 }
 
+export type GQLFederationArticleSettingState =
+  | 'disabled'
+  | 'enabled'
+  | 'inherit'
+
+export type GQLFederationAuthorSettingState = 'disabled' | 'enabled'
+
 export type GQLFilterInput = {
   inRangeEnd?: InputMaybe<Scalars['DateTime']['input']>
   inRangeStart?: InputMaybe<Scalars['DateTime']['input']>
@@ -2147,6 +2161,7 @@ export type GQLMutation = {
   /** Publish an article onto IPFS. */
   publishArticle: GQLDraft
   putAnnouncement: GQLAnnouncement
+  putArticleFederationSetting: GQLArticleFederationSetting
   /** Create or update a Circle. */
   putCircle: GQLCircle
   /**
@@ -2172,6 +2187,7 @@ export type GQLMutation = {
   putTagChannel: GQLTag
   putTopicChannel: GQLTopicChannel
   putUserFeatureFlags: Array<GQLUser>
+  putUserFederationSetting: GQLUserFederationSetting
   putWritingChallenge: GQLWritingChallenge
   /** Read an article. */
   readArticle: GQLArticle
@@ -2434,6 +2450,10 @@ export type GQLMutationPutAnnouncementArgs = {
   input: GQLPutAnnouncementInput
 }
 
+export type GQLMutationPutArticleFederationSettingArgs = {
+  input: GQLPutArticleFederationSettingInput
+}
+
 export type GQLMutationPutCircleArgs = {
   input: GQLPutCircleInput
 }
@@ -2496,6 +2516,10 @@ export type GQLMutationPutTopicChannelArgs = {
 
 export type GQLMutationPutUserFeatureFlagsArgs = {
   input: GQLPutUserFeatureFlagsInput
+}
+
+export type GQLMutationPutUserFederationSettingArgs = {
+  input: GQLPutUserFederationSettingInput
 }
 
 export type GQLMutationPutWritingChallengeArgs = {
@@ -3088,6 +3112,11 @@ export type GQLPutAnnouncementInput = {
   visible?: InputMaybe<Scalars['Boolean']['input']>
 }
 
+export type GQLPutArticleFederationSettingInput = {
+  id: Scalars['ID']['input']
+  state: GQLFederationArticleSettingState
+}
+
 export type GQLPutCircleArticlesInput = {
   /** Access Type, `public` or `paywall` only. */
   accessType: GQLArticleAccessType
@@ -3239,6 +3268,11 @@ export type GQLPutTopicChannelInput = {
 export type GQLPutUserFeatureFlagsInput = {
   flags: Array<GQLUserFeatureFlagType>
   ids: Array<Scalars['ID']['input']>
+}
+
+export type GQLPutUserFederationSettingInput = {
+  id: Scalars['ID']['input']
+  state: GQLFederationAuthorSettingState
 }
 
 export type GQLPutWritingChallengeInput = {
@@ -4557,6 +4591,13 @@ export type GQLUserFeatureFlagType =
   | 'readSpamStatus'
   | 'unlimitedArticleFetch'
 
+export type GQLUserFederationSetting = {
+  __typename?: 'UserFederationSetting'
+  state: GQLFederationAuthorSettingState
+  updatedBy?: Maybe<Scalars['ID']['output']>
+  userId: Scalars['ID']['output']
+}
+
 export type GQLUserGroup = 'a' | 'b'
 
 export type GQLUserInfo = {
@@ -5187,6 +5228,7 @@ export type GQLResolversTypes = ResolversObject<{
   ArticleEdge: ResolverTypeWrapper<
     Omit<GQLArticleEdge, 'node'> & { node: GQLResolversTypes['Article'] }
   >
+  ArticleFederationSetting: ResolverTypeWrapper<GQLArticleFederationSetting>
   ArticleInput: GQLArticleInput
   ArticleLicenseType: GQLArticleLicenseType
   ArticleNotice: ResolverTypeWrapper<NoticeItemModel>
@@ -5412,6 +5454,8 @@ export type GQLResolversTypes = ResolversObject<{
   FeatureName: GQLFeatureName
   FeaturedCommentsInput: GQLFeaturedCommentsInput
   FeaturedTagsInput: GQLFeaturedTagsInput
+  FederationArticleSettingState: GQLFederationArticleSettingState
+  FederationAuthorSettingState: GQLFederationAuthorSettingState
   FilterInput: GQLFilterInput
   Float: ResolverTypeWrapper<Scalars['Float']['output']>
   Following: ResolverTypeWrapper<UserModel>
@@ -5583,6 +5627,7 @@ export type GQLResolversTypes = ResolversObject<{
   PublishArticleInput: GQLPublishArticleInput
   PublishState: GQLPublishState
   PutAnnouncementInput: GQLPutAnnouncementInput
+  PutArticleFederationSettingInput: GQLPutArticleFederationSettingInput
   PutCircleArticlesInput: GQLPutCircleArticlesInput
   PutCircleArticlesType: GQLPutCircleArticlesType
   PutCircleInput: GQLPutCircleInput
@@ -5599,6 +5644,7 @@ export type GQLResolversTypes = ResolversObject<{
   PutTagChannelInput: GQLPutTagChannelInput
   PutTopicChannelInput: GQLPutTopicChannelInput
   PutUserFeatureFlagsInput: GQLPutUserFeatureFlagsInput
+  PutUserFederationSettingInput: GQLPutUserFederationSettingInput
   PutWritingChallengeInput: GQLPutWritingChallengeInput
   Query: ResolverTypeWrapper<{}>
   QuoteCurrency: GQLQuoteCurrency
@@ -5844,6 +5890,7 @@ export type GQLResolversTypes = ResolversObject<{
   >
   UserFeatureFlag: ResolverTypeWrapper<GQLUserFeatureFlag>
   UserFeatureFlagType: GQLUserFeatureFlagType
+  UserFederationSetting: ResolverTypeWrapper<GQLUserFederationSetting>
   UserGroup: GQLUserGroup
   UserInfo: ResolverTypeWrapper<UserModel>
   UserInfoFields: GQLUserInfoFields
@@ -5950,6 +5997,7 @@ export type GQLResolversParentTypes = ResolversObject<{
   ArticleEdge: Omit<GQLArticleEdge, 'node'> & {
     node: GQLResolversParentTypes['Article']
   }
+  ArticleFederationSetting: GQLArticleFederationSetting
   ArticleInput: GQLArticleInput
   ArticleNotice: NoticeItemModel
   ArticleOSS: ArticleModel
@@ -6242,6 +6290,7 @@ export type GQLResolversParentTypes = ResolversObject<{
   Price: CirclePriceModel
   PublishArticleInput: GQLPublishArticleInput
   PutAnnouncementInput: GQLPutAnnouncementInput
+  PutArticleFederationSettingInput: GQLPutArticleFederationSettingInput
   PutCircleArticlesInput: GQLPutCircleArticlesInput
   PutCircleInput: GQLPutCircleInput
   PutCollectionInput: GQLPutCollectionInput
@@ -6257,6 +6306,7 @@ export type GQLResolversParentTypes = ResolversObject<{
   PutTagChannelInput: GQLPutTagChannelInput
   PutTopicChannelInput: GQLPutTopicChannelInput
   PutUserFeatureFlagsInput: GQLPutUserFeatureFlagsInput
+  PutUserFederationSettingInput: GQLPutUserFederationSettingInput
   PutWritingChallengeInput: GQLPutWritingChallengeInput
   Query: {}
   ReadArticleInput: GQLReadArticleInput
@@ -6445,6 +6495,7 @@ export type GQLResolversParentTypes = ResolversObject<{
     node: GQLResolversParentTypes['User']
   }
   UserFeatureFlag: GQLUserFeatureFlag
+  UserFederationSetting: GQLUserFederationSetting
   UserInfo: UserModel
   UserInput: GQLUserInput
   UserNotice: NoticeItemModel
@@ -7077,6 +7128,20 @@ export type GQLArticleEdgeResolvers<
 > = ResolversObject<{
   cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
   node?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArticleFederationSettingResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArticleFederationSetting'] = GQLResolversParentTypes['ArticleFederationSetting']
+> = ResolversObject<{
+  articleId?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  state?: Resolver<
+    GQLResolversTypes['FederationArticleSettingState'],
+    ParentType,
+    ContextType
+  >
+  updatedBy?: Resolver<Maybe<GQLResolversTypes['ID']>, ParentType, ContextType>
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }>
 
@@ -8893,6 +8958,12 @@ export type GQLMutationResolvers<
     ContextType,
     RequireFields<GQLMutationPutAnnouncementArgs, 'input'>
   >
+  putArticleFederationSetting?: Resolver<
+    GQLResolversTypes['ArticleFederationSetting'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPutArticleFederationSettingArgs, 'input'>
+  >
   putCircle?: Resolver<
     GQLResolversTypes['Circle'],
     ParentType,
@@ -8988,6 +9059,12 @@ export type GQLMutationResolvers<
     ParentType,
     ContextType,
     RequireFields<GQLMutationPutUserFeatureFlagsArgs, 'input'>
+  >
+  putUserFederationSetting?: Resolver<
+    GQLResolversTypes['UserFederationSetting'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPutUserFederationSettingArgs, 'input'>
   >
   putWritingChallenge?: Resolver<
     GQLResolversTypes['WritingChallenge'],
@@ -10862,6 +10939,20 @@ export type GQLUserFeatureFlagResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }>
 
+export type GQLUserFederationSettingResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UserFederationSetting'] = GQLResolversParentTypes['UserFederationSetting']
+> = ResolversObject<{
+  state?: Resolver<
+    GQLResolversTypes['FederationAuthorSettingState'],
+    ParentType,
+    ContextType
+  >
+  updatedBy?: Resolver<Maybe<GQLResolversTypes['ID']>, ParentType, ContextType>
+  userId?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
 export type GQLUserInfoResolvers<
   ContextType = Context,
   ParentType extends GQLResolversParentTypes['UserInfo'] = GQLResolversParentTypes['UserInfo']
@@ -11275,6 +11366,7 @@ export type GQLResolvers<ContextType = Context> = ResolversObject<{
   ArticleDonationConnection?: GQLArticleDonationConnectionResolvers<ContextType>
   ArticleDonationEdge?: GQLArticleDonationEdgeResolvers<ContextType>
   ArticleEdge?: GQLArticleEdgeResolvers<ContextType>
+  ArticleFederationSetting?: GQLArticleFederationSettingResolvers<ContextType>
   ArticleNotice?: GQLArticleNoticeResolvers<ContextType>
   ArticleOSS?: GQLArticleOssResolvers<ContextType>
   ArticleRecommendationActivity?: GQLArticleRecommendationActivityResolvers<ContextType>
@@ -11430,6 +11522,7 @@ export type GQLResolvers<ContextType = Context> = ResolversObject<{
   UserCreateCircleActivity?: GQLUserCreateCircleActivityResolvers<ContextType>
   UserEdge?: GQLUserEdgeResolvers<ContextType>
   UserFeatureFlag?: GQLUserFeatureFlagResolvers<ContextType>
+  UserFederationSetting?: GQLUserFederationSettingResolvers<ContextType>
   UserInfo?: GQLUserInfoResolvers<ContextType>
   UserNotice?: GQLUserNoticeResolvers<ContextType>
   UserOSS?: GQLUserOssResolvers<ContextType>

--- a/src/mutations/system/__test__/federationSetting.test.ts
+++ b/src/mutations/system/__test__/federationSetting.test.ts
@@ -1,0 +1,120 @@
+import { NODE_TYPES } from '#common/enums/index.js'
+import { toGlobalId } from '#common/utils/index.js'
+import { jest } from '@jest/globals'
+
+import putArticleFederationSetting from '../putArticleFederationSetting.js'
+import putUserFederationSetting from '../putUserFederationSetting.js'
+
+describe('federation setting mutations', () => {
+  test('upserts author federation setting with global IDs', async () => {
+    const upsertAuthorFederationSetting = jest.fn(async () => ({
+      userId: '2',
+      state: 'enabled',
+      updatedBy: '9',
+    }))
+
+    const result = await (putUserFederationSetting as any)(
+      {},
+      {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.User, id: '2' }),
+          state: 'enabled',
+        },
+      },
+      {
+        viewer: { id: '9' },
+        dataSources: {
+          federationExportService: { upsertAuthorFederationSetting },
+        },
+      }
+    )
+
+    expect(upsertAuthorFederationSetting).toHaveBeenCalledWith({
+      userId: '2',
+      state: 'enabled',
+      updatedBy: '9',
+    })
+    expect(result).toEqual({
+      userId: toGlobalId({ type: NODE_TYPES.User, id: '2' }),
+      state: 'enabled',
+      updatedBy: toGlobalId({ type: NODE_TYPES.User, id: '9' }),
+    })
+  })
+
+  test('upserts article federation setting with global IDs', async () => {
+    const upsertArticleFederationSetting = jest.fn(async () => ({
+      articleId: '1',
+      state: 'disabled',
+      updatedBy: '9',
+    }))
+
+    const result = await (putArticleFederationSetting as any)(
+      {},
+      {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.Article, id: '1' }),
+          state: 'disabled',
+        },
+      },
+      {
+        viewer: { id: '9' },
+        dataSources: {
+          federationExportService: { upsertArticleFederationSetting },
+        },
+      }
+    )
+
+    expect(upsertArticleFederationSetting).toHaveBeenCalledWith({
+      articleId: '1',
+      state: 'disabled',
+      updatedBy: '9',
+    })
+    expect(result).toEqual({
+      articleId: toGlobalId({ type: NODE_TYPES.Article, id: '1' }),
+      state: 'disabled',
+      updatedBy: toGlobalId({ type: NODE_TYPES.User, id: '9' }),
+    })
+  })
+
+  test('rejects IDs for the wrong node type', async () => {
+    await expect(
+      (putUserFederationSetting as any)(
+        {},
+        {
+          input: {
+            id: toGlobalId({ type: NODE_TYPES.Article, id: '1' }),
+            state: 'enabled',
+          },
+        },
+        {
+          viewer: { id: '9' },
+          dataSources: {
+            federationExportService: {
+              upsertAuthorFederationSetting: jest.fn(),
+            },
+          },
+        }
+      )
+    ).rejects.toMatchObject({ extensions: { code: 'BAD_USER_INPUT' } })
+
+    await expect(
+      (putArticleFederationSetting as any)(
+        {},
+        {
+          input: {
+            id: toGlobalId({ type: NODE_TYPES.User, id: '2' }),
+            state: 'disabled',
+          },
+        },
+        {
+          viewer: { id: '9' },
+          dataSources: {
+            federationExportService: {
+              upsertArticleFederationSetting: jest.fn(),
+            },
+          },
+        }
+      )
+    ).rejects.toMatchObject({ extensions: { code: 'BAD_USER_INPUT' } })
+  })
+})

--- a/src/mutations/system/index.ts
+++ b/src/mutations/system/index.ts
@@ -4,11 +4,13 @@ import deleteBlockedSearchKeywords from './deleteBlockedSearchKeywords.js'
 import directImageUpload from './directImageUpload.js'
 import logRecord from './logRecord.js'
 import putAnnouncement from './putAnnouncement.js'
+import putArticleFederationSetting from './putArticleFederationSetting.js'
 import putIcymiTopic from './putIcymiTopic.js'
 import putRemark from './putRemark.js'
 import putRestrictedUsers from './putRestrictedUsers.js'
 import putSkippedListItem from './putSkippedListItem.js'
 import putUserFeatureFlags from './putUserFeatureFlags.js'
+import putUserFederationSetting from './putUserFederationSetting.js'
 import reviewTopicChannelFeedback from './reviewTopicChannelFeedback.js'
 import setAdStatus from './setAdStatus.js'
 import setBoost from './setBoost.js'
@@ -34,6 +36,8 @@ export default {
     deleteBlockedSearchKeywords,
     putRestrictedUsers,
     putUserFeatureFlags,
+    putUserFederationSetting,
+    putArticleFederationSetting,
     submitReport,
     putIcymiTopic,
     setSpamStatus,

--- a/src/mutations/system/putArticleFederationSetting.ts
+++ b/src/mutations/system/putArticleFederationSetting.ts
@@ -1,0 +1,33 @@
+import type { GQLMutationResolvers } from '#definitions/index.js'
+
+import { NODE_TYPES } from '#common/enums/index.js'
+import { UserInputError } from '#common/errors.js'
+import { fromGlobalId, toGlobalId } from '#common/utils/index.js'
+
+const resolver: GQLMutationResolvers['putArticleFederationSetting'] = async (
+  _: unknown,
+  { input: { id, state } },
+  { viewer, dataSources: { federationExportService } }
+) => {
+  const { id: articleId, type } = fromGlobalId(id)
+
+  if (type !== NODE_TYPES.Article) {
+    throw new UserInputError('id must be an Article ID')
+  }
+
+  const updated = await federationExportService.upsertArticleFederationSetting({
+    articleId,
+    state,
+    updatedBy: viewer.id || null,
+  })
+
+  return {
+    ...updated,
+    articleId: toGlobalId({ type: NODE_TYPES.Article, id: updated.articleId }),
+    updatedBy: updated.updatedBy
+      ? toGlobalId({ type: NODE_TYPES.User, id: updated.updatedBy })
+      : null,
+  }
+}
+
+export default resolver

--- a/src/mutations/system/putUserFederationSetting.ts
+++ b/src/mutations/system/putUserFederationSetting.ts
@@ -1,0 +1,33 @@
+import type { GQLMutationResolvers } from '#definitions/index.js'
+
+import { NODE_TYPES } from '#common/enums/index.js'
+import { UserInputError } from '#common/errors.js'
+import { fromGlobalId, toGlobalId } from '#common/utils/index.js'
+
+const resolver: GQLMutationResolvers['putUserFederationSetting'] = async (
+  _: unknown,
+  { input: { id, state } },
+  { viewer, dataSources: { federationExportService } }
+) => {
+  const { id: userId, type } = fromGlobalId(id)
+
+  if (type !== NODE_TYPES.User) {
+    throw new UserInputError('id must be a User ID')
+  }
+
+  const updated = await federationExportService.upsertAuthorFederationSetting({
+    userId,
+    state,
+    updatedBy: viewer.id || null,
+  })
+
+  return {
+    ...updated,
+    userId: toGlobalId({ type: NODE_TYPES.User, id: updated.userId }),
+    updatedBy: updated.updatedBy
+      ? toGlobalId({ type: NODE_TYPES.User, id: updated.updatedBy })
+      : null,
+  }
+}
+
+export default resolver

--- a/src/routes/graphql.ts
+++ b/src/routes/graphql.ts
@@ -33,6 +33,7 @@ import {
   SearchService,
   LikeCoin,
   ExchangeRate,
+  FederationExportService,
 } from '#connectors/index.js'
 import {
   RevisionQueue,
@@ -163,6 +164,7 @@ export const graphql = async (app: Express) => {
       translationService: new TranslationService(connections),
       notificationService: new NotificationService(connections),
       searchService: new SearchService(connections),
+      federationExportService: new FederationExportService(connections),
       connections,
       queues,
     }

--- a/src/types/__test__/2/system.test.ts
+++ b/src/types/__test__/2/system.test.ts
@@ -300,6 +300,26 @@ const PUT_USER_FEATURE_FLAGS = /* GraphQL */ `
   }
 `
 
+const PUT_USER_FEDERATION_SETTING = /* GraphQL */ `
+  mutation ($input: PutUserFederationSettingInput!) {
+    putUserFederationSetting(input: $input) {
+      userId
+      state
+      updatedBy
+    }
+  }
+`
+
+const PUT_ARTICLE_FEDERATION_SETTING = /* GraphQL */ `
+  mutation ($input: PutArticleFederationSettingInput!) {
+    putArticleFederationSetting(input: $input) {
+      articleId
+      state
+      updatedBy
+    }
+  }
+`
+
 describe('query nodes of different type', () => {
   test('query user node', async () => {
     const id = toGlobalId({ type: NODE_TYPES.User, id: 1 })
@@ -995,6 +1015,65 @@ describe('user feature flags', () => {
         ({ type }: { type: GQLUserFeatureFlagType }) => type
       )
     ).toEqual(['bypassSpamDetection'])
+  })
+})
+
+describe('federation settings', () => {
+  const userId = toGlobalId({ type: NODE_TYPES.User, id: '2' })
+  const articleId = toGlobalId({ type: NODE_TYPES.Article, id: '1' })
+
+  test('only admin can update author federation setting', async () => {
+    const notAdminServer = await testClient({
+      isAuth: true,
+      isAdmin: false,
+      connections,
+    })
+    const { errors } = await notAdminServer.executeOperation({
+      query: PUT_USER_FEDERATION_SETTING,
+      variables: { input: { id: userId, state: 'enabled' } },
+    })
+    expect(errors![0]!.extensions!.code).toBe('FORBIDDEN')
+
+    const adminServer = await testClient({
+      isAuth: true,
+      isAdmin: true,
+      connections,
+    })
+    const { data } = await adminServer.executeOperation({
+      query: PUT_USER_FEDERATION_SETTING,
+      variables: { input: { id: userId, state: 'enabled' } },
+    })
+    expect(data!.putUserFederationSetting).toMatchObject({
+      userId,
+      state: 'enabled',
+    })
+  })
+
+  test('only admin can update article federation setting', async () => {
+    const notAdminServer = await testClient({
+      isAuth: true,
+      isAdmin: false,
+      connections,
+    })
+    const { errors } = await notAdminServer.executeOperation({
+      query: PUT_ARTICLE_FEDERATION_SETTING,
+      variables: { input: { id: articleId, state: 'disabled' } },
+    })
+    expect(errors![0]!.extensions!.code).toBe('FORBIDDEN')
+
+    const adminServer = await testClient({
+      isAuth: true,
+      isAdmin: true,
+      connections,
+    })
+    const { data } = await adminServer.executeOperation({
+      query: PUT_ARTICLE_FEDERATION_SETTING,
+      variables: { input: { id: articleId, state: 'disabled' } },
+    })
+    expect(data!.putArticleFederationSetting).toMatchObject({
+      articleId,
+      state: 'disabled',
+    })
   })
 })
 

--- a/src/types/__test__/utils.ts
+++ b/src/types/__test__/utils.ts
@@ -30,6 +30,7 @@ import {
   TranslationService,
   ChannelService,
   SearchService,
+  FederationExportService,
 } from '#connectors/index.js'
 import {
   RevisionQueue,
@@ -195,6 +196,7 @@ export const testClient = async ({
       translationService: new TranslationService(connections),
       channelService: new ChannelService(connections),
       searchService: new SearchService(connections),
+      federationExportService: new FederationExportService(connections),
       notificationService,
       connections,
       queues,

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -46,6 +46,8 @@ export default /* GraphQL */ `
     deleteAnnouncements(input: DeleteAnnouncementsInput!): Boolean! @auth(mode: "${AUTH_MODE.admin}")
     putRestrictedUsers(input: PutRestrictedUsersInput!): [User!]! @complexity(value: 1, multipliers: ["input.ids"]) @auth(mode: "${AUTH_MODE.admin}")
     putUserFeatureFlags(input: PutUserFeatureFlagsInput!): [User!]! @complexity(value: 1, multipliers: ["input.ids"]) @auth(mode: "${AUTH_MODE.admin}")
+    putUserFederationSetting(input: PutUserFederationSettingInput!): UserFederationSetting! @auth(mode: "${AUTH_MODE.admin}")
+    putArticleFederationSetting(input: PutArticleFederationSettingInput!): ArticleFederationSetting! @auth(mode: "${AUTH_MODE.admin}")
     putIcymiTopic(input: PutIcymiTopicInput!): IcymiTopic @auth(mode: "${AUTH_MODE.admin}") @purgeCache(type: "${NODE_TYPES.IcymiTopic}")
     setSpamStatus(input: SetSpamStatusInput!): Writing! @auth(mode: "${AUTH_MODE.admin}") @purgeCache(type: "${NODE_TYPES.Writing}")
     setAdStatus(input: SetAdStatusInput!): Article! @auth(mode: "${AUTH_MODE.admin}") @purgeCache(type: "${NODE_TYPES.Article}")
@@ -403,6 +405,16 @@ export default /* GraphQL */ `
     flags: [UserFeatureFlagType!]!
   }
 
+  input PutUserFederationSettingInput {
+    id: ID!
+    state: FederationAuthorSettingState!
+  }
+
+  input PutArticleFederationSettingInput {
+    id: ID!
+    state: FederationArticleSettingState!
+  }
+
   input SubmitReportInput {
     targetId: ID!
     reason: ReportReason!
@@ -530,6 +542,29 @@ export default /* GraphQL */ `
     unlimitedArticleFetch
     readSpamStatus
     communityWatch
+  }
+
+  enum FederationAuthorSettingState {
+    enabled
+    disabled
+  }
+
+  enum FederationArticleSettingState {
+    inherit
+    enabled
+    disabled
+  }
+
+  type UserFederationSetting {
+    userId: ID!
+    state: FederationAuthorSettingState!
+    updatedBy: ID
+  }
+
+  type ArticleFederationSetting {
+    articleId: ID!
+    state: FederationArticleSettingState!
+    updatedBy: ID
   }
 
   enum ReportReason {


### PR DESCRIPTION
## Summary
- add admin-only GraphQL mutations for author/article federation settings
- wire FederationExportService into GraphQL data sources
- return global GraphQL IDs and record the admin updater
- document the narrow internal/staging scope

## Safety
- no production deployment change
- no bundle generation, IPFS/IPNS publish, or ActivityPub publish trigger
- no article visibility change
- mutations require admin auth and only update federation setting tables

## Verification
- npm run build
- npm run lint
- npm run gen
- npm run testcmd -- build/mutations/system/__test__/federationSetting.test.js --runInBand --forceExit

Note: local GraphQL system integration test could not run because local Postgres on ::1:5432 is not available; CI should run it with service dependencies.