### PR TITLE
feat: add Community Watch staff review actions

### DIFF
--- a/db/migrations/20260511001000_create_community_watch_review_event_table.js
+++ b/db/migrations/20260511001000_create_community_watch_review_event_table.js
@@ -1,0 +1,37 @@
+const table = 'community_watch_review_event'
+
+export const up = async (knex) => {
+  await knex('entity_type').insert({ table })
+
+  await knex.schema.createTable(table, (t) => {
+    t.bigIncrements('id').primary()
+    t.uuid('uuid').notNullable().unique()
+    t.bigInteger('action_id').unsigned().notNullable()
+    t.enu('event_type', [
+      'appeal_received',
+      'appeal_resolved',
+      'review_upheld',
+      'review_reversed',
+      'reason_changed',
+      'comment_restored',
+      'content_cleared',
+      'state_updated',
+    ]).notNullable()
+    t.bigInteger('actor_id').unsigned().notNullable()
+    t.text('old_value')
+    t.text('new_value')
+    t.text('note')
+    t.timestamp('created_at').defaultTo(knex.fn.now())
+
+    t.foreign('action_id').references('id').inTable('community_watch_action')
+    t.foreign('actor_id').references('id').inTable('user')
+    t.index(['action_id', 'created_at'])
+    t.index(['actor_id', 'created_at'])
+    t.index(['event_type', 'created_at'])
+  })
+}
+
+export const down = async (knex) => {
+  await knex('entity_type').where({ table }).del()
+  await knex.schema.dropTable(table)
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -120,6 +120,15 @@ type Mutation {
   """Remove a spam comment as a Community Watch member."""
   communityWatchRemoveComment(input: CommunityWatchRemoveCommentInput!): Comment!
 
+  """Update Community Watch appeal, review, or reason as staff."""
+  updateCommunityWatchActionState(input: UpdateCommunityWatchActionStateInput!): CommunityWatchAction!
+
+  """Restore a comment removed by Community Watch as staff."""
+  restoreCommunityWatchComment(input: RestoreCommunityWatchCommentInput!): CommunityWatchAction!
+
+  """Clear stored original content for a Community Watch action as staff."""
+  clearCommunityWatchOriginalContent(input: ClearCommunityWatchOriginalContentInput!): CommunityWatchAction!
+
   """Pin a comment."""
   pinComment(input: PinCommentInput!): Comment!
 
@@ -1756,6 +1765,24 @@ input CommunityWatchActionsInput {
 
 input CommunityWatchActionInput {
   uuid: ID!
+}
+
+input UpdateCommunityWatchActionStateInput {
+  uuid: ID!
+  appealState: CommunityWatchAppealState
+  reviewState: CommunityWatchReviewState
+  reason: CommunityWatchRemoveCommentReason
+  note: String
+}
+
+input RestoreCommunityWatchCommentInput {
+  uuid: ID!
+  note: String
+}
+
+input ClearCommunityWatchOriginalContentInput {
+  uuid: ID!
+  note: String
 }
 
 enum CommunityWatchRemoveCommentReason {

--- a/src/common/utils/__test__/communityWatchReviewEventMigration.test.ts
+++ b/src/common/utils/__test__/communityWatchReviewEventMigration.test.ts
@@ -1,0 +1,127 @@
+import { pathToFileURL } from 'url'
+
+type Migration = {
+  up: (knex: MockKnex) => Promise<void>
+  down: (knex: MockKnex) => Promise<void>
+}
+
+type MockKnex = {
+  (table: string): {
+    insert: (data: Record<string, string>) => Promise<void>
+    where: (query: Record<string, string>) => {
+      del: () => Promise<void>
+    }
+  }
+  fn: {
+    now: () => Date
+  }
+  schema: {
+    createTable: (
+      table: string,
+      callback: (tableBuilder: MockTableBuilder) => void
+    ) => Promise<void>
+    dropTable: (table: string) => Promise<void>
+  }
+}
+
+type MockTableBuilder = Record<string, (...args: any[]) => MockTableBuilder>
+
+const migrationUrl = pathToFileURL(
+  `${process.cwd()}/db/migrations/20260511001000_create_community_watch_review_event_table.js`
+).href
+
+const createTableBuilder = (calls: string[]) => {
+  const builder = new Proxy(
+    {},
+    {
+      get: (_, prop: string) => {
+        if (prop === 'foreign') {
+          return (column: string) => {
+            calls.push(`foreign:${column}`)
+            return builder
+          }
+        }
+        if (['references', 'inTable', 'notNullable', 'unique'].includes(prop)) {
+          return () => builder
+        }
+        return (...args: any[]) => {
+          calls.push(`${prop}:${args[0] ?? ''}`)
+          return builder
+        }
+      },
+    }
+  )
+  return builder as MockTableBuilder
+}
+
+const createKnex = () => {
+  const entityTypeInserts: Array<Record<string, string>> = []
+  const entityTypeDeletes: Array<Record<string, string>> = []
+  const tableCalls: string[] = []
+  const droppedTables: string[] = []
+
+  const knex = ((table: string) => ({
+    insert: async (data: Record<string, string>) => {
+      entityTypeInserts.push(data)
+    },
+    where: (query: Record<string, string>) => ({
+      del: async () => {
+        entityTypeDeletes.push(query)
+      },
+    }),
+  })) as MockKnex
+
+  knex.fn = { now: () => new Date('2026-05-11T00:00:00.000Z') }
+  knex.schema = {
+    createTable: async (table: string, callback) => {
+      tableCalls.push(`create:${table}`)
+      callback(createTableBuilder(tableCalls))
+    },
+    dropTable: async (table: string) => {
+      droppedTables.push(table)
+    },
+  }
+
+  return { knex, entityTypeInserts, entityTypeDeletes, tableCalls, droppedTables }
+}
+
+describe('community watch review event migration', () => {
+  test('creates append-only staff review event table', async () => {
+    const { up } = (await import(migrationUrl)) as Migration
+    const { knex, entityTypeInserts, tableCalls } = createKnex()
+
+    await up(knex)
+
+    expect(entityTypeInserts).toEqual([
+      { table: 'community_watch_review_event' },
+    ])
+    expect(tableCalls).toEqual(
+      expect.arrayContaining([
+        'create:community_watch_review_event',
+        'bigIncrements:id',
+        'uuid:uuid',
+        'bigInteger:action_id',
+        'enu:event_type',
+        'bigInteger:actor_id',
+        'text:old_value',
+        'text:new_value',
+        'text:note',
+        'foreign:action_id',
+        'foreign:actor_id',
+        'index:action_id,created_at',
+      ])
+    )
+  })
+
+  test('drops event table and entity type on rollback', async () => {
+    const { down } = (await import(migrationUrl)) as Migration
+    const { knex, entityTypeDeletes, droppedTables } = createKnex()
+
+    await down(knex)
+
+    expect(entityTypeDeletes).toEqual([
+      { table: 'community_watch_review_event' },
+    ])
+    expect(droppedTables).toEqual(['community_watch_review_event'])
+  })
+})

--- a/src/common/utils/__test__/communityWatchStaffReview.test.ts
+++ b/src/common/utils/__test__/communityWatchStaffReview.test.ts
@@ -1,0 +1,383 @@
+import type { Comment, CommunityWatchAction } from '#definitions/index.js'
+
+import { jest } from '@jest/globals'
+
+import {
+  COMMENT_STATE,
+  COMMENT_TYPE,
+} from '#common/enums/index.js'
+import { CommentService } from '#connectors/commentService.js'
+import clearCommunityWatchOriginalContent from '#mutations/comment/clearCommunityWatchOriginalContent.js'
+import restoreCommunityWatchComment from '#mutations/comment/restoreCommunityWatchComment.js'
+import updateCommunityWatchActionState from '#mutations/comment/updateCommunityWatchActionState.js'
+
+const clearMutation = clearCommunityWatchOriginalContent as any
+const restoreMutation = restoreCommunityWatchComment as any
+const updateMutation = updateCommunityWatchActionState as any
+
+const baseAction: CommunityWatchAction = {
+  id: '501',
+  uuid: 'cw-action-uuid',
+  commentId: '101',
+  commentType: COMMENT_TYPE.article,
+  targetType: COMMENT_TYPE.article,
+  targetId: '11',
+  targetTitle: 'Article title',
+  targetShortHash: 'article-hash',
+  reason: 'porn_ad',
+  actorId: '2',
+  commentAuthorId: '1',
+  originalContent: '<p>spam</p>',
+  originalState: COMMENT_STATE.active,
+  actionState: 'active',
+  appealState: 'none',
+  reviewState: 'pending',
+  reviewerId: null,
+  reviewNote: null,
+  reviewedAt: null,
+  contentExpiresAt: new Date('2026-05-18T00:00:00.000Z'),
+  createdAt: new Date('2026-05-11T00:00:00.000Z'),
+  updatedAt: new Date('2026-05-11T00:00:00.000Z'),
+}
+
+const baseComment: Comment = {
+  id: '101',
+  uuid: 'comment-uuid',
+  authorId: '1',
+  articleId: null,
+  articleVersionId: null,
+  parentCommentId: null,
+  content: '<p>spam</p>',
+  state: COMMENT_STATE.banned,
+  pinned: false,
+  quotationStart: null,
+  quotationEnd: null,
+  quotationContent: null,
+  replyTo: null,
+  remark: null,
+  targetId: '11',
+  targetTypeId: '1',
+  type: COMMENT_TYPE.article,
+  pinnedAt: null,
+  spamScore: null,
+  isSpam: null,
+  createdAt: new Date('2026-05-11T00:00:00.000Z'),
+  updatedAt: new Date('2026-05-11T00:00:00.000Z'),
+}
+
+const createService = ({
+  action = baseAction,
+  comment = baseComment,
+}: {
+  action?: CommunityWatchAction | null
+  comment?: Comment | null
+} = {}) => {
+  const actionUpdates: any[] = []
+  const commentUpdates: any[] = []
+  const eventInserts: any[] = []
+
+  const createBuilder = (table: string) => {
+    const builder: any = {
+      select: () => builder,
+      where: () => builder,
+      forUpdate: () => builder,
+      first: async () => {
+        if (table === 'community_watch_action') {
+          return action
+        }
+        if (table === 'comment') {
+          return comment
+        }
+        return undefined
+      },
+      update: (data: any) => {
+        if (table === 'community_watch_action') {
+          actionUpdates.push(data)
+        }
+        if (table === 'comment') {
+          commentUpdates.push(data)
+        }
+        return builder
+      },
+      returning: async () => {
+        if (table === 'community_watch_action') {
+          return [{ ...action, ...actionUpdates.at(-1) }]
+        }
+        if (table === 'comment') {
+          return [{ ...comment, ...commentUpdates.at(-1) }]
+        }
+        return []
+      },
+      insert: async (data: any) => {
+        if (table === 'community_watch_review_event') {
+          eventInserts.push(...data)
+        }
+      },
+    }
+    return builder
+  }
+
+  const trx = ((table: string) => createBuilder(table)) as any
+  const knex = (() => createBuilder('')) as any
+  knex.transaction = async (callback: (trx: any) => Promise<any>) =>
+    callback(trx)
+
+  const service = new CommentService({
+    knex,
+    knexRO: knex,
+    knexSearch: knex,
+    redis: {},
+    objectCacheRedis: {},
+  } as any)
+
+  return { service, actionUpdates, commentUpdates, eventInserts }
+}
+
+const createMutationContext = ({
+  isAdmin = true,
+  commentService = {},
+}: {
+  isAdmin?: boolean
+  commentService?: Record<string, unknown>
+} = {}) =>
+  ({
+    viewer: {
+      id: '9',
+      hasRole: (role: string) => isAdmin && role === 'admin',
+    },
+    dataSources: {
+      commentService,
+      connections: { redis: { smembers: async () => [] } },
+    },
+  }) as any
+
+describe('community watch staff review service', () => {
+  test('updates appeal, review, and reason with review events', async () => {
+    const { service, actionUpdates, eventInserts } = createService()
+
+    const result = await service.updateCommunityWatchActionState({
+      uuid: baseAction.uuid,
+      actorId: '9',
+      appealState: 'received',
+      reviewState: 'upheld',
+      reason: 'spam_ad',
+      note: 'reviewed by staff',
+    })
+
+    expect(result.reason).toBe('spam_ad')
+    expect(actionUpdates[0]).toEqual(
+      expect.objectContaining({
+        appealState: 'received',
+        reviewState: 'upheld',
+        reason: 'spam_ad',
+        reviewerId: '9',
+        reviewNote: 'reviewed by staff',
+      })
+    )
+    expect(eventInserts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: 'appeal_received',
+          oldValue: 'none',
+          newValue: 'received',
+          actorId: '9',
+        }),
+        expect.objectContaining({
+          eventType: 'review_upheld',
+          oldValue: 'pending',
+          newValue: 'upheld',
+        }),
+        expect.objectContaining({
+          eventType: 'reason_changed',
+          oldValue: 'porn_ad',
+          newValue: 'spam_ad',
+        }),
+      ])
+    )
+  })
+
+  test('restores the comment and marks the action as reversed', async () => {
+    const { service, actionUpdates, commentUpdates, eventInserts } =
+      createService()
+
+    const result = await service.restoreCommunityWatchComment({
+      uuid: baseAction.uuid,
+      actorId: '9',
+      note: 'appeal accepted',
+    })
+
+    expect(result.comment.state).toBe(COMMENT_STATE.active)
+    expect(commentUpdates[0]).toEqual(
+      expect.objectContaining({ state: COMMENT_STATE.active })
+    )
+    expect(actionUpdates[0]).toEqual(
+      expect.objectContaining({
+        actionState: 'restored',
+        reviewState: 'reversed',
+        reviewerId: '9',
+      })
+    )
+    expect(eventInserts[0]).toEqual(
+      expect.objectContaining({
+        eventType: 'comment_restored',
+        oldValue: COMMENT_STATE.banned,
+        newValue: COMMENT_STATE.active,
+      })
+    )
+  })
+
+  test('requires the restore mutation for reversed review state', async () => {
+    const { service } = createService()
+
+    await expect(
+      service.updateCommunityWatchActionState({
+        uuid: baseAction.uuid,
+        actorId: '9',
+        reviewState: 'reversed',
+      })
+    ).rejects.toHaveProperty('extensions.code', 'BAD_USER_INPUT')
+  })
+
+  test('clears original content while keeping the audit row', async () => {
+    const { service, actionUpdates, eventInserts } = createService()
+
+    const result = await service.clearCommunityWatchOriginalContent({
+      uuid: baseAction.uuid,
+      actorId: '9',
+      note: 'privacy request',
+    })
+
+    expect(result.originalContent).toBeNull()
+    expect(actionUpdates[0]).toEqual(
+      expect.objectContaining({
+        originalContent: null,
+        reviewerId: '9',
+        reviewNote: 'privacy request',
+      })
+    )
+    expect(eventInserts[0]).toEqual(
+      expect.objectContaining({
+        eventType: 'content_cleared',
+        oldValue: 'present',
+        newValue: null,
+      })
+    )
+  })
+})
+
+describe('community watch staff review mutations', () => {
+  test('requires admin permission for state updates', async () => {
+    await expect(
+      updateMutation(
+        {},
+        { input: { uuid: baseAction.uuid, appealState: 'received' } },
+        createMutationContext({ isAdmin: false }),
+        {} as any
+      )
+    ).rejects.toHaveProperty('extensions.code', 'FORBIDDEN')
+  })
+
+  test('passes the viewer and input to the state update service', async () => {
+    const updateCommunityWatchActionStateService = jest
+      .fn<any>()
+      .mockResolvedValue(baseAction)
+    const context = createMutationContext({
+      commentService: {
+        updateCommunityWatchActionState: updateCommunityWatchActionStateService,
+      },
+    })
+
+    await updateMutation(
+      {},
+      {
+        input: {
+          uuid: baseAction.uuid,
+          reason: 'spam_ad',
+          note: 'wrong reason',
+        },
+      },
+      context,
+      {} as any
+    )
+
+    expect(updateCommunityWatchActionStateService).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uuid: baseAction.uuid,
+        actorId: '9',
+        reason: 'spam_ad',
+        note: 'wrong reason',
+      })
+    )
+  })
+
+  test('requires admin permission for restore and clear mutations', async () => {
+    await expect(
+      restoreMutation(
+        {},
+        { input: { uuid: baseAction.uuid } },
+        createMutationContext({ isAdmin: false }),
+        {} as any
+      )
+    ).rejects.toHaveProperty('extensions.code', 'FORBIDDEN')
+
+    await expect(
+      clearMutation(
+        {},
+        { input: { uuid: baseAction.uuid } },
+        createMutationContext({ isAdmin: false }),
+        {} as any
+      )
+    ).rejects.toHaveProperty('extensions.code', 'FORBIDDEN')
+  })
+
+  test('restores through the service and returns the updated action', async () => {
+    const restoreCommunityWatchCommentService = jest
+      .fn<any>()
+      .mockResolvedValue({ action: baseAction, comment: baseComment })
+    const context = createMutationContext({
+      commentService: {
+        restoreCommunityWatchComment: restoreCommunityWatchCommentService,
+      },
+    })
+
+    const result = await restoreMutation(
+      {},
+      { input: { uuid: baseAction.uuid, note: 'appeal accepted' } },
+      context,
+      {} as any
+    )
+
+    expect(result).toBe(baseAction)
+    expect(restoreCommunityWatchCommentService).toHaveBeenCalledWith({
+      uuid: baseAction.uuid,
+      actorId: '9',
+      note: 'appeal accepted',
+    })
+  })
+
+  test('clears original content through the service', async () => {
+    const clearCommunityWatchOriginalContentService = jest
+      .fn<any>()
+      .mockResolvedValue({ ...baseAction, originalContent: null })
+    const context = createMutationContext({
+      commentService: {
+        clearCommunityWatchOriginalContent:
+          clearCommunityWatchOriginalContentService,
+      },
+    })
+
+    const result = await clearMutation(
+      {},
+      { input: { uuid: baseAction.uuid, note: 'privacy request' } },
+      context,
+      {} as any
+    )
+
+    expect(result.originalContent).toBeNull()
+    expect(clearCommunityWatchOriginalContentService).toHaveBeenCalledWith({
+      uuid: baseAction.uuid,
+      actorId: '9',
+      note: 'privacy request',
+    })
+  })
+})

--- a/src/connectors/commentService.ts
+++ b/src/connectors/commentService.ts
@@ -3,9 +3,12 @@ import type {
   Circle,
   Comment,
   CommunityWatchAction,
+  CommunityWatchActionReason,
+  CommunityWatchAppealState,
   Connections,
   GQLCommentCommentsInput,
   GQLCommentsInput,
+  CommunityWatchReviewState,
   User,
   ValueOf,
 } from '#definitions/index.js'
@@ -20,7 +23,13 @@ import {
   NOTICE_TYPE,
 } from '#common/enums/index.js'
 import { environment } from '#common/environment.js'
-import { ForbiddenByStateError, ForbiddenError } from '#common/errors.js'
+import {
+  CommentNotFoundError,
+  ForbiddenByStateError,
+  ForbiddenError,
+  UserInputError,
+} from '#common/errors.js'
+import { v4 } from 'uuid'
 
 import { BaseService } from './baseService.js'
 import { NotificationService } from './notification/notificationService.js'
@@ -43,6 +52,25 @@ export type CommunityWatchActionsFilter = {
   appealState?: string | null
   reviewState?: string | null
 }
+
+export type CommunityWatchActionStateUpdate = {
+  uuid: string
+  actorId: string
+  appealState?: CommunityWatchAppealState | null
+  reviewState?: CommunityWatchReviewState | null
+  reason?: CommunityWatchActionReason | null
+  note?: string | null
+}
+
+type CommunityWatchReviewEventType =
+  | 'appeal_received'
+  | 'appeal_resolved'
+  | 'review_upheld'
+  | 'review_reversed'
+  | 'reason_changed'
+  | 'comment_restored'
+  | 'content_cleared'
+  | 'state_updated'
 
 export class CommentService extends BaseService<Comment> {
   public constructor(connections: Connections) {
@@ -104,6 +132,264 @@ export class CommentService extends BaseService<Comment> {
     ])
 
     return [actions, Number(countResult?.count || 0)]
+  }
+
+  public updateCommunityWatchActionState = async ({
+    uuid,
+    actorId,
+    appealState,
+    reviewState,
+    reason,
+    note,
+  }: CommunityWatchActionStateUpdate): Promise<CommunityWatchAction> => {
+    if (!appealState && !reviewState && !reason) {
+      throw new UserInputError('no Community Watch action update provided')
+    }
+    if (reviewState === 'reversed') {
+      throw new UserInputError(
+        'use restoreCommunityWatchComment to reverse an action'
+      )
+    }
+
+    return this.knex.transaction(async (trx) => {
+      const action = await trx<CommunityWatchAction>('community_watch_action')
+        .select()
+        .where({ uuid })
+        .forUpdate()
+        .first()
+      if (!action) {
+        throw new UserInputError('Community Watch action not found')
+      }
+
+      const now = new Date()
+      const patch: Partial<CommunityWatchAction> = {
+        reviewerId: actorId,
+        reviewNote: note || null,
+        reviewedAt: now,
+        updatedAt: now,
+      }
+      const events: Array<{
+        eventType: CommunityWatchReviewEventType
+        oldValue: string | null
+        newValue: string | null
+      }> = []
+
+      if (appealState && appealState !== action.appealState) {
+        patch.appealState = appealState
+        events.push({
+          eventType:
+            appealState === 'received'
+              ? 'appeal_received'
+              : appealState === 'resolved'
+              ? 'appeal_resolved'
+              : 'state_updated',
+          oldValue: action.appealState,
+          newValue: appealState,
+        })
+      }
+
+      if (reviewState && reviewState !== action.reviewState) {
+        patch.reviewState = reviewState
+        events.push({
+          eventType:
+            reviewState === 'upheld'
+              ? 'review_upheld'
+              : 'state_updated',
+          oldValue: action.reviewState,
+          newValue: reviewState,
+        })
+      }
+
+      if (reason && reason !== action.reason) {
+        patch.reason = reason
+        if (!patch.reviewState) {
+          patch.reviewState = 'reason_adjusted'
+        }
+        events.push({
+          eventType: 'reason_changed',
+          oldValue: action.reason,
+          newValue: reason,
+        })
+      }
+
+      if (events.length === 0) {
+        events.push({
+          eventType: 'state_updated',
+          oldValue: null,
+          newValue: null,
+        })
+      }
+
+      const [updatedAction] = await trx<CommunityWatchAction>(
+        'community_watch_action'
+      )
+        .where({ id: action.id })
+        .update(patch)
+        .returning('*')
+
+      await this.insertCommunityWatchReviewEvents(trx, {
+        actionId: action.id,
+        actorId,
+        note,
+        events,
+      })
+
+      return updatedAction
+    })
+  }
+
+  public restoreCommunityWatchComment = async ({
+    uuid,
+    actorId,
+    note,
+  }: {
+    uuid: string
+    actorId: string
+    note?: string | null
+  }): Promise<{ action: CommunityWatchAction; comment: Comment }> =>
+    this.knex.transaction(async (trx) => {
+      const action = await trx<CommunityWatchAction>('community_watch_action')
+        .select()
+        .where({ uuid })
+        .forUpdate()
+        .first()
+      if (!action) {
+        throw new UserInputError('Community Watch action not found')
+      }
+      if (action.actionState !== 'active') {
+        throw new UserInputError('Community Watch action is not active')
+      }
+
+      const comment = await trx<Comment>('comment')
+        .select()
+        .where({ id: action.commentId })
+        .forUpdate()
+        .first()
+      if (!comment) {
+        throw new CommentNotFoundError('comment not found')
+      }
+      if (comment.state !== COMMENT_STATE.banned) {
+        throw new UserInputError('comment is not restorable')
+      }
+
+      const now = new Date()
+      const [updatedComment] = await trx<Comment>('comment')
+        .where({ id: comment.id })
+        .update({
+          state: action.originalState,
+          updatedAt: now,
+        })
+        .returning('*')
+      const [updatedAction] = await trx<CommunityWatchAction>(
+        'community_watch_action'
+      )
+        .where({ id: action.id })
+        .update({
+          actionState: 'restored',
+          reviewState: 'reversed',
+          reviewerId: actorId,
+          reviewNote: note || null,
+          reviewedAt: now,
+          updatedAt: now,
+        })
+        .returning('*')
+
+      await this.insertCommunityWatchReviewEvents(trx, {
+        actionId: action.id,
+        actorId,
+        note,
+        events: [
+          {
+            eventType: 'comment_restored',
+            oldValue: comment.state,
+            newValue: action.originalState,
+          },
+        ],
+      })
+
+      return { action: updatedAction, comment: updatedComment }
+    })
+
+  public clearCommunityWatchOriginalContent = async ({
+    uuid,
+    actorId,
+    note,
+  }: {
+    uuid: string
+    actorId: string
+    note?: string | null
+  }): Promise<CommunityWatchAction> =>
+    this.knex.transaction(async (trx) => {
+      const action = await trx<CommunityWatchAction>('community_watch_action')
+        .select()
+        .where({ uuid })
+        .forUpdate()
+        .first()
+      if (!action) {
+        throw new UserInputError('Community Watch action not found')
+      }
+
+      const now = new Date()
+      const [updatedAction] = await trx<CommunityWatchAction>(
+        'community_watch_action'
+      )
+        .where({ id: action.id })
+        .update({
+          originalContent: null,
+          reviewerId: actorId,
+          reviewNote: note || null,
+          reviewedAt: now,
+          updatedAt: now,
+        })
+        .returning('*')
+
+      await this.insertCommunityWatchReviewEvents(trx, {
+        actionId: action.id,
+        actorId,
+        note,
+        events: [
+          {
+            eventType: 'content_cleared',
+            oldValue: action.originalContent ? 'present' : null,
+            newValue: null,
+          },
+        ],
+      })
+
+      return updatedAction
+    })
+
+  private insertCommunityWatchReviewEvents = async (
+    trx: Knex.Transaction,
+    {
+      actionId,
+      actorId,
+      note,
+      events,
+    }: {
+      actionId: string
+      actorId: string
+      note?: string | null
+      events: Array<{
+        eventType: CommunityWatchReviewEventType
+        oldValue: string | null
+        newValue: string | null
+      }>
+    }
+  ) => {
+    const now = new Date()
+    await trx('community_watch_review_event').insert(
+      events.map(({ eventType, oldValue, newValue }) => ({
+        uuid: v4(),
+        actionId,
+        eventType,
+        actorId,
+        oldValue,
+        newValue,
+        note: note || null,
+        createdAt: now,
+      }))
+    )
   }
 
   /**

--- a/src/definitions/communityWatch.d.ts
+++ b/src/definitions/communityWatch.d.ts
@@ -9,6 +9,15 @@ export type CommunityWatchReviewState =
   | 'upheld'
   | 'reversed'
   | 'reason_adjusted'
+export type CommunityWatchReviewEventType =
+  | 'appeal_received'
+  | 'appeal_resolved'
+  | 'review_upheld'
+  | 'review_reversed'
+  | 'reason_changed'
+  | 'comment_restored'
+  | 'content_cleared'
+  | 'state_updated'
 
 export interface CommunityWatchAction {
   id: string
@@ -33,4 +42,16 @@ export interface CommunityWatchAction {
   contentExpiresAt: Date
   createdAt: Date
   updatedAt: Date
+}
+
+export interface CommunityWatchReviewEvent {
+  id: string
+  uuid: string
+  actionId: string
+  eventType: CommunityWatchReviewEventType
+  actorId: string
+  oldValue: string | null
+  newValue: string | null
+  note: string | null
+  createdAt: Date
 }

--- a/src/definitions/index.d.ts
+++ b/src/definitions/index.d.ts
@@ -90,7 +90,10 @@ import type {
 } from './circle.js'
 import type { Collection, CollectionArticle } from './collection.js'
 import type { Comment, FeaturedCommentMaterialized } from './comment.js'
-import type { CommunityWatchAction } from './communityWatch.js'
+import type {
+  CommunityWatchAction,
+  CommunityWatchReviewEvent,
+} from './communityWatch.js'
 import type { Draft } from './draft.js'
 import type { TopicChannelFeedback } from './feedback.ts'
 import type {
@@ -269,6 +272,7 @@ export interface TableTypeMap {
   collection_article: CollectionArticle
   comment: Comment
   community_watch_action: CommunityWatchAction
+  community_watch_review_event: CommunityWatchReviewEvent
   crypto_wallet: CryptoWallet
   crypto_wallet_signature: CryptoWalletSignature
   customer: Customer

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -1226,6 +1226,11 @@ export type GQLClassifyArticlesChannelsInput = {
   ids: Array<Scalars['ID']['input']>
 }
 
+export type GQLClearCommunityWatchOriginalContentInput = {
+  note?: InputMaybe<Scalars['String']['input']>
+  uuid: Scalars['ID']['input']
+}
+
 export type GQLClearReadHistoryInput = {
   id?: InputMaybe<Scalars['ID']['input']>
 }
@@ -2160,6 +2165,8 @@ export type GQLMutation = {
   /** Let Traveloggers owner claims a Logbook, returns transaction hash */
   claimLogbooks: GQLClaimLogbooksResult
   classifyArticlesChannels: Scalars['Boolean']['output']
+  /** Clear stored original content for a Community Watch action as staff. */
+  clearCommunityWatchOriginalContent: GQLCommunityWatchAction
   /** Clear read history for user. */
   clearReadHistory: GQLUser
   /** Clear search history for user. */
@@ -2252,6 +2259,8 @@ export type GQLMutation = {
   resetLikerId: GQLUser
   /** Reset user or payment password. */
   resetPassword?: Maybe<Scalars['Boolean']['output']>
+  /** Restore a comment removed by Community Watch as staff. */
+  restoreCommunityWatchComment: GQLCommunityWatchAction
   reviewTopicChannelFeedback: GQLTopicChannelFeedback
   sendCampaignAnnouncement?: Maybe<Scalars['Boolean']['output']>
   /** Send verification code for email. */
@@ -2321,6 +2330,8 @@ export type GQLMutation = {
   updateCampaignApplicationState: GQLCampaign
   /** Update a comments' state. */
   updateCommentsState: Array<GQLComment>
+  /** Update Community Watch appeal, review, or reason as staff. */
+  updateCommunityWatchActionState: GQLCommunityWatchAction
   /** Update user notification settings. */
   updateNotificationSetting: GQLUser
   /** Update referralCode of a user, used in OSS. */
@@ -2385,6 +2396,10 @@ export type GQLMutationClaimLogbooksArgs = {
 
 export type GQLMutationClassifyArticlesChannelsArgs = {
   input: GQLClassifyArticlesChannelsInput
+}
+
+export type GQLMutationClearCommunityWatchOriginalContentArgs = {
+  input: GQLClearCommunityWatchOriginalContentInput
 }
 
 export type GQLMutationClearReadHistoryArgs = {
@@ -2603,6 +2618,10 @@ export type GQLMutationResetPasswordArgs = {
   input: GQLResetPasswordInput
 }
 
+export type GQLMutationRestoreCommunityWatchCommentArgs = {
+  input: GQLRestoreCommunityWatchCommentInput
+}
+
 export type GQLMutationReviewTopicChannelFeedbackArgs = {
   input: GQLReviewTopicChannelFeedbackInput
 }
@@ -2761,6 +2780,10 @@ export type GQLMutationUpdateCampaignApplicationStateArgs = {
 
 export type GQLMutationUpdateCommentsStateArgs = {
   input: GQLUpdateCommentsStateInput
+}
+
+export type GQLMutationUpdateCommunityWatchActionStateArgs = {
+  input: GQLUpdateCommunityWatchActionStateInput
 }
 
 export type GQLMutationUpdateNotificationSettingArgs = {
@@ -3676,6 +3699,11 @@ export type GQLResponsesInput = {
   sort?: InputMaybe<GQLResponseSort>
 }
 
+export type GQLRestoreCommunityWatchCommentInput = {
+  note?: InputMaybe<Scalars['String']['input']>
+  uuid: Scalars['ID']['input']
+}
+
 export type GQLReviewTopicChannelFeedbackInput = {
   action: GQLTopicChannelFeedbackAction
   feedback: Scalars['ID']['input']
@@ -4375,6 +4403,14 @@ export type GQLUpdateCampaignApplicationStateInput = {
 export type GQLUpdateCommentsStateInput = {
   ids: Array<Scalars['ID']['input']>
   state: GQLCommentState
+}
+
+export type GQLUpdateCommunityWatchActionStateInput = {
+  appealState?: InputMaybe<GQLCommunityWatchAppealState>
+  note?: InputMaybe<Scalars['String']['input']>
+  reason?: InputMaybe<GQLCommunityWatchRemoveCommentReason>
+  reviewState?: InputMaybe<GQLCommunityWatchReviewState>
+  uuid: Scalars['ID']['input']
 }
 
 export type GQLUpdateNotificationSettingInput = {
@@ -5436,6 +5472,7 @@ export type GQLResolversTypes = ResolversObject<{
   ClaimLogbooksInput: GQLClaimLogbooksInput
   ClaimLogbooksResult: ResolverTypeWrapper<GQLClaimLogbooksResult>
   ClassifyArticlesChannelsInput: GQLClassifyArticlesChannelsInput
+  ClearCommunityWatchOriginalContentInput: GQLClearCommunityWatchOriginalContentInput
   ClearReadHistoryInput: GQLClearReadHistoryInput
   Collection: ResolverTypeWrapper<CollectionModel>
   CollectionArticlesInput: GQLCollectionArticlesInput
@@ -5786,6 +5823,7 @@ export type GQLResolversTypes = ResolversObject<{
   >
   ResponseSort: GQLResponseSort
   ResponsesInput: GQLResponsesInput
+  RestoreCommunityWatchCommentInput: GQLRestoreCommunityWatchCommentInput
   ReviewTopicChannelFeedbackInput: GQLReviewTopicChannelFeedbackInput
   Role: GQLRole
   SearchAPIVersion: GQLSearchApiVersion
@@ -5928,6 +5966,7 @@ export type GQLResolversTypes = ResolversObject<{
   UpdateArticleStateInput: GQLUpdateArticleStateInput
   UpdateCampaignApplicationStateInput: GQLUpdateCampaignApplicationStateInput
   UpdateCommentsStateInput: GQLUpdateCommentsStateInput
+  UpdateCommunityWatchActionStateInput: GQLUpdateCommunityWatchActionStateInput
   UpdateNotificationSettingInput: GQLUpdateNotificationSettingInput
   UpdateUserExtraInput: GQLUpdateUserExtraInput
   UpdateUserInfoInput: GQLUpdateUserInfoInput
@@ -6181,6 +6220,7 @@ export type GQLResolversParentTypes = ResolversObject<{
   ClaimLogbooksInput: GQLClaimLogbooksInput
   ClaimLogbooksResult: GQLClaimLogbooksResult
   ClassifyArticlesChannelsInput: GQLClassifyArticlesChannelsInput
+  ClearCommunityWatchOriginalContentInput: GQLClearCommunityWatchOriginalContentInput
   ClearReadHistoryInput: GQLClearReadHistoryInput
   Collection: CollectionModel
   CollectionArticlesInput: GQLCollectionArticlesInput
@@ -6442,6 +6482,7 @@ export type GQLResolversParentTypes = ResolversObject<{
     node: GQLResolversParentTypes['Response']
   }
   ResponsesInput: GQLResponsesInput
+  RestoreCommunityWatchCommentInput: GQLRestoreCommunityWatchCommentInput
   ReviewTopicChannelFeedbackInput: GQLReviewTopicChannelFeedbackInput
   SearchFilter: GQLSearchFilter
   SearchInput: GQLSearchInput
@@ -6545,6 +6586,7 @@ export type GQLResolversParentTypes = ResolversObject<{
   UpdateArticleStateInput: GQLUpdateArticleStateInput
   UpdateCampaignApplicationStateInput: GQLUpdateCampaignApplicationStateInput
   UpdateCommentsStateInput: GQLUpdateCommentsStateInput
+  UpdateCommunityWatchActionStateInput: GQLUpdateCommunityWatchActionStateInput
   UpdateNotificationSettingInput: GQLUpdateNotificationSettingInput
   UpdateUserExtraInput: GQLUpdateUserExtraInput
   UpdateUserInfoInput: GQLUpdateUserInfoInput
@@ -8937,6 +8979,12 @@ export type GQLMutationResolvers<
     ContextType,
     RequireFields<GQLMutationClassifyArticlesChannelsArgs, 'input'>
   >
+  clearCommunityWatchOriginalContent?: Resolver<
+    GQLResolversTypes['CommunityWatchAction'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationClearCommunityWatchOriginalContentArgs, 'input'>
+  >
   clearReadHistory?: Resolver<
     GQLResolversTypes['User'],
     ParentType,
@@ -9276,6 +9324,12 @@ export type GQLMutationResolvers<
     ContextType,
     RequireFields<GQLMutationResetPasswordArgs, 'input'>
   >
+  restoreCommunityWatchComment?: Resolver<
+    GQLResolversTypes['CommunityWatchAction'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationRestoreCommunityWatchCommentArgs, 'input'>
+  >
   reviewTopicChannelFeedback?: Resolver<
     GQLResolversTypes['TopicChannelFeedback'],
     ParentType,
@@ -9518,6 +9572,12 @@ export type GQLMutationResolvers<
     ParentType,
     ContextType,
     RequireFields<GQLMutationUpdateCommentsStateArgs, 'input'>
+  >
+  updateCommunityWatchActionState?: Resolver<
+    GQLResolversTypes['CommunityWatchAction'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationUpdateCommunityWatchActionStateArgs, 'input'>
   >
   updateNotificationSetting?: Resolver<
     GQLResolversTypes['User'],

--- a/src/mutations/comment/clearCommunityWatchOriginalContent.ts
+++ b/src/mutations/comment/clearCommunityWatchOriginalContent.ts
@@ -1,0 +1,28 @@
+import type { Context, GQLMutationResolvers } from '#definitions/index.js'
+
+import { ForbiddenError } from '#common/errors.js'
+
+type ClearCommunityWatchOriginalContentInput = {
+  uuid: string
+  note?: string | null
+}
+
+const resolver = async (
+  _: unknown,
+  {
+    input: { uuid, note },
+  }: { input: ClearCommunityWatchOriginalContentInput },
+  { viewer, dataSources: { commentService } }: Context
+) => {
+  if (!viewer.hasRole('admin')) {
+    throw new ForbiddenError('viewer has no permission')
+  }
+
+  return commentService.clearCommunityWatchOriginalContent({
+    uuid,
+    actorId: viewer.id,
+    note,
+  })
+}
+
+export default resolver as GQLMutationResolvers['clearCommunityWatchOriginalContent']

--- a/src/mutations/comment/index.ts
+++ b/src/mutations/comment/index.ts
@@ -1,11 +1,14 @@
+import clearCommunityWatchOriginalContent from './clearCommunityWatchOriginalContent.js'
 import communityWatchRemoveComment from './communityWatchRemoveComment.js'
 import deleteComment from './deleteComment.js'
 import pinComment from './pinComment.js'
 import putComment from './putComment.js'
+import restoreCommunityWatchComment from './restoreCommunityWatchComment.js'
 import togglePinComment from './togglePinComment.js'
 import unpinComment from './unpinComment.js'
 import unvoteComment from './unvoteComment.js'
 import updateCommentsState from './updateCommentsState.js'
+import updateCommunityWatchActionState from './updateCommunityWatchActionState.js'
 import voteComment from './voteComment.js'
 
 export default {
@@ -19,5 +22,8 @@ export default {
     updateCommentsState,
     togglePinComment,
     communityWatchRemoveComment,
+    updateCommunityWatchActionState,
+    restoreCommunityWatchComment,
+    clearCommunityWatchOriginalContent,
   },
 }

--- a/src/mutations/comment/restoreCommunityWatchComment.ts
+++ b/src/mutations/comment/restoreCommunityWatchComment.ts
@@ -1,0 +1,41 @@
+import type { Context, GQLMutationResolvers } from '#definitions/index.js'
+
+import { COMMENT_TYPE, NODE_TYPES } from '#common/enums/index.js'
+import { ForbiddenError } from '#common/errors.js'
+import { invalidateFQC } from '@matters/apollo-response-cache'
+
+type RestoreCommunityWatchCommentInput = {
+  uuid: string
+  note?: string | null
+}
+
+const resolver = async (
+  _: unknown,
+  { input: { uuid, note } }: { input: RestoreCommunityWatchCommentInput },
+  { viewer, dataSources: { commentService, connections } }: Context
+) => {
+  if (!viewer.hasRole('admin')) {
+    throw new ForbiddenError('viewer has no permission')
+  }
+
+  const { action, comment } = await commentService.restoreCommunityWatchComment({
+    uuid,
+    actorId: viewer.id,
+    note,
+  })
+
+  await invalidateFQC({
+    node: {
+      id: comment.targetId,
+      type:
+        comment.type === COMMENT_TYPE.article
+          ? NODE_TYPES.Article
+          : NODE_TYPES.Moment,
+    },
+    redis: connections.redis,
+  })
+
+  return action
+}
+
+export default resolver as GQLMutationResolvers['restoreCommunityWatchComment']

--- a/src/mutations/comment/updateCommunityWatchActionState.ts
+++ b/src/mutations/comment/updateCommunityWatchActionState.ts
@@ -1,0 +1,40 @@
+import type {
+  Context,
+  GQLMutationResolvers,
+  CommunityWatchActionReason,
+  CommunityWatchAppealState,
+  CommunityWatchReviewState,
+} from '#definitions/index.js'
+
+import { ForbiddenError } from '#common/errors.js'
+
+type UpdateCommunityWatchActionStateInput = {
+  uuid: string
+  appealState?: CommunityWatchAppealState | null
+  reviewState?: CommunityWatchReviewState | null
+  reason?: CommunityWatchActionReason | null
+  note?: string | null
+}
+
+const resolver = async (
+  _: unknown,
+  {
+    input: { uuid, appealState, reviewState, reason, note },
+  }: { input: UpdateCommunityWatchActionStateInput },
+  { viewer, dataSources: { commentService } }: Context
+) => {
+  if (!viewer.hasRole('admin')) {
+    throw new ForbiddenError('viewer has no permission')
+  }
+
+  return commentService.updateCommunityWatchActionState({
+    uuid,
+    actorId: viewer.id,
+    appealState,
+    reviewState,
+    reason,
+    note,
+  })
+}
+
+export default resolver as GQLMutationResolvers['updateCommunityWatchActionState']

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -39,6 +39,15 @@ export default /* GraphQL */ `
     "Remove a spam comment as a Community Watch member."
     communityWatchRemoveComment(input: CommunityWatchRemoveCommentInput!): Comment! @auth(mode: "${AUTH_MODE.oauth}", group: "${SCOPE_GROUP.level2}") @purgeCache(type: "${NODE_TYPES.Comment}")
 
+    "Update Community Watch appeal, review, or reason as staff."
+    updateCommunityWatchActionState(input: UpdateCommunityWatchActionStateInput!): CommunityWatchAction! @auth(mode: "${AUTH_MODE.oauth}", group: "${SCOPE_GROUP.level2}") @purgeCache(type: "${NODE_TYPES.Comment}")
+
+    "Restore a comment removed by Community Watch as staff."
+    restoreCommunityWatchComment(input: RestoreCommunityWatchCommentInput!): CommunityWatchAction! @auth(mode: "${AUTH_MODE.oauth}", group: "${SCOPE_GROUP.level2}") @purgeCache(type: "${NODE_TYPES.Comment}")
+
+    "Clear stored original content for a Community Watch action as staff."
+    clearCommunityWatchOriginalContent(input: ClearCommunityWatchOriginalContentInput!): CommunityWatchAction! @auth(mode: "${AUTH_MODE.oauth}", group: "${SCOPE_GROUP.level2}") @purgeCache(type: "${NODE_TYPES.Comment}")
+
 
     ##############
     # DEPRECATED #
@@ -250,6 +259,24 @@ export default /* GraphQL */ `
 
   input CommunityWatchActionInput {
     uuid: ID!
+  }
+
+  input UpdateCommunityWatchActionStateInput {
+    uuid: ID!
+    appealState: CommunityWatchAppealState
+    reviewState: CommunityWatchReviewState
+    reason: CommunityWatchRemoveCommentReason
+    note: String
+  }
+
+  input RestoreCommunityWatchCommentInput {
+    uuid: ID!
+    note: String
+  }
+
+  input ClearCommunityWatchOriginalContentInput {
+    uuid: ID!
+    note: String
   }
 
   enum CommunityWatchRemoveCommentReason {


### PR DESCRIPTION
## Summary
- add an append-only community_watch_review_event table for staff review audit evidence
- add admin-only Community Watch staff mutations for appeal/review state updates, comment restore, and original content clearing
- keep restore state changes in CommentService and invalidate article/moment comment cache after restore

## Notes
- disabling a Community Watch member continues to use the existing admin putUserFeatureFlags flow
- generic state update rejects reviewState: reversed; staff must use restoreCommunityWatchComment so the comment state and audit state stay consistent

## Verification
- npm run gen
- npm run build
- npm run lint
- MATTERS_ENV=test node --experimental-vm-modules node_modules/.bin/jest build/common/utils/__test__/communityWatchReviewEventMigration.test.js build/common/utils/__test__/communityWatchStaffReview.test.js --runInBand --forceExit