### PR TITLE
Expose federation setting read API

### DIFF
--- a/db/migrations/20260511000000_add_fediverse_beta_feature_flag.js
+++ b/db/migrations/20260511000000_add_fediverse_beta_feature_flag.js
@@ -1,0 +1,27 @@
+import { alterEnumString } from '../utils.js'
+
+const table = 'user_feature_flag'
+
+const featureFlags = [
+  'bypassSpamDetection',
+  'unlimitedArticleFetch',
+  'readSpamStatus',
+  'communityWatch',
+  'fediverseBeta',
+]
+
+const previousFeatureFlags = [
+  'bypassSpamDetection',
+  'unlimitedArticleFetch',
+  'readSpamStatus',
+  'communityWatch',
+]
+
+export const up = async (knex) => {
+  await knex.raw(alterEnumString(table, 'type', featureFlags))
+}
+
+export const down = async (knex) => {
+  await knex(table).where({ type: 'fediverseBeta' }).del()
+  await knex.raw(alterEnumString(table, 'type', previousFeatureFlags))
+}

--- a/docs/Federation-Export.md
+++ b/docs/Federation-Export.md
@@ -24,7 +24,7 @@ The current pure function is `resolveFederationExportGate` in `src/connectors/ar
 
 The candidate loader can include federation setting joins when strict opt-in input is needed. Without that strict input, the service preserves the public-only preflight boundary.
 
-`FederationExportService` also exposes bounded upsert methods for author and article federation settings. These methods validate allowed states before writing and are wired to admin-only GraphQL mutations for internal/staging control.
+`FederationExportService` also exposes bounded upsert methods for author and article federation settings. These methods validate allowed states before writing and are wired to admin-only GraphQL mutations for internal/staging control plus pilot-scoped user mutations for G2-B.
 
 ## Internal admin entry points
 
@@ -39,14 +39,25 @@ Both mutations require global GraphQL IDs and record the admin viewer ID in `upd
 
 `evaluateFederationExportRows` returns a `decisionReport` with selected, eligible, skipped, and per-article skip reasons. Downstream async workers can persist or log that report without exposing credentials or private content.
 
+## Pilot product entry points
+
+G2-B adds two OAuth mutations gated by the `fediverseBeta` user feature flag:
+
+| Mutation                                            | Purpose                                                                 |
+| --------------------------------------------------- | ----------------------------------------------------------------------- |
+| `setViewerFederationSetting(input: { state })`      | Lets a pilot viewer set only their own author-level federation setting. |
+| `setArticleFederationSetting(input: { id, state })` | Lets a pilot author set only their own article federation override.     |
+
+The feature flag is assigned through the existing admin feature-flag tooling. These mutations do not publish, backfill, delete, or export content; they only record settings for the server-side gate.
+
 ## Read-side product fields
 
 G2-B adds read-side fields for Matters Web/App to display the current contract state without writing settings:
 
-| Field                           | Purpose                                                                 |
-| ------------------------------- | ----------------------------------------------------------------------- |
-| `User.federationSetting`        | Returns the author's explicit opt-in row, or `null` when default-off.   |
-| `Article.federationSetting`     | Returns the article override row, or `null` when it inherits.           |
+| Field                           | Purpose                                                                  |
+| ------------------------------- | ------------------------------------------------------------------------ |
+| `User.federationSetting`        | Returns the author's explicit opt-in row, or `null` when default-off.    |
+| `Article.federationSetting`     | Returns the article override row, or `null` when it inherits.            |
 | `Article.federationEligibility` | Returns the computed server-side decision and effective article setting. |
 
 `Article.federationEligibility` uses the same server gate as export runs. Matters Web may use it to show disabled states, but the UI must not treat its own state as authoritative.
@@ -60,11 +71,11 @@ The schema scaffold uses two independent tables:
 | `user_federation_setting`    | One row per author. `state` is `enabled` or `disabled`; missing rows are treated as disabled by the service contract. |
 | `article_federation_setting` | One row per article. `state` is `inherit`, `enabled`, or `disabled`; missing rows are treated as `inherit`.           |
 
-Both tables include `updated_by`, `created_at`, and `updated_at`. The migration, service methods, and internal admin GraphQL mutations are present for branch review and staging validation, but this slice does not run it against production or expose user-facing UI.
+Both tables include `updated_by`, `created_at`, and `updated_at`. The migration, service methods, internal admin GraphQL mutations, and pilot product mutations are present for branch review and staging validation, but this slice does not run it against production or expose broad user-facing UI.
 
 ## Deferred production work
 
-- Add product copy and UI controls.
+- Add product copy and Matters Web UI controls.
 - Move bundle generation and file publication to `lambda-handlers`.
 - Wire async export trigger behavior after publishing or editing an eligible article.
 - Add audit logs for export decisions and skipped reasons.

--- a/docs/Federation-Export.md
+++ b/docs/Federation-Export.md
@@ -39,6 +39,18 @@ Both mutations require global GraphQL IDs and record the admin viewer ID in `upd
 
 `evaluateFederationExportRows` returns a `decisionReport` with selected, eligible, skipped, and per-article skip reasons. Downstream async workers can persist or log that report without exposing credentials or private content.
 
+## Read-side product fields
+
+G2-B adds read-side fields for Matters Web/App to display the current contract state without writing settings:
+
+| Field                           | Purpose                                                                 |
+| ------------------------------- | ----------------------------------------------------------------------- |
+| `User.federationSetting`        | Returns the author's explicit opt-in row, or `null` when default-off.   |
+| `Article.federationSetting`     | Returns the article override row, or `null` when it inherits.           |
+| `Article.federationEligibility` | Returns the computed server-side decision and effective article setting. |
+
+`Article.federationEligibility` uses the same server gate as export runs. Matters Web may use it to show disabled states, but the UI must not treat its own state as authoritative.
+
 ## Durable state scaffold
 
 The schema scaffold uses two independent tables:

--- a/schema.graphql
+++ b/schema.graphql
@@ -46,6 +46,9 @@ type Mutation {
   """Edit an article."""
   editArticle(input: EditArticleInput!): Article!
 
+  """Set current author's Fediverse federation preference for an article."""
+  setArticleFederationSetting(input: SetArticleFederationSettingInput!): ArticleFederationSetting!
+
   """Bookmark or unbookmark article"""
   toggleSubscribeArticle(input: ToggleItemInput!): Article! @deprecated(reason: "Use toggleBookmarkArticle instead")
   toggleBookmarkArticle(input: ToggleItemInput!): Article!
@@ -177,6 +180,9 @@ type Mutation {
 
   """Set user currency preference."""
   setCurrency(input: SetCurrencyInput!): User!
+
+  """Set current viewer's Fediverse federation preference."""
+  setViewerFederationSetting(input: SetViewerFederationSettingInput!): UserFederationSetting!
 
   """Login user."""
   emailLogin(input: EmailLoginInput!): AuthResult!
@@ -808,6 +814,11 @@ input EditArticleInput {
 
   """which campaigns to attach"""
   campaigns: [ArticleCampaignInput!]
+}
+
+input SetArticleFederationSettingInput {
+  id: ID!
+  state: FederationArticleSettingState!
 }
 
 input ArticleCampaignInput {
@@ -2671,6 +2682,7 @@ enum UserFeatureFlagType {
   unlimitedArticleFetch
   readSpamStatus
   communityWatch
+  fediverseBeta
 }
 
 enum FederationAuthorSettingState {
@@ -3357,6 +3369,10 @@ input VerifyEmailInput {
 
 input SetCurrencyInput {
   currency: QuoteCurrency
+}
+
+input SetViewerFederationSettingInput {
+  state: FederationAuthorSettingState!
 }
 
 input GenerateSigningMessageInput {

--- a/schema.graphql
+++ b/schema.graphql
@@ -364,6 +364,12 @@ type Article implements Node & PinnableWork {
   """Original language of content"""
   language: String
 
+  """Article-level federation setting override."""
+  federationSetting: ArticleFederationSetting
+
+  """Computed federation export eligibility for this article."""
+  federationEligibility: ArticleFederationEligibility!
+
   """List of articles which added this article into their connections."""
   connectedBy(input: ConnectionArgs!): ArticleConnection!
 
@@ -1240,6 +1246,9 @@ type User implements Node {
 
   """User settings."""
   settings: UserSettings!
+
+  """User-level federation opt-in setting."""
+  federationSetting: UserFederationSetting
 
   """Recommendations for current user."""
   recommendation: Recommendation!
@@ -2675,6 +2684,13 @@ enum FederationArticleSettingState {
   disabled
 }
 
+enum FederationExportDecisionReason {
+  eligible
+  article_not_public
+  author_not_opted_in
+  article_disabled
+}
+
 type UserFederationSetting {
   userId: ID!
   state: FederationAuthorSettingState!
@@ -2685,6 +2701,12 @@ type ArticleFederationSetting {
   articleId: ID!
   state: FederationArticleSettingState!
   updatedBy: ID
+}
+
+type ArticleFederationEligibility {
+  eligible: Boolean!
+  reason: FederationExportDecisionReason!
+  effectiveArticleSetting: FederationArticleSettingState!
 }
 
 enum ReportReason {

--- a/src/common/enums/oss.ts
+++ b/src/common/enums/oss.ts
@@ -8,4 +8,5 @@ export const USER_FEATURE_FLAG_TYPE = {
   unlimitedArticleFetch: 'unlimitedArticleFetch',
   readSpamStatus: 'readSpamStatus',
   communityWatch: 'communityWatch',
+  fediverseBeta: 'fediverseBeta',
 } as const

--- a/src/connectors/__test__/federationExportService.test.ts
+++ b/src/connectors/__test__/federationExportService.test.ts
@@ -71,6 +71,16 @@ const createKnexWrite = (rows: any[]) => {
   return { knex, query }
 }
 
+const createKnexFirst = (row: any) => {
+  const query: any = {
+    where: jest.fn(() => query),
+    first: jest.fn(() => Promise.resolve(row)),
+  }
+  const knexRO = jest.fn(() => query)
+
+  return { knexRO, query }
+}
+
 describe('federationExportService', () => {
   test('builds canonical Matters article URLs from short hashes', () => {
     expect(
@@ -439,6 +449,50 @@ describe('federationExportService', () => {
       updatedAt: 'now',
     })
     expect(query.returning).toHaveBeenCalledWith([
+      'articleId',
+      'state',
+      'updatedBy',
+    ])
+    expect(row).toEqual({
+      articleId: '101',
+      state: FEDERATION_ARTICLE_SETTING.disabled,
+      updatedBy: null,
+    })
+  })
+
+  test('loads author federation setting from read-only DB', async () => {
+    const { knexRO, query } = createKnexFirst({
+      userId: '1',
+      state: FEDERATION_AUTHOR_SETTING.enabled,
+      updatedBy: '99',
+    })
+    const service = new FederationExportService({ knexRO } as any)
+
+    const row = await service.loadAuthorFederationSetting('1')
+
+    expect(knexRO).toHaveBeenCalledWith('user_federation_setting')
+    expect(query.where).toHaveBeenCalledWith({ userId: '1' })
+    expect(query.first).toHaveBeenCalledWith(['userId', 'state', 'updatedBy'])
+    expect(row).toEqual({
+      userId: '1',
+      state: FEDERATION_AUTHOR_SETTING.enabled,
+      updatedBy: '99',
+    })
+  })
+
+  test('loads article federation setting from read-only DB', async () => {
+    const { knexRO, query } = createKnexFirst({
+      articleId: '101',
+      state: FEDERATION_ARTICLE_SETTING.disabled,
+      updatedBy: null,
+    })
+    const service = new FederationExportService({ knexRO } as any)
+
+    const row = await service.loadArticleFederationSetting('101')
+
+    expect(knexRO).toHaveBeenCalledWith('article_federation_setting')
+    expect(query.where).toHaveBeenCalledWith({ articleId: '101' })
+    expect(query.first).toHaveBeenCalledWith([
       'articleId',
       'state',
       'updatedBy',

--- a/src/connectors/article/federationExportService.ts
+++ b/src/connectors/article/federationExportService.ts
@@ -270,6 +270,26 @@ export class FederationExportService {
     return row
   }
 
+  public async loadAuthorFederationSetting(
+    userId: string
+  ): Promise<FederationAuthorSettingRow | null> {
+    const row = await this.knexRO('user_federation_setting')
+      .where({ userId })
+      .first(['userId', 'state', 'updatedBy'])
+
+    return row ?? null
+  }
+
+  public async loadArticleFederationSetting(
+    articleId: string
+  ): Promise<FederationArticleSettingRow | null> {
+    const row = await this.knexRO('article_federation_setting')
+      .where({ articleId })
+      .first(['articleId', 'state', 'updatedBy'])
+
+    return row ?? null
+  }
+
   public async loadSelectedArticleRows(
     articleIds: string[],
     options: { includeFederationSettings?: boolean } = {}

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -275,6 +275,10 @@ export type GQLArticle = GQLNode &
     donations: GQLArticleDonationConnection
     /** List of featured comments of this article. */
     featuredComments: GQLCommentConnection
+    /** Computed federation export eligibility for this article. */
+    federationEligibility: GQLArticleFederationEligibility
+    /** Article-level federation setting override. */
+    federationSetting?: Maybe<GQLArticleFederationSetting>
     /** This value determines if current viewer has appreciated or not. */
     hasAppreciate: Scalars['Boolean']['output']
     /** Unique ID of this article */
@@ -547,6 +551,13 @@ export type GQLArticleEdge = {
   __typename?: 'ArticleEdge'
   cursor: Scalars['String']['output']
   node: GQLArticle
+}
+
+export type GQLArticleFederationEligibility = {
+  __typename?: 'ArticleFederationEligibility'
+  effectiveArticleSetting: GQLFederationArticleSettingState
+  eligible: Scalars['Boolean']['output']
+  reason: GQLFederationExportDecisionReason
 }
 
 export type GQLArticleFederationSetting = {
@@ -1791,6 +1802,12 @@ export type GQLFederationArticleSettingState =
   | 'inherit'
 
 export type GQLFederationAuthorSettingState = 'disabled' | 'enabled'
+
+export type GQLFederationExportDecisionReason =
+  | 'article_disabled'
+  | 'article_not_public'
+  | 'author_not_opted_in'
+  | 'eligible'
 
 export type GQLFilterInput = {
   inRangeEnd?: InputMaybe<Scalars['DateTime']['input']>
@@ -4377,6 +4394,8 @@ export type GQLUser = GQLNode & {
   displayName?: Maybe<Scalars['String']['output']>
   /** Drafts authored by current user. */
   drafts: GQLDraftConnection
+  /** User-level federation opt-in setting. */
+  federationSetting?: Maybe<GQLUserFederationSetting>
   /** Followers of this user. */
   followers: GQLUserConnection
   /** Following contents of this user. */
@@ -5228,6 +5247,7 @@ export type GQLResolversTypes = ResolversObject<{
   ArticleEdge: ResolverTypeWrapper<
     Omit<GQLArticleEdge, 'node'> & { node: GQLResolversTypes['Article'] }
   >
+  ArticleFederationEligibility: ResolverTypeWrapper<GQLArticleFederationEligibility>
   ArticleFederationSetting: ResolverTypeWrapper<GQLArticleFederationSetting>
   ArticleInput: GQLArticleInput
   ArticleLicenseType: GQLArticleLicenseType
@@ -5456,6 +5476,7 @@ export type GQLResolversTypes = ResolversObject<{
   FeaturedTagsInput: GQLFeaturedTagsInput
   FederationArticleSettingState: GQLFederationArticleSettingState
   FederationAuthorSettingState: GQLFederationAuthorSettingState
+  FederationExportDecisionReason: GQLFederationExportDecisionReason
   FilterInput: GQLFilterInput
   Float: ResolverTypeWrapper<Scalars['Float']['output']>
   Following: ResolverTypeWrapper<UserModel>
@@ -5997,6 +6018,7 @@ export type GQLResolversParentTypes = ResolversObject<{
   ArticleEdge: Omit<GQLArticleEdge, 'node'> & {
     node: GQLResolversParentTypes['Article']
   }
+  ArticleFederationEligibility: GQLArticleFederationEligibility
   ArticleFederationSetting: GQLArticleFederationSetting
   ArticleInput: GQLArticleInput
   ArticleNotice: NoticeItemModel
@@ -6887,6 +6909,16 @@ export type GQLArticleResolvers<
     ContextType,
     RequireFields<GQLArticleFeaturedCommentsArgs, 'input'>
   >
+  federationEligibility?: Resolver<
+    GQLResolversTypes['ArticleFederationEligibility'],
+    ParentType,
+    ContextType
+  >
+  federationSetting?: Resolver<
+    Maybe<GQLResolversTypes['ArticleFederationSetting']>,
+    ParentType,
+    ContextType
+  >
   hasAppreciate?: Resolver<
     GQLResolversTypes['Boolean'],
     ParentType,
@@ -7128,6 +7160,24 @@ export type GQLArticleEdgeResolvers<
 > = ResolversObject<{
   cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
   node?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArticleFederationEligibilityResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArticleFederationEligibility'] = GQLResolversParentTypes['ArticleFederationEligibility']
+> = ResolversObject<{
+  effectiveArticleSetting?: Resolver<
+    GQLResolversTypes['FederationArticleSettingState'],
+    ParentType,
+    ContextType
+  >
+  eligible?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  reason?: Resolver<
+    GQLResolversTypes['FederationExportDecisionReason'],
+    ParentType,
+    ContextType
+  >
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }>
 
@@ -10728,6 +10778,11 @@ export type GQLUserResolvers<
     ContextType,
     RequireFields<GQLUserDraftsArgs, 'input'>
   >
+  federationSetting?: Resolver<
+    Maybe<GQLResolversTypes['UserFederationSetting']>,
+    ParentType,
+    ContextType
+  >
   followers?: Resolver<
     GQLResolversTypes['UserConnection'],
     ParentType,
@@ -11366,6 +11421,7 @@ export type GQLResolvers<ContextType = Context> = ResolversObject<{
   ArticleDonationConnection?: GQLArticleDonationConnectionResolvers<ContextType>
   ArticleDonationEdge?: GQLArticleDonationEdgeResolvers<ContextType>
   ArticleEdge?: GQLArticleEdgeResolvers<ContextType>
+  ArticleFederationEligibility?: GQLArticleFederationEligibilityResolvers<ContextType>
   ArticleFederationSetting?: GQLArticleFederationSettingResolvers<ContextType>
   ArticleNotice?: GQLArticleNoticeResolvers<ContextType>
   ArticleOSS?: GQLArticleOssResolvers<ContextType>

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -2225,6 +2225,8 @@ export type GQLMutation = {
   /** Send verification code for email. */
   sendVerificationCode?: Maybe<Scalars['Boolean']['output']>
   setAdStatus: GQLArticle
+  /** Set current author's Fediverse federation preference for an article. */
+  setArticleFederationSetting: GQLArticleFederationSetting
   setArticleTopicChannels: GQLArticle
   setBoost: GQLNode
   /** Set user currency preference. */
@@ -2237,6 +2239,8 @@ export type GQLMutation = {
   setSpamStatus: GQLWriting
   /** Set user name. */
   setUserName: GQLUser
+  /** Set current viewer's Fediverse federation preference. */
+  setViewerFederationSetting: GQLUserFederationSetting
   /** Upload a single file. */
   singleFileUpload: GQLAsset
   /** Login/Signup via social accounts. */
@@ -2587,6 +2591,10 @@ export type GQLMutationSetAdStatusArgs = {
   input: GQLSetAdStatusInput
 }
 
+export type GQLMutationSetArticleFederationSettingArgs = {
+  input: GQLSetArticleFederationSettingInput
+}
+
 export type GQLMutationSetArticleTopicChannelsArgs = {
   input: GQLSetArticleTopicChannelsInput
 }
@@ -2617,6 +2625,10 @@ export type GQLMutationSetSpamStatusArgs = {
 
 export type GQLMutationSetUserNameArgs = {
   input: GQLSetUserNameInput
+}
+
+export type GQLMutationSetViewerFederationSettingArgs = {
+  input: GQLSetViewerFederationSettingInput
 }
 
 export type GQLMutationSingleFileUploadArgs = {
@@ -3707,6 +3719,11 @@ export type GQLSetAdStatusInput = {
   isAd: Scalars['Boolean']['input']
 }
 
+export type GQLSetArticleFederationSettingInput = {
+  id: Scalars['ID']['input']
+  state: GQLFederationArticleSettingState
+}
+
 export type GQLSetArticleTopicChannelsInput = {
   channels: Array<Scalars['ID']['input']>
   id: Scalars['ID']['input']
@@ -3743,6 +3760,10 @@ export type GQLSetSpamStatusInput = {
 
 export type GQLSetUserNameInput = {
   userName: Scalars['String']['input']
+}
+
+export type GQLSetViewerFederationSettingInput = {
+  state: GQLFederationAuthorSettingState
 }
 
 export type GQLSigningMessagePurpose =
@@ -4607,6 +4628,7 @@ export type GQLUserFeatureFlag = {
 export type GQLUserFeatureFlagType =
   | 'bypassSpamDetection'
   | 'communityWatch'
+  | 'fediverseBeta'
   | 'readSpamStatus'
   | 'unlimitedArticleFetch'
 
@@ -5745,6 +5767,7 @@ export type GQLResolversTypes = ResolversObject<{
   SendCampaignAnnouncementInput: GQLSendCampaignAnnouncementInput
   SendVerificationCodeInput: GQLSendVerificationCodeInput
   SetAdStatusInput: GQLSetAdStatusInput
+  SetArticleFederationSettingInput: GQLSetArticleFederationSettingInput
   SetArticleTopicChannelsInput: GQLSetArticleTopicChannelsInput
   SetBoostInput: GQLSetBoostInput
   SetCurrencyInput: GQLSetCurrencyInput
@@ -5753,6 +5776,7 @@ export type GQLResolversTypes = ResolversObject<{
   SetPasswordInput: GQLSetPasswordInput
   SetSpamStatusInput: GQLSetSpamStatusInput
   SetUserNameInput: GQLSetUserNameInput
+  SetViewerFederationSettingInput: GQLSetViewerFederationSettingInput
   SigningMessagePurpose: GQLSigningMessagePurpose
   SigningMessageResult: ResolverTypeWrapper<GQLSigningMessageResult>
   SingleFileUploadInput: GQLSingleFileUploadInput
@@ -6385,6 +6409,7 @@ export type GQLResolversParentTypes = ResolversObject<{
   SendCampaignAnnouncementInput: GQLSendCampaignAnnouncementInput
   SendVerificationCodeInput: GQLSendVerificationCodeInput
   SetAdStatusInput: GQLSetAdStatusInput
+  SetArticleFederationSettingInput: GQLSetArticleFederationSettingInput
   SetArticleTopicChannelsInput: GQLSetArticleTopicChannelsInput
   SetBoostInput: GQLSetBoostInput
   SetCurrencyInput: GQLSetCurrencyInput
@@ -6393,6 +6418,7 @@ export type GQLResolversParentTypes = ResolversObject<{
   SetPasswordInput: GQLSetPasswordInput
   SetSpamStatusInput: GQLSetSpamStatusInput
   SetUserNameInput: GQLSetUserNameInput
+  SetViewerFederationSettingInput: GQLSetViewerFederationSettingInput
   SigningMessageResult: GQLSigningMessageResult
   SingleFileUploadInput: GQLSingleFileUploadInput
   SkippedListItem: GQLSkippedListItem
@@ -9193,6 +9219,12 @@ export type GQLMutationResolvers<
     ContextType,
     RequireFields<GQLMutationSetAdStatusArgs, 'input'>
   >
+  setArticleFederationSetting?: Resolver<
+    GQLResolversTypes['ArticleFederationSetting'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationSetArticleFederationSettingArgs, 'input'>
+  >
   setArticleTopicChannels?: Resolver<
     GQLResolversTypes['Article'],
     ParentType,
@@ -9240,6 +9272,12 @@ export type GQLMutationResolvers<
     ParentType,
     ContextType,
     RequireFields<GQLMutationSetUserNameArgs, 'input'>
+  >
+  setViewerFederationSetting?: Resolver<
+    GQLResolversTypes['UserFederationSetting'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationSetViewerFederationSettingArgs, 'input'>
   >
   singleFileUpload?: Resolver<
     GQLResolversTypes['Asset'],

--- a/src/mutations/article/index.ts
+++ b/src/mutations/article/index.ts
@@ -5,6 +5,7 @@ import mergeTags from './mergeTags.js'
 import publishArticle from './publishArticle.js'
 import readArticle from './readArticle.js'
 import renameTag from './renameTag.js'
+import setArticleFederationSetting from './setArticleFederationSetting.js'
 import toggleArticleRecommend from './toggleArticleRecommend.js'
 import toggleBookmarkArticle from './toggleBookmarkArticle.js'
 import updateArticleSensitive from './updateArticleSensitive.js'
@@ -14,6 +15,7 @@ export default {
   Mutation: {
     publishArticle,
     editArticle,
+    setArticleFederationSetting,
     appreciateArticle,
     readArticle,
     toggleArticleRecommend,

--- a/src/mutations/article/setArticleFederationSetting.ts
+++ b/src/mutations/article/setArticleFederationSetting.ts
@@ -1,0 +1,72 @@
+import type {
+  Article,
+  Context,
+  GQLMutationResolvers,
+} from '#definitions/index.js'
+import type { GlobalId } from '#definitions/nominal.js'
+
+import { NODE_TYPES, USER_FEATURE_FLAG_TYPE } from '#common/enums/index.js'
+import {
+  ArticleNotFoundError,
+  ForbiddenError,
+  UserInputError,
+} from '#common/errors.js'
+import { fromGlobalId, toGlobalId } from '#common/utils/index.js'
+
+type SetArticleFederationSettingState = 'inherit' | 'enabled' | 'disabled'
+
+const resolver = async (
+  _: unknown,
+  {
+    input: { id, state },
+  }: { input: { id: GlobalId; state: SetArticleFederationSettingState } },
+  {
+    viewer,
+    dataSources: { articleService, federationExportService, userService },
+  }: Context
+) => {
+  userService.validateUserState(viewer)
+
+  const featureFlags = await userService.findFeatureFlags(viewer.id)
+  const isFediverseBeta = featureFlags
+    .map(({ type: featureFlagType }) => featureFlagType)
+    .includes(USER_FEATURE_FLAG_TYPE.fediverseBeta)
+
+  if (!isFediverseBeta) {
+    throw new ForbiddenError('viewer is not in Fediverse beta')
+  }
+
+  const { id: articleId, type } = fromGlobalId(id)
+
+  if (type !== NODE_TYPES.Article) {
+    throw new UserInputError('id must be an Article ID')
+  }
+
+  const article = await articleService.baseFindById<Pick<Article, 'authorId'>>(
+    articleId
+  )
+
+  if (!article) {
+    throw new ArticleNotFoundError('Cannot find article')
+  }
+
+  if (article.authorId !== viewer.id) {
+    throw new ForbiddenError('viewer has no permission')
+  }
+
+  const updated = await federationExportService.upsertArticleFederationSetting({
+    articleId,
+    state,
+    updatedBy: viewer.id,
+  })
+
+  return {
+    ...updated,
+    articleId: toGlobalId({ type: NODE_TYPES.Article, id: updated.articleId }),
+    updatedBy: updated.updatedBy
+      ? toGlobalId({ type: NODE_TYPES.User, id: updated.updatedBy })
+      : null,
+  }
+}
+
+export default resolver as GQLMutationResolvers['setArticleFederationSetting']

--- a/src/mutations/system/__test__/federationSetting.test.ts
+++ b/src/mutations/system/__test__/federationSetting.test.ts
@@ -2,6 +2,8 @@ import { NODE_TYPES } from '#common/enums/index.js'
 import { toGlobalId } from '#common/utils/index.js'
 import { jest } from '@jest/globals'
 
+import setArticleFederationSetting from '../../article/setArticleFederationSetting.js'
+import setViewerFederationSetting from '../../user/setViewerFederationSetting.js'
 import putArticleFederationSetting from '../putArticleFederationSetting.js'
 import putUserFederationSetting from '../putUserFederationSetting.js'
 
@@ -116,5 +118,133 @@ describe('federation setting mutations', () => {
         }
       )
     ).rejects.toMatchObject({ extensions: { code: 'BAD_USER_INPUT' } })
+  })
+
+  test('lets Fediverse beta viewers update their own author setting', async () => {
+    const upsertAuthorFederationSetting = jest.fn(async () => ({
+      userId: '9',
+      state: 'enabled',
+      updatedBy: '9',
+    }))
+
+    const result = await (setViewerFederationSetting as any)(
+      {},
+      { input: { state: 'enabled' } },
+      {
+        viewer: { id: '9' },
+        dataSources: {
+          federationExportService: { upsertAuthorFederationSetting },
+          userService: {
+            findFeatureFlags: jest.fn(async () => [{ type: 'fediverseBeta' }]),
+            validateUserState: jest.fn(),
+          },
+        },
+      }
+    )
+
+    expect(upsertAuthorFederationSetting).toHaveBeenCalledWith({
+      userId: '9',
+      state: 'enabled',
+      updatedBy: '9',
+    })
+    expect(result).toEqual({
+      userId: toGlobalId({ type: NODE_TYPES.User, id: '9' }),
+      state: 'enabled',
+      updatedBy: toGlobalId({ type: NODE_TYPES.User, id: '9' }),
+    })
+  })
+
+  test('requires Fediverse beta flag for viewer author setting', async () => {
+    await expect(
+      (setViewerFederationSetting as any)(
+        {},
+        { input: { state: 'enabled' } },
+        {
+          viewer: { id: '9' },
+          dataSources: {
+            federationExportService: {
+              upsertAuthorFederationSetting: jest.fn(),
+            },
+            userService: {
+              findFeatureFlags: jest.fn(async () => []),
+              validateUserState: jest.fn(),
+            },
+          },
+        }
+      )
+    ).rejects.toMatchObject({ extensions: { code: 'FORBIDDEN' } })
+  })
+
+  test('lets Fediverse beta authors update their own article setting', async () => {
+    const upsertArticleFederationSetting = jest.fn(async () => ({
+      articleId: '101',
+      state: 'disabled',
+      updatedBy: '9',
+    }))
+
+    const result = await (setArticleFederationSetting as any)(
+      {},
+      {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.Article, id: '101' }),
+          state: 'disabled',
+        },
+      },
+      {
+        viewer: { id: '9' },
+        dataSources: {
+          articleService: {
+            baseFindById: jest.fn(async () => ({ authorId: '9' })),
+          },
+          federationExportService: { upsertArticleFederationSetting },
+          userService: {
+            findFeatureFlags: jest.fn(async () => [{ type: 'fediverseBeta' }]),
+            validateUserState: jest.fn(),
+          },
+        },
+      }
+    )
+
+    expect(upsertArticleFederationSetting).toHaveBeenCalledWith({
+      articleId: '101',
+      state: 'disabled',
+      updatedBy: '9',
+    })
+    expect(result).toEqual({
+      articleId: toGlobalId({ type: NODE_TYPES.Article, id: '101' }),
+      state: 'disabled',
+      updatedBy: toGlobalId({ type: NODE_TYPES.User, id: '9' }),
+    })
+  })
+
+  test('rejects article setting updates by non-authors', async () => {
+    await expect(
+      (setArticleFederationSetting as any)(
+        {},
+        {
+          input: {
+            id: toGlobalId({ type: NODE_TYPES.Article, id: '101' }),
+            state: 'disabled',
+          },
+        },
+        {
+          viewer: { id: '9' },
+          dataSources: {
+            articleService: {
+              baseFindById: jest.fn(async () => ({ authorId: '8' })),
+            },
+            federationExportService: {
+              upsertArticleFederationSetting: jest.fn(),
+            },
+            userService: {
+              findFeatureFlags: jest.fn(async () => [
+                { type: 'fediverseBeta' },
+              ]),
+              validateUserState: jest.fn(),
+            },
+          },
+        }
+      )
+    ).rejects.toMatchObject({ extensions: { code: 'FORBIDDEN' } })
   })
 })

--- a/src/mutations/user/index.ts
+++ b/src/mutations/user/index.ts
@@ -17,6 +17,7 @@ import setCurrency from './setCurrency.js'
 import setEmail from './setEmail.js'
 import setPassword from './setPassword.js'
 import setUserName from './setUserName.js'
+import setViewerFederationSetting from './setViewerFederationSetting.js'
 import {
   socialLogin,
   addSocialLogin,
@@ -56,6 +57,7 @@ export default {
     updateUserInfo,
     updateNotificationSetting,
     setCurrency,
+    setViewerFederationSetting,
     toggleBlockUser,
     toggleBookmarkTag,
     toggleFollowTag: toggleBookmarkTag,

--- a/src/mutations/user/setViewerFederationSetting.ts
+++ b/src/mutations/user/setViewerFederationSetting.ts
@@ -1,0 +1,40 @@
+import type { Context, GQLMutationResolvers } from '#definitions/index.js'
+
+import { NODE_TYPES, USER_FEATURE_FLAG_TYPE } from '#common/enums/index.js'
+import { ForbiddenError } from '#common/errors.js'
+import { toGlobalId } from '#common/utils/index.js'
+
+type SetViewerFederationSettingState = 'enabled' | 'disabled'
+
+const resolver = async (
+  _: unknown,
+  { input: { state } }: { input: { state: SetViewerFederationSettingState } },
+  { viewer, dataSources: { federationExportService, userService } }: Context
+) => {
+  userService.validateUserState(viewer)
+
+  const featureFlags = await userService.findFeatureFlags(viewer.id)
+  const isFediverseBeta = featureFlags
+    .map(({ type: featureFlagType }) => featureFlagType)
+    .includes(USER_FEATURE_FLAG_TYPE.fediverseBeta)
+
+  if (!isFediverseBeta) {
+    throw new ForbiddenError('viewer is not in Fediverse beta')
+  }
+
+  const updated = await federationExportService.upsertAuthorFederationSetting({
+    userId: viewer.id,
+    state,
+    updatedBy: viewer.id,
+  })
+
+  return {
+    ...updated,
+    userId: toGlobalId({ type: NODE_TYPES.User, id: updated.userId }),
+    updatedBy: updated.updatedBy
+      ? toGlobalId({ type: NODE_TYPES.User, id: updated.updatedBy })
+      : null,
+  }
+}
+
+export default resolver as GQLMutationResolvers['setViewerFederationSetting']

--- a/src/queries/__test__/federationSetting.test.ts
+++ b/src/queries/__test__/federationSetting.test.ts
@@ -1,0 +1,105 @@
+import { NODE_TYPES } from '#common/enums/index.js'
+import { toGlobalId } from '#common/utils/index.js'
+import {
+  ARTICLE_ACCESS_TYPE,
+  ARTICLE_STATE,
+  USER_STATE,
+} from '#common/enums/index.js'
+import { jest } from '@jest/globals'
+
+import articleFederationEligibility from '../article/federationEligibility.js'
+import articleFederationSetting from '../article/federationSetting.js'
+import userFederationSetting from '../user/federationSetting.js'
+
+describe('federation setting query resolvers', () => {
+  test('resolves author federation setting with global IDs', async () => {
+    const loadAuthorFederationSetting = jest.fn(async () => ({
+      userId: '2',
+      state: 'enabled',
+      updatedBy: '9',
+    }))
+
+    const result = await (userFederationSetting as any)(
+      { id: '2' },
+      {},
+      {
+        dataSources: {
+          federationExportService: { loadAuthorFederationSetting },
+        },
+      }
+    )
+
+    expect(loadAuthorFederationSetting).toHaveBeenCalledWith('2')
+    expect(result).toEqual({
+      userId: toGlobalId({ type: NODE_TYPES.User, id: '2' }),
+      state: 'enabled',
+      updatedBy: toGlobalId({ type: NODE_TYPES.User, id: '9' }),
+    })
+  })
+
+  test('resolves article federation setting with global IDs', async () => {
+    const loadArticleFederationSetting = jest.fn(async () => ({
+      articleId: '101',
+      state: 'disabled',
+      updatedBy: null,
+    }))
+
+    const result = await (articleFederationSetting as any)(
+      { id: '101' },
+      {},
+      {
+        dataSources: {
+          federationExportService: { loadArticleFederationSetting },
+        },
+      }
+    )
+
+    expect(loadArticleFederationSetting).toHaveBeenCalledWith('101')
+    expect(result).toEqual({
+      articleId: toGlobalId({ type: NODE_TYPES.Article, id: '101' }),
+      state: 'disabled',
+      updatedBy: null,
+    })
+  })
+
+  test('resolves article federation eligibility from server gate', async () => {
+    const loadSelectedArticleRows = jest.fn(async () => [
+      {
+        articleId: '101',
+        articleState: ARTICLE_STATE.active,
+        title: '公開長文',
+        summary: '摘要',
+        content: '<p>內容</p>',
+        access: ARTICLE_ACCESS_TYPE.public,
+        createdAt: new Date('2026-05-11T00:00:00.000Z'),
+        federationSetting: 'inherit',
+        author: {
+          id: '2',
+          userName: 'mashbean',
+          displayName: 'Mashbean',
+          state: USER_STATE.active,
+          federationSetting: 'enabled',
+        },
+      },
+    ])
+
+    const result = await (articleFederationEligibility as any)(
+      { id: '101' },
+      {},
+      {
+        dataSources: {
+          federationExportService: { loadSelectedArticleRows },
+        },
+      }
+    )
+
+    expect(loadSelectedArticleRows).toHaveBeenCalledWith(['101'], {
+      includeFederationSettings: true,
+    })
+    expect(result).toMatchObject({
+      eligible: true,
+      reason: 'eligible',
+      effectiveArticleSetting: 'inherit',
+    })
+  })
+})

--- a/src/queries/article/federationEligibility.ts
+++ b/src/queries/article/federationEligibility.ts
@@ -1,0 +1,28 @@
+import type { GQLArticleResolvers } from '#definitions/index.js'
+
+import {
+  FEDERATION_ARTICLE_SETTING,
+  resolveFederationExportGateForRow,
+} from '#connectors/article/federationExportService.js'
+
+const resolver: GQLArticleResolvers['federationEligibility'] = async (
+  { id }: { id: string },
+  _: unknown,
+  { dataSources: { federationExportService } }: any
+) => {
+  const [row] = await federationExportService.loadSelectedArticleRows([id], {
+    includeFederationSettings: true,
+  })
+
+  if (!row) {
+    return {
+      eligible: false,
+      reason: 'article_not_public',
+      effectiveArticleSetting: FEDERATION_ARTICLE_SETTING.inherit,
+    }
+  }
+
+  return resolveFederationExportGateForRow(row)
+}
+
+export default resolver

--- a/src/queries/article/federationSetting.ts
+++ b/src/queries/article/federationSetting.ts
@@ -1,0 +1,25 @@
+import type { GQLArticleResolvers } from '#definitions/index.js'
+
+import { NODE_TYPES } from '#common/enums/index.js'
+import { toGlobalId } from '#common/utils/index.js'
+
+const resolver: GQLArticleResolvers['federationSetting'] = async (
+  { id }: { id: string },
+  _: unknown,
+  { dataSources: { federationExportService } }: any
+) => {
+  const row = await federationExportService.loadArticleFederationSetting(id)
+  if (!row) {
+    return null
+  }
+
+  return {
+    ...row,
+    articleId: toGlobalId({ type: NODE_TYPES.Article, id: row.articleId }),
+    updatedBy: row.updatedBy
+      ? toGlobalId({ type: NODE_TYPES.User, id: row.updatedBy })
+      : null,
+  }
+}
+
+export default resolver

--- a/src/queries/article/index.ts
+++ b/src/queries/article/index.ts
@@ -30,6 +30,8 @@ import displayCover from './displayCover.js'
 import donated from './donated.js'
 import donationCount from './donationCount.js'
 import donations from './donations.js'
+import federationEligibility from './federationEligibility.js'
+import federationSetting from './federationSetting.js'
 import hasAppreciate from './hasAppreciate.js'
 import idResolver from './id.js'
 import indentFirstLine from './indentFirstLine.js'
@@ -105,6 +107,8 @@ const schema: GQLResolvers = {
     connectedBy,
     hasAppreciate,
     canSuperLike,
+    federationSetting,
+    federationEligibility,
     language,
     oss: (root) => root,
     relatedArticles,

--- a/src/queries/user/federationSetting.ts
+++ b/src/queries/user/federationSetting.ts
@@ -1,0 +1,29 @@
+import type { GQLUserResolvers } from '#definitions/index.js'
+
+import { NODE_TYPES } from '#common/enums/index.js'
+import { toGlobalId } from '#common/utils/index.js'
+
+const resolver: GQLUserResolvers['federationSetting'] = async (
+  { id }: { id?: string | null },
+  _: unknown,
+  { dataSources: { federationExportService } }: any
+) => {
+  if (!id) {
+    return null
+  }
+
+  const row = await federationExportService.loadAuthorFederationSetting(id)
+  if (!row) {
+    return null
+  }
+
+  return {
+    ...row,
+    userId: toGlobalId({ type: NODE_TYPES.User, id: row.userId }),
+    updatedBy: row.updatedBy
+      ? toGlobalId({ type: NODE_TYPES.User, id: row.updatedBy })
+      : null,
+  }
+}
+
+export default resolver

--- a/src/queries/user/index.ts
+++ b/src/queries/user/index.ts
@@ -42,6 +42,7 @@ import commentCount from './commentCount.js'
 import cryptoWallet from './cryptoWallet.js'
 import donatedArticleCount from './donatedArticleCount.js'
 import featuredTags from './featuredTags.js'
+import federationSetting from './federationSetting.js'
 import followers from './followers.js'
 import Following from './following/index.js'
 import group from './group.js'
@@ -122,6 +123,7 @@ const user: {
     info: (root) => root,
     wallet: (root) => root,
     settings: (root) => root,
+    federationSetting,
     status: (root) => (root.id ? root : null),
     activity: (root) => root,
     following: (root) => root,

--- a/src/types/__test__/2/system.test.ts
+++ b/src/types/__test__/2/system.test.ts
@@ -320,6 +320,26 @@ const PUT_ARTICLE_FEDERATION_SETTING = /* GraphQL */ `
   }
 `
 
+const SET_VIEWER_FEDERATION_SETTING = /* GraphQL */ `
+  mutation ($input: SetViewerFederationSettingInput!) {
+    setViewerFederationSetting(input: $input) {
+      userId
+      state
+      updatedBy
+    }
+  }
+`
+
+const SET_ARTICLE_FEDERATION_SETTING = /* GraphQL */ `
+  mutation ($input: SetArticleFederationSettingInput!) {
+    setArticleFederationSetting(input: $input) {
+      articleId
+      state
+      updatedBy
+    }
+  }
+`
+
 const GET_FEDERATION_SETTINGS = /* GraphQL */ `
   query ($userInput: UserInput!, $articleId: ID!) {
     user(input: $userInput) {
@@ -1047,8 +1067,23 @@ describe('user feature flags', () => {
 })
 
 describe('federation settings', () => {
+  const viewerId = toGlobalId({ type: NODE_TYPES.User, id: '1' })
   const userId = toGlobalId({ type: NODE_TYPES.User, id: '2' })
   const articleId = toGlobalId({ type: NODE_TYPES.Article, id: '1' })
+
+  test('returns null when federation settings are not configured', async () => {
+    const server = await testClient({ connections })
+    const { data } = await server.executeOperation({
+      query: GET_FEDERATION_SETTINGS,
+      variables: {
+        userInput: { userName: 'test2' },
+        articleId,
+      },
+    })
+
+    expect(data!.user!.federationSetting).toBeNull()
+    expect(data!.article!.federationSetting).toBeNull()
+  })
 
   test('only admin can update author federation setting', async () => {
     const notAdminServer = await testClient({
@@ -1101,6 +1136,79 @@ describe('federation settings', () => {
     expect(data!.putArticleFederationSetting).toMatchObject({
       articleId,
       state: 'disabled',
+    })
+  })
+
+  test('pilot viewer can update own author federation setting', async () => {
+    const server = await testClient({
+      isAuth: true,
+      isAdmin: false,
+      connections,
+    })
+    const { errors } = await server.executeOperation({
+      query: SET_VIEWER_FEDERATION_SETTING,
+      variables: { input: { state: 'enabled' } },
+    })
+    expect(errors![0]!.extensions!.code).toBe('FORBIDDEN')
+
+    const adminServer = await testClient({
+      isAuth: true,
+      isAdmin: true,
+      connections,
+    })
+    await adminServer.executeOperation({
+      query: PUT_USER_FEATURE_FLAGS,
+      variables: { input: { ids: [viewerId], flags: ['fediverseBeta'] } },
+    })
+
+    const { data } = await server.executeOperation({
+      query: SET_VIEWER_FEDERATION_SETTING,
+      variables: { input: { state: 'enabled' } },
+    })
+    expect(data!.setViewerFederationSetting).toMatchObject({
+      userId: viewerId,
+      state: 'enabled',
+      updatedBy: viewerId,
+    })
+  })
+
+  test('pilot author can update own article federation setting', async () => {
+    const adminServer = await testClient({
+      isAuth: true,
+      isAdmin: true,
+      connections,
+    })
+    await adminServer.executeOperation({
+      query: PUT_USER_FEATURE_FLAGS,
+      variables: {
+        input: { ids: [viewerId, userId], flags: ['fediverseBeta'] },
+      },
+    })
+
+    const nonAuthorServer = await testClient({
+      userId: '2',
+      isAuth: true,
+      connections,
+    })
+    const { errors } = await nonAuthorServer.executeOperation({
+      query: SET_ARTICLE_FEDERATION_SETTING,
+      variables: { input: { id: articleId, state: 'enabled' } },
+    })
+    expect(errors![0]!.extensions!.code).toBe('FORBIDDEN')
+
+    const authorServer = await testClient({
+      isAuth: true,
+      isAdmin: false,
+      connections,
+    })
+    const { data } = await authorServer.executeOperation({
+      query: SET_ARTICLE_FEDERATION_SETTING,
+      variables: { input: { id: articleId, state: 'enabled' } },
+    })
+    expect(data!.setArticleFederationSetting).toMatchObject({
+      articleId,
+      state: 'enabled',
+      updatedBy: viewerId,
     })
   })
 

--- a/src/types/__test__/2/system.test.ts
+++ b/src/types/__test__/2/system.test.ts
@@ -320,6 +320,32 @@ const PUT_ARTICLE_FEDERATION_SETTING = /* GraphQL */ `
   }
 `
 
+const GET_FEDERATION_SETTINGS = /* GraphQL */ `
+  query ($userInput: UserInput!, $articleInput: ArticleInput!) {
+    user(input: $userInput) {
+      id
+      federationSetting {
+        userId
+        state
+        updatedBy
+      }
+    }
+    article(input: $articleInput) {
+      id
+      federationSetting {
+        articleId
+        state
+        updatedBy
+      }
+      federationEligibility {
+        eligible
+        reason
+        effectiveArticleSetting
+      }
+    }
+  }
+`
+
 describe('query nodes of different type', () => {
   test('query user node', async () => {
     const id = toGlobalId({ type: NODE_TYPES.User, id: 1 })
@@ -1073,6 +1099,45 @@ describe('federation settings', () => {
     expect(data!.putArticleFederationSetting).toMatchObject({
       articleId,
       state: 'disabled',
+    })
+  })
+
+  test('exposes read-side federation settings and article eligibility', async () => {
+    const adminServer = await testClient({
+      isAuth: true,
+      isAdmin: true,
+      connections,
+    })
+    await adminServer.executeOperation({
+      query: PUT_USER_FEDERATION_SETTING,
+      variables: { input: { id: userId, state: 'enabled' } },
+    })
+    await adminServer.executeOperation({
+      query: PUT_ARTICLE_FEDERATION_SETTING,
+      variables: { input: { id: articleId, state: 'disabled' } },
+    })
+
+    const server = await testClient({ connections })
+    const { data } = await server.executeOperation({
+      query: GET_FEDERATION_SETTINGS,
+      variables: {
+        userInput: { userName: 'test2' },
+        articleInput: { shortHash: 'test1' },
+      },
+    })
+
+    expect(data!.user!.federationSetting).toMatchObject({
+      userId,
+      state: 'enabled',
+    })
+    expect(data!.article!.federationSetting).toMatchObject({
+      articleId,
+      state: 'disabled',
+    })
+    expect(data!.article!.federationEligibility).toMatchObject({
+      eligible: false,
+      reason: 'article_disabled',
+      effectiveArticleSetting: 'disabled',
     })
   })
 })

--- a/src/types/__test__/2/system.test.ts
+++ b/src/types/__test__/2/system.test.ts
@@ -321,7 +321,7 @@ const PUT_ARTICLE_FEDERATION_SETTING = /* GraphQL */ `
 `
 
 const GET_FEDERATION_SETTINGS = /* GraphQL */ `
-  query ($userInput: UserInput!, $articleInput: ArticleInput!) {
+  query ($userInput: UserInput!, $articleId: ID!) {
     user(input: $userInput) {
       id
       federationSetting {
@@ -330,17 +330,19 @@ const GET_FEDERATION_SETTINGS = /* GraphQL */ `
         updatedBy
       }
     }
-    article(input: $articleInput) {
-      id
-      federationSetting {
-        articleId
-        state
-        updatedBy
-      }
-      federationEligibility {
-        eligible
-        reason
-        effectiveArticleSetting
+    article: node(input: { id: $articleId }) {
+      ... on Article {
+        id
+        federationSetting {
+          articleId
+          state
+          updatedBy
+        }
+        federationEligibility {
+          eligible
+          reason
+          effectiveArticleSetting
+        }
       }
     }
   }
@@ -1122,7 +1124,7 @@ describe('federation settings', () => {
       query: GET_FEDERATION_SETTINGS,
       variables: {
         userInput: { userName: 'test2' },
-        articleInput: { shortHash: 'test1' },
+        articleId,
       },
     })
 

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -23,6 +23,9 @@ export default /* GraphQL */ `
     "Edit an article."
     editArticle(input: EditArticleInput!): Article! @auth(mode: "${AUTH_MODE.oauth}", group: "${SCOPE_GROUP.level3}") @purgeCache(type: "${NODE_TYPES.Article}")
 
+    "Set current author's Fediverse federation preference for an article."
+    setArticleFederationSetting(input: SetArticleFederationSettingInput!): ArticleFederationSetting! @auth(mode: "${AUTH_MODE.oauth}", group: "${SCOPE_GROUP.level3}") @purgeCache(type: "${NODE_TYPES.Article}")
+
     "Bookmark or unbookmark article"
     toggleSubscribeArticle(input: ToggleItemInput!): Article! @auth(mode: "${AUTH_MODE.oauth}", group: "${SCOPE_GROUP.level1}") @purgeCache(type: "${NODE_TYPES.Article}") @deprecated(reason: "Use toggleBookmarkArticle instead")
     toggleBookmarkArticle(input: ToggleItemInput!): Article! @auth(mode: "${AUTH_MODE.oauth}", group: "${SCOPE_GROUP.level1}") @purgeCache(type: "${NODE_TYPES.Article}")
@@ -540,6 +543,11 @@ export default /* GraphQL */ `
 
     "which campaigns to attach"
     campaigns: [ArticleCampaignInput!]
+  }
+
+  input SetArticleFederationSettingInput {
+    id: ID!
+    state: FederationArticleSettingState!
   }
 
   input ArticleCampaignInput {

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -121,6 +121,12 @@ export default /* GraphQL */ `
     "Original language of content"
     language: String
 
+    "Article-level federation setting override."
+    federationSetting: ArticleFederationSetting
+
+    "Computed federation export eligibility for this article."
+    federationEligibility: ArticleFederationEligibility!
+
     "List of articles which added this article into their connections."
     connectedBy(input: ConnectionArgs!): ArticleConnection! @complexity(multipliers: ["input.first"], value: 1)
 

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -555,6 +555,13 @@ export default /* GraphQL */ `
     disabled
   }
 
+  enum FederationExportDecisionReason {
+    eligible
+    article_not_public
+    author_not_opted_in
+    article_disabled
+  }
+
   type UserFederationSetting {
     userId: ID!
     state: FederationAuthorSettingState!
@@ -565,6 +572,12 @@ export default /* GraphQL */ `
     articleId: ID!
     state: FederationArticleSettingState!
     updatedBy: ID
+  }
+
+  type ArticleFederationEligibility {
+    eligible: Boolean!
+    reason: FederationExportDecisionReason!
+    effectiveArticleSetting: FederationArticleSettingState!
   }
 
   enum ReportReason {

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -542,6 +542,7 @@ export default /* GraphQL */ `
     unlimitedArticleFetch
     readSpamStatus
     communityWatch
+    fediverseBeta
   }
 
   enum FederationAuthorSettingState {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -31,6 +31,9 @@ export default /* GraphQL */ `
     "Set user currency preference."
     setCurrency(input: SetCurrencyInput!): User! @auth(mode: "${AUTH_MODE.oauth}", group: "${SCOPE_GROUP.level1}") @purgeCache(type: "${NODE_TYPES.User}")
 
+    "Set current viewer's Fediverse federation preference."
+    setViewerFederationSetting(input: SetViewerFederationSettingInput!): UserFederationSetting! @auth(mode: "${AUTH_MODE.oauth}", group: "${SCOPE_GROUP.level1}") @purgeCache(type: "${NODE_TYPES.User}")
+
     "Login user."
     emailLogin(input: EmailLoginInput!): AuthResult!
 
@@ -725,6 +728,10 @@ export default /* GraphQL */ `
 
   input SetCurrencyInput {
       currency: QuoteCurrency
+  }
+
+  input SetViewerFederationSettingInput {
+    state: FederationAuthorSettingState!
   }
 
   input GenerateSigningMessageInput {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -137,6 +137,9 @@ export default /* GraphQL */ `
     "User settings."
     settings: UserSettings! @auth(mode: "${AUTH_MODE.oauth}")
 
+    "User-level federation opt-in setting."
+    federationSetting: UserFederationSetting
+
     "Recommendations for current user."
     recommendation: Recommendation!
 


### PR DESCRIPTION
## Summary
- keep the existing admin-only federation setting mutations on this branch
- add read-side GraphQL fields for `User.federationSetting`, `Article.federationSetting`, and `Article.federationEligibility`
- add `fediverseBeta` pilot flag plus OAuth mutations for pilot viewers/authors to update their own author/article settings
- document the G2-B read/write product contract in `docs/Federation-Export.md`

## Verification
- commit hooks: lint, build, gen, format
- `npm run build`
- targeted ESLint for new federation mutation/query files passed
- targeted Node 18 Jest: federation mutation unit coverage passed
- `git diff --check`

## Note
- DB-backed `build/types/__test__/2/system.test.js` cannot run on this Mac because local PostgreSQL is not running (`ECONNREFUSED ::1:5432`). The prior CI failure came from the read-side test querying an article by a stale shortHash; this branch now queries the article by global ID via `node`, and CI is rerunning that DB-backed check.
