### PR TITLE
Fix Community Watch audit read consistency

### DIFF
--- a/src/common/utils/__test__/communityWatchStaffReview.test.ts
+++ b/src/common/utils/__test__/communityWatchStaffReview.test.ts
@@ -151,7 +151,56 @@ const createMutationContext = ({
     },
   }) as any
 
+const createReadService = () => {
+  const createBuilder = () => {
+    let countQuery = false
+    const builder: any = {
+      select: () => builder,
+      where: () => builder,
+      orderBy: () => builder,
+      offset: () => builder,
+      limit: async () => [baseAction],
+      count: () => {
+        countQuery = true
+        return builder
+      },
+      clone: () => builder,
+      first: async () => (countQuery ? { count: '1' } : baseAction),
+    }
+    return builder
+  }
+  const knex = jest.fn((_: string) => createBuilder()) as any
+  const knexRO = jest.fn((_: string) => createBuilder()) as any
+  const service = new CommentService({
+    knex,
+    knexRO,
+    knexSearch: knex,
+    redis: {},
+    objectCacheRedis: {},
+  } as any)
+
+  return { service, knex, knexRO }
+}
+
 describe('community watch staff review service', () => {
+  test('reads audit records from primary database for immediate consistency', async () => {
+    const { service, knex, knexRO } = createReadService()
+
+    await service.findActiveCommunityWatchAction(baseAction.commentId)
+    await service.findCommunityWatchActionByUUID(baseAction.uuid)
+    await service.findCommunityWatchActions({
+      filter: { actionState: 'active' },
+      skip: 0,
+      take: 10,
+    })
+
+    expect(knex).toHaveBeenCalledTimes(3)
+    expect(knex).toHaveBeenNthCalledWith(1, 'community_watch_action')
+    expect(knex).toHaveBeenNthCalledWith(2, 'community_watch_action')
+    expect(knex).toHaveBeenNthCalledWith(3, 'community_watch_action')
+    expect(knexRO).not.toHaveBeenCalled()
+  })
+
   test('updates appeal, review, and reason with review events', async () => {
     const { service, actionUpdates, eventInserts } = createService()
 

--- a/src/connectors/commentService.ts
+++ b/src/connectors/commentService.ts
@@ -80,7 +80,7 @@ export class CommentService extends BaseService<Comment> {
   public findActiveCommunityWatchAction = async (
     commentId: string
   ): Promise<CommunityWatchAction | null> => {
-    const action = await this.knexRO('community_watch_action')
+    const action = await this.knex('community_watch_action')
       .select()
       .where({ commentId, actionState: 'active' })
       .first()
@@ -90,7 +90,7 @@ export class CommentService extends BaseService<Comment> {
   public findCommunityWatchActionByUUID = async (
     uuid: string
   ): Promise<CommunityWatchAction | null> => {
-    const action = await this.knexRO('community_watch_action')
+    const action = await this.knex('community_watch_action')
       .select()
       .where({ uuid })
       .first()
@@ -106,7 +106,8 @@ export class CommentService extends BaseService<Comment> {
     skip: number
     take: number
   }): Promise<[CommunityWatchAction[], number]> => {
-    const baseQuery = this.knexRO('community_watch_action').select()
+    // Community Watch audit records are read immediately after moderation and review mutations.
+    const baseQuery = this.knex('community_watch_action').select()
 
     if (filter.reason) {
       baseQuery.where({ reason: filter.reason })


### PR DESCRIPTION
## Summary
- Read Community Watch audit records from the primary database instead of the read replica.
- Cover the connector read path so immediate post-mutation public/audit reads do not regress.

## Why
Staging validation found that after restoring a Community Watch removed comment, the mutation returned the updated action but public queries could still read stale action/review state values. The audit table is low-volume and needs read-after-write correctness for the transparency page and comment placeholder state.

## Tests
- npm run build
- MATTERS_ENV=test node --experimental-vm-modules node_modules/.bin/jest --runTestsByPath build/common/utils/__test__/communityWatchStaffReview.test.js build/common/utils/__test__/communityWatchPublicQueries.test.js build/common/utils/__test__/communityWatchRemoveComment.test.js --coverageDirectory coverage/utils
- npx eslint src/connectors/commentService.ts src/common/utils/__test__/communityWatchStaffReview.test.ts --quiet

Note: npm run test:utils with additional positional filters cannot run in this local Node 24 shell because the repo script includes the Node 18-era no-experimental-fetch flag; the targeted Jest command above omits only that incompatible flag.