### PR TITLE
[codex] Keep Community Watch placeholders in comment lists

### DIFF
--- a/src/connectors/__test__/commentService.test.ts
+++ b/src/connectors/__test__/commentService.test.ts
@@ -74,6 +74,44 @@ describe('find subcomments by parent comment id', () => {
 
     const [_, count2] = await commentService.findByParent({ id: '1' })
     expect(count2).toBe(count)
+
+    const communityWatchRemoved = await atomService.create({
+      table: 'comment',
+      data: {
+        type: 'article',
+        targetId: '1',
+        targetTypeId,
+        parentCommentId: '1',
+        state: COMMENT_STATE.banned,
+        uuid: uuidv4(),
+        authorId: '1',
+      },
+    })
+    await atomService.create({
+      table: 'community_watch_action',
+      data: {
+        uuid: uuidv4(),
+        commentId: communityWatchRemoved.id,
+        commentType: COMMENT_TYPE.article,
+        targetType: COMMENT_TYPE.article,
+        targetId: communityWatchRemoved.targetId,
+        targetTitle: 'Test article',
+        targetShortHash: 'test-short-hash',
+        reason: 'porn_ad',
+        actorId: '1',
+        commentAuthorId: '1',
+        originalContent: '<p>spam</p>',
+        originalState: COMMENT_STATE.active,
+        actionState: 'active',
+        appealState: 'none',
+        reviewState: 'pending',
+        contentExpiresAt: new Date('2026-05-20T00:00:00.000Z'),
+      },
+    })
+
+    const [comments3, count3] = await commentService.findByParent({ id: '1' })
+    expect(comments3.map((c) => c.id)).toContain(communityWatchRemoved.id)
+    expect(count3).toBe(count + 1)
   })
 })
 
@@ -208,6 +246,53 @@ describe('find comments', () => {
     expect(comments4.map((c) => c.id)).toContain(archived.id)
     expect(comments4.map((c) => c.id)).toContain(banned.id)
     expect(count4).toBe(count + 2)
+
+    const communityWatchRemoved = await atomService.create({
+      table: 'comment',
+      data: {
+        type: 'article',
+        targetId: '1',
+        targetTypeId,
+        parentCommentId: null,
+        state: COMMENT_STATE.banned,
+        uuid: uuidv4(),
+        authorId: '1',
+      },
+    })
+    await atomService.create({
+      table: 'community_watch_action',
+      data: {
+        uuid: uuidv4(),
+        commentId: communityWatchRemoved.id,
+        commentType: COMMENT_TYPE.article,
+        targetType: COMMENT_TYPE.article,
+        targetId: communityWatchRemoved.targetId,
+        targetTitle: 'Test article',
+        targetShortHash: 'test-short-hash',
+        reason: 'porn_ad',
+        actorId: '1',
+        commentAuthorId: '1',
+        originalContent: '<p>spam</p>',
+        originalState: COMMENT_STATE.active,
+        actionState: 'active',
+        appealState: 'none',
+        reviewState: 'pending',
+        contentExpiresAt: new Date('2026-05-20T00:00:00.000Z'),
+      },
+    })
+    const [commentsWithCommunityWatch, countWithCommunityWatch] =
+      await commentService.find({
+        where: {
+          type: 'article',
+          targetId: '1',
+          targetTypeId,
+          parentCommentId: null,
+        },
+      })
+    expect(commentsWithCommunityWatch.map((c) => c.id)).toContain(
+      communityWatchRemoved.id
+    )
+    expect(countWithCommunityWatch).toBe(count + 3)
 
     // when state is provided, filter by state
     const [comments5, _] = await commentService.find({

--- a/src/connectors/commentService.ts
+++ b/src/connectors/commentService.ts
@@ -193,9 +193,7 @@ export class CommentService extends BaseService<Comment> {
         patch.reviewState = reviewState
         events.push({
           eventType:
-            reviewState === 'upheld'
-              ? 'review_upheld'
-              : 'state_updated',
+            reviewState === 'upheld' ? 'review_upheld' : 'state_updated',
           oldValue: action.reviewState,
           newValue: reviewState,
         })
@@ -439,7 +437,20 @@ export class CommentService extends BaseService<Comment> {
         .select(['*', this.knex.raw('count(1) OVER() AS total_count')])
         .from(this.table)
         .where(where)
-        .whereIn('state', [COMMENT_STATE.active, COMMENT_STATE.collapsed])
+        .andWhere((builder) => {
+          builder
+            .whereIn('state', [COMMENT_STATE.active, COMMENT_STATE.collapsed])
+            .orWhere((communityWatchBuilder) => {
+              communityWatchBuilder
+                .where({ state: COMMENT_STATE.banned })
+                .andWhere(
+                  this.knexRO.raw(
+                    'EXISTS (SELECT 1 FROM community_watch_action WHERE community_watch_action.comment_id = comment.id AND community_watch_action.action_state = ?)',
+                    ['active']
+                  )
+                )
+            })
+        })
         .orderBy('created_at', by)
 
     if (author) {
@@ -491,6 +502,16 @@ export class CommentService extends BaseService<Comment> {
           andWhereBuilder
             .where({ state: COMMENT_STATE.active })
             .orWhere({ state: COMMENT_STATE.collapsed })
+            .orWhere((orWhereBuilder) => {
+              orWhereBuilder
+                .where({ state: COMMENT_STATE.banned })
+                .andWhere(
+                  this.knexRO.raw(
+                    'EXISTS (SELECT 1 FROM community_watch_action WHERE community_watch_action.comment_id = outer_comment.id AND community_watch_action.action_state = ?)',
+                    ['active']
+                  )
+                )
+            })
             .orWhere((orWhereBuilder) => {
               orWhereBuilder.andWhere(
                 this.knexRO.raw(


### PR DESCRIPTION
## Summary
- include Community Watch-removed banned comments with an active audit action in article comment list queries
- keep ordinary archived/banned comments filtered out
- add connector coverage for top-level and child comment list behavior

## Why
Staging E2E showed that a Community Watch-removed comment was stored and restored correctly, but the article page had no comment section when the removed comment was the only comment. The server list query was still filtering the banned placeholder row.

## Validation
- npm run build
- npm run lint
- npx prettier --check src/connectors/commentService.ts src/connectors/__test__/commentService.test.ts

## Notes
- Focused Jest connector test could not run locally because Postgres is not running on localhost:5432 and Docker is not available in this environment (`docker: command not found`). The added test is included for CI coverage.
