### PR TITLE
ci: add develop federation export event query

### DIFF
--- a/.github/workflows/query-develop-federation-export-event.yml
+++ b/.github/workflows/query-develop-federation-export-event.yml
@@ -1,0 +1,113 @@
+name: Query Develop Federation Export Event
+
+on:
+  workflow_dispatch:
+    inputs:
+      article_id:
+        description: 'matters.icu staging article id to inspect'
+        required: true
+        type: string
+      limit:
+        description: 'Maximum rows to print'
+        required: false
+        default: '20'
+        type: string
+
+concurrency:
+  group: query-develop-federation-export-event-${{ github.event.inputs.article_id }}
+  cancel-in-progress: false
+
+jobs:
+  query:
+    name: Query matters.icu develop federation export events
+    runs-on: ubuntu-latest
+    environment: develop
+    timeout-minutes: 10
+
+    steps:
+      - name: Validate input
+        run: |
+          case "${{ inputs.article_id }}" in
+            ''|*[!0-9]*)
+              echo "article_id must be a numeric staging article id" >&2
+              exit 1
+              ;;
+          esac
+
+          case "${{ inputs.limit }}" in
+            ''|*[!0-9]*)
+              echo "limit must be numeric" >&2
+              exit 1
+              ;;
+          esac
+
+          if [ "${{ inputs.limit }}" -lt 1 ] || [ "${{ inputs.limit }}" -gt 100 ]; then
+            echo "limit must be between 1 and 100" >&2
+            exit 1
+          fi
+
+      - name: Install tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y openvpn postgresql-client
+
+      - name: Start develop VPN
+        run: |
+          mkdir -p .github
+          echo "$VPN_AUTH" | base64 -d > "$VPN_AUTH_PATH"
+          echo "$VPN_CONFIG" | base64 -d > "$VPN_CONFIG_PATH"
+          sudo openvpn --config "$VPN_CONFIG_PATH" --auth-user-pass "$VPN_AUTH_PATH" --daemon
+          sleep 15s
+        env:
+          VPN_CONFIG: ${{ secrets.DEVELOP_VPN_CONFIG }}
+          VPN_CONFIG_PATH: '.github/config.ovpn'
+          VPN_AUTH: ${{ secrets.DEVELOP_VPN_AUTH }}
+          VPN_AUTH_PATH: '.github/auth.txt'
+
+      - name: Check develop DB connection
+        run: nc -zv -w 5 "$MATTERS_PG_HOST" 5432
+        env:
+          MATTERS_PG_HOST: ${{ secrets.DEVELOP_PG_HOST }}
+
+      - name: Query federation export event rows
+        run: |
+          psql \
+            --host "$MATTERS_PG_HOST" \
+            --username "$MATTERS_PG_USER" \
+            --dbname "$MATTERS_PG_DATABASE" \
+            --no-password \
+            --set ON_ERROR_STOP=1 \
+            --set article_id="${{ inputs.article_id }}" \
+            --set row_limit="${{ inputs.limit }}" \
+            --command "
+              select coalesce(jsonb_pretty(jsonb_agg(row_to_json(events)::jsonb)), '[]'::text) as federation_export_events
+              from (
+                select
+                  id,
+                  article_id,
+                  actor_id,
+                  trigger,
+                  mode,
+                  status,
+                  eligible,
+                  reason,
+                  author_setting,
+                  article_setting,
+                  effective_article_setting,
+                  decision_report,
+                  created_at
+                from federation_export_event
+                where article_id = :'article_id'::bigint
+                order by created_at desc
+                limit :'row_limit'::integer
+              ) events;
+            "
+        env:
+          MATTERS_PG_HOST: ${{ secrets.DEVELOP_PG_HOST }}
+          MATTERS_PG_DATABASE: ${{ secrets.DEVELOP_PG_DATABASE }}
+          MATTERS_PG_USER: ${{ secrets.DEVELOP_PG_USER }}
+          PGPASSWORD: ${{ secrets.DEVELOP_PG_PASSWORD }}
+
+      - name: Kill VPN
+        if: always()
+        run: sudo killall openvpn || true


### PR DESCRIPTION
## Summary
- Add a develop-only manual workflow for querying federation_export_event rows by staging article id.
- Use the existing develop VPN and develop Postgres secrets.
- Keep the workflow read-only and scoped to the develop GitHub environment.

## Safety
- Does not reference production DB secrets.
- Does not deploy code or change runtime configuration.
- Prints only federation export audit rows for the provided matters.icu article id.

## Test
- npx prettier --check .github/workflows/query-develop-federation-export-event.yml