### PR TITLE
ci: fix develop federation export event query

### DIFF
--- a/.github/workflows/query-develop-federation-export-event.yml
+++ b/.github/workflows/query-develop-federation-export-event.yml
@@ -77,8 +77,6 @@ jobs:
             --dbname "$MATTERS_PG_DATABASE" \
             --no-password \
             --set ON_ERROR_STOP=1 \
-            --set article_id="${{ inputs.article_id }}" \
-            --set row_limit="${{ inputs.limit }}" \
             --command "
               select coalesce(jsonb_pretty(jsonb_agg(row_to_json(events)::jsonb)), '[]'::text) as federation_export_events
               from (
@@ -97,9 +95,9 @@ jobs:
                   decision_report,
                   created_at
                 from federation_export_event
-                where article_id = :'article_id'::bigint
+                where article_id = ${{ inputs.article_id }}::bigint
                 order by created_at desc
-                limit :'row_limit'::integer
+                limit ${{ inputs.limit }}::integer
               ) events;
             "
         env:


### PR DESCRIPTION
## Summary
- Fix the develop-only federation_export_event query workflow so numeric inputs are rendered directly after validation.
- Keep the workflow read-only and scoped to develop.

## Validation
- npx prettier --check .github/workflows/query-develop-federation-export-event.yml
- Commit hook completed lint/build/gen/format.

## Prior smoke test
- VPN and develop DB connection passed in run 25791626330; SQL variable substitution failed and is fixed here.