### PR TITLE
ci: fix develop user feature flag workflow SQL

### DIFF
--- a/.github/workflows/ensure-develop-user-feature-flag.yml
+++ b/.github/workflows/ensure-develop-user-feature-flag.yml
@@ -78,27 +78,26 @@ jobs:
             --set ON_ERROR_STOP=1 \
             --set user_email="${{ inputs.email }}" \
             --set feature_flag="${{ inputs.flag }}" <<'SQL'
-              do $$
-              declare
-                target_user_id bigint;
-              begin
+              with target_user as (
                 select id
-                into target_user_id
                 from "user"
                 where lower(email) = lower(:'user_email')
                   and state <> 'archived'
                 order by id desc
-                limit 1;
-
-                if target_user_id is null then
-                  raise exception 'No active staging user found for email %', :'user_email';
-                end if;
-
+                limit 1
+              ),
+              ensure_target as (
+                select
+                  case
+                    when exists (select 1 from target_user) then 1
+                    else 1 / 0
+                  end as ok
+              )
                 insert into user_feature_flag (user_id, type)
-                values (target_user_id, :'feature_flag')
+                select target_user.id, :'feature_flag'
+                from target_user
+                cross join ensure_target
                 on conflict (user_id, type) do nothing;
-              end
-              $$;
 
               select
                 u.id,


### PR DESCRIPTION
## Summary
- Fix the develop-only user feature flag workflow SQL so psql variables are used outside a dollar-quoted block.
- Keeps the workflow scoped to develop and preserves existing user feature flags.

## Validation
- npx prettier --check .github/workflows/ensure-develop-user-feature-flag.yml
- Commit hook completed lint/build/gen/format.

## Prior smoke test
- Run 25793419273 proved develop VPN and DB connectivity; SQL variable substitution failed and is fixed here.