### PR TITLE
Sync Community Watch badge with feature flag

### DIFF
--- a/db/migrations/20260514000000_add_community_watch_user_badge.js
+++ b/db/migrations/20260514000000_add_community_watch_user_badge.js
@@ -1,0 +1,29 @@
+import { alterEnumString } from '../utils.js'
+
+const table = 'user_badge'
+
+const badgeTypes = [
+  'seed',
+  'golden_motor',
+  'architect',
+  'nomad',
+  'grand_slam',
+  'community_watch',
+]
+
+const previousBadgeTypes = [
+  'seed',
+  'golden_motor',
+  'architect',
+  'nomad',
+  'grand_slam',
+]
+
+export const up = async (knex) => {
+  await knex.raw(alterEnumString(table, 'type', badgeTypes))
+}
+
+export const down = async (knex) => {
+  await knex(table).where({ type: 'community_watch' }).del()
+  await knex.raw(alterEnumString(table, 'type', previousBadgeTypes))
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -3582,6 +3582,7 @@ enum BadgeType {
   golden_motor
   architect
   grand_slam
+  community_watch
   nomad1
   nomad2
   nomad3

--- a/src/common/enums/badges.ts
+++ b/src/common/enums/badges.ts
@@ -4,6 +4,7 @@ export const ALL_BADGE_TYPES = [
   'golden_motor',
   'seed',
   'grand_slam',
+  'community_watch',
   // user can only get 1 of the 4 nomad badges
   'nomad1',
   'nomad2',

--- a/src/common/utils/__test__/communityWatchBadgeMigration.test.ts
+++ b/src/common/utils/__test__/communityWatchBadgeMigration.test.ts
@@ -1,0 +1,64 @@
+import { pathToFileURL } from 'url'
+
+type Migration = {
+  up: (knex: MockKnex) => Promise<void>
+  down: (knex: MockKnex) => Promise<void>
+}
+
+type MockKnex = {
+  (table: string): {
+    where: (query: Record<string, string>) => {
+      del: () => Promise<void>
+    }
+  }
+  raw: (sql: string) => Promise<void>
+}
+
+const migrationUrl = pathToFileURL(
+  `${process.cwd()}/db/migrations/20260514000000_add_community_watch_user_badge.js`
+).href
+
+const createKnex = () => {
+  const rawCalls: string[] = []
+  const deletes: Array<{ table: string; query: Record<string, string> }> = []
+
+  const knex = ((table: string) => ({
+    where: (query: Record<string, string>) => ({
+      del: async () => {
+        deletes.push({ table, query })
+      },
+    }),
+  })) as unknown as MockKnex
+
+  knex.raw = async (sql: string) => {
+    rawCalls.push(sql)
+  }
+
+  return { knex, rawCalls, deletes }
+}
+
+describe('community watch badge migration', () => {
+  test('adds community_watch to user badge type', async () => {
+    const { up } = (await import(migrationUrl)) as Migration
+    const { knex, rawCalls } = createKnex()
+
+    await up(knex)
+
+    expect(rawCalls).toEqual([expect.stringContaining("'community_watch'")])
+  })
+
+  test('removes community_watch badges before restoring previous badge types', async () => {
+    const { down } = (await import(migrationUrl)) as Migration
+    const { knex, rawCalls, deletes } = createKnex()
+
+    await down(knex)
+
+    expect(deletes).toEqual([
+      {
+        table: 'user_badge',
+        query: { type: 'community_watch' },
+      },
+    ])
+    expect(rawCalls).toEqual([expect.not.stringContaining('community_watch')])
+  })
+})

--- a/src/connectors/userService.ts
+++ b/src/connectors/userService.ts
@@ -1813,6 +1813,28 @@ export class UserService extends BaseService<User> {
       ...toAdd.map((i) => this.addFeatureFlag(id, i)),
       ...toDel.map((i) => this.removeFeatureFlag(id, i)),
     ])
+    await this.syncCommunityWatchBadge(id, news)
+  }
+
+  private syncCommunityWatchBadge = async (
+    id: string,
+    types: Array<keyof typeof USER_FEATURE_FLAG_TYPE>
+  ) => {
+    const table = 'user_badge'
+    const type = 'community_watch'
+    const enabled = types.includes(USER_FEATURE_FLAG_TYPE.communityWatch)
+
+    if (enabled) {
+      await this.models.upsert({
+        table,
+        where: { userId: id, type },
+        update: { enabled },
+        create: { userId: id, type, enabled },
+      })
+      return
+    }
+
+    await this.models.deleteMany({ table, where: { userId: id, type } })
   }
 
   public addFeatureFlag = async (

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -760,6 +760,7 @@ export type GQLBadge = {
 
 export type GQLBadgeType =
   | 'architect'
+  | 'community_watch'
   | 'golden_motor'
   | 'grand_slam'
   | 'nomad1'

--- a/src/types/__test__/2/system.test.ts
+++ b/src/types/__test__/2/system.test.ts
@@ -296,6 +296,11 @@ const PUT_USER_FEATURE_FLAGS = /* GraphQL */ `
           createdAt
         }
       }
+      info {
+        badges {
+          type
+        }
+      }
     }
   }
 `
@@ -1039,6 +1044,44 @@ describe('user feature flags', () => {
         ({ type }: { type: GQLUserFeatureFlagType }) => type
       )
     ).toEqual(['communityWatch'])
+    expect(
+      data!.putUserFeatureFlags![0]!.info!.badges!.map(
+        ({ type }: { type: GQLBadgeType }) => type
+      )
+    ).toContain('community_watch')
+  })
+
+  test('admin removes community watch badge when removing community watch flag', async () => {
+    const server = await testClient({
+      isAuth: true,
+      isAdmin: true,
+      connections,
+    })
+    await server.executeOperation({
+      query: PUT_USER_FEATURE_FLAGS,
+      variables: {
+        input: {
+          ids: [userId1],
+          flags: ['communityWatch'],
+        },
+      },
+    })
+    const { data, errors } = await server.executeOperation({
+      query: PUT_USER_FEATURE_FLAGS,
+      variables: {
+        input: {
+          ids: [userId1],
+          flags: [],
+        },
+      },
+    })
+    expect(errors).toBeUndefined()
+    expect(data!.putUserFeatureFlags![0]!.oss!.featureFlags).toEqual([])
+    expect(
+      data!.putUserFeatureFlags![0]!.info!.badges!.map(
+        ({ type }: { type: GQLBadgeType }) => type
+      )
+    ).not.toContain('community_watch')
   })
 
   test('bulk update', async () => {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -854,6 +854,7 @@ export default /* GraphQL */ `
     golden_motor
     architect
     grand_slam
+    community_watch
     # can only have 1 of the 4 levels of nomad badges
     nomad1
     nomad2


### PR DESCRIPTION
## Summary
- add the `community_watch` user badge type and DB migration
- synchronize the badge when admin updates the `communityWatch` feature flag via `putUserFeatureFlags`
- cover assign/remove behavior in existing system GraphQL tests

## Validation
- npm run build
- npm run lint
- npm run gen
- attempted targeted system test with Node 24 fallback command; blocked by missing test connections (`AggregateError`, `connections.knex` undefined), not by assertion failure
