### PR TITLE
Backfill Community Watch badges

### DIFF
--- a/db/migrations/20260514010000_backfill_community_watch_user_badge.js
+++ b/db/migrations/20260514010000_backfill_community_watch_user_badge.js
@@ -1,0 +1,21 @@
+export const up = async (knex) => {
+  await knex.raw(`
+    INSERT INTO user_badge (user_id, type)
+    SELECT user_id, 'community_watch'
+    FROM user_feature_flag
+    WHERE type = 'communityWatch'
+    ON CONFLICT (user_id, type) DO NOTHING
+  `)
+}
+
+export const down = async (knex) => {
+  await knex.raw(`
+    DELETE FROM user_badge
+    WHERE type = 'community_watch'
+      AND user_id IN (
+        SELECT user_id
+        FROM user_feature_flag
+        WHERE type = 'communityWatch'
+      )
+  `)
+}

--- a/src/common/utils/__test__/communityWatchBadgeBackfillMigration.test.ts
+++ b/src/common/utils/__test__/communityWatchBadgeBackfillMigration.test.ts
@@ -1,0 +1,53 @@
+import { pathToFileURL } from 'url'
+
+type Migration = {
+  up: (knex: MockKnex) => Promise<void>
+  down: (knex: MockKnex) => Promise<void>
+}
+
+type MockKnex = {
+  raw: (sql: string) => Promise<void>
+}
+
+const migrationUrl = pathToFileURL(
+  `${process.cwd()}/db/migrations/20260514010000_backfill_community_watch_user_badge.js`
+).href
+
+const createKnex = () => {
+  const rawCalls: string[] = []
+  const knex = {
+    raw: async (sql: string) => {
+      rawCalls.push(sql)
+    },
+  }
+
+  return { knex: knex as MockKnex, rawCalls }
+}
+
+describe('community watch badge backfill migration', () => {
+  test('backfills badges from existing community watch feature flags', async () => {
+    const { up } = (await import(migrationUrl)) as Migration
+    const { knex, rawCalls } = createKnex()
+
+    await up(knex)
+
+    expect(rawCalls).toHaveLength(1)
+    expect(rawCalls[0]).toContain('INSERT INTO user_badge')
+    expect(rawCalls[0]).toContain("SELECT user_id, 'community_watch'")
+    expect(rawCalls[0]).toContain("WHERE type = 'communityWatch'")
+    expect(rawCalls[0]).toContain('ON CONFLICT (user_id, type) DO NOTHING')
+  })
+
+  test('removes backfilled badges for community watch feature flag users', async () => {
+    const { down } = (await import(migrationUrl)) as Migration
+    const { knex, rawCalls } = createKnex()
+
+    await down(knex)
+
+    expect(rawCalls).toHaveLength(1)
+    expect(rawCalls[0]).toContain('DELETE FROM user_badge')
+    expect(rawCalls[0]).toContain("WHERE type = 'community_watch'")
+    expect(rawCalls[0]).toContain('FROM user_feature_flag')
+    expect(rawCalls[0]).toContain("WHERE type = 'communityWatch'")
+  })
+})


### PR DESCRIPTION
## Summary
- Backfill community_watch badges for users who already have the communityWatch feature flag.
- Keep the migration idempotent with ON CONFLICT (user_id, type) DO NOTHING.
- Add rollback coverage for removing the backfilled badge rows tied to existing Community Watch flags.

## Validation
- npm run build
- npm run lint -- src/common/utils/__test__/communityWatchBadgeBackfillMigration.test.ts
- MATTERS_ENV=test node --experimental-vm-modules node_modules/.bin/jest build/common/utils/__test__/communityWatchBadgeBackfillMigration.test.js --runTestsByPath --forceExit --coverage=false
- commit hook: lint, build, gen, format