### PR TITLE
Align Community Watch content retention

### DIFF
--- a/db/migrations/20260516000000_make_community_watch_content_expiry_nullable.js
+++ b/db/migrations/20260516000000_make_community_watch_content_expiry_nullable.js
@@ -1,0 +1,18 @@
+const table = 'community_watch_action'
+
+export const up = async (knex) => {
+  await knex.schema.alterTable(table, (t) => {
+    t.timestamp('content_expires_at').nullable().alter()
+  })
+}
+
+export const down = async (knex) => {
+  await knex.raw(`
+    UPDATE ${table}
+    SET content_expires_at = COALESCE(content_expires_at, created_at + INTERVAL '7 days')
+  `)
+
+  await knex.schema.alterTable(table, (t) => {
+    t.timestamp('content_expires_at').notNullable().alter()
+  })
+}

--- a/src/common/utils/__test__/communityWatchContentExpiryMigration.test.ts
+++ b/src/common/utils/__test__/communityWatchContentExpiryMigration.test.ts
@@ -1,0 +1,104 @@
+import { pathToFileURL } from 'url'
+
+type Migration = {
+  up: (knex: MockKnex) => Promise<void>
+  down: (knex: MockKnex) => Promise<void>
+}
+
+type MockKnex = {
+  raw: (sql: string) => Promise<void>
+  schema: {
+    alterTable: (
+      table: string,
+      callback: (tableBuilder: MockTableBuilder) => void
+    ) => Promise<void>
+  }
+}
+
+type MockTableBuilder = {
+  timestamp: (column: string) => MockColumnBuilder
+}
+
+type MockColumnBuilder = {
+  nullable: () => MockColumnBuilder
+  notNullable: () => MockColumnBuilder
+  alter: () => MockColumnBuilder
+}
+
+const migrationUrl = pathToFileURL(
+  `${process.cwd()}/db/migrations/20260516000000_make_community_watch_content_expiry_nullable.js`
+).href
+
+const createKnex = () => {
+  const rawCalls: string[] = []
+  const alterCalls: string[] = []
+
+  const columnBuilder: MockColumnBuilder = {
+    nullable: () => {
+      alterCalls.push('nullable')
+      return columnBuilder
+    },
+    notNullable: () => {
+      alterCalls.push('notNullable')
+      return columnBuilder
+    },
+    alter: () => {
+      alterCalls.push('alter')
+      return columnBuilder
+    },
+  }
+
+  const tableBuilder: MockTableBuilder = {
+    timestamp: (column: string) => {
+      alterCalls.push(`timestamp:${column}`)
+      return columnBuilder
+    },
+  }
+
+  const knex: MockKnex = {
+    raw: async (sql: string) => {
+      rawCalls.push(sql)
+    },
+    schema: {
+      alterTable: async (table: string, callback) => {
+        alterCalls.push(`alterTable:${table}`)
+        callback(tableBuilder)
+      },
+    },
+  }
+
+  return { knex, rawCalls, alterCalls }
+}
+
+describe('community watch content expiry migration', () => {
+  test('allows audit original content to have no expiry', async () => {
+    const { up } = (await import(migrationUrl)) as Migration
+    const { knex, alterCalls } = createKnex()
+
+    await up(knex)
+
+    expect(alterCalls).toEqual([
+      'alterTable:community_watch_action',
+      'timestamp:content_expires_at',
+      'nullable',
+      'alter',
+    ])
+  })
+
+  test('restores seven-day fallback expiry before rollback', async () => {
+    const { down } = (await import(migrationUrl)) as Migration
+    const { knex, rawCalls, alterCalls } = createKnex()
+
+    await down(knex)
+
+    expect(rawCalls).toEqual([
+      expect.stringContaining("created_at + INTERVAL '7 days'"),
+    ])
+    expect(alterCalls).toEqual([
+      'alterTable:community_watch_action',
+      'timestamp:content_expires_at',
+      'notNullable',
+      'alter',
+    ])
+  })
+})

--- a/src/common/utils/__test__/communityWatchRemoveComment.test.ts
+++ b/src/common/utils/__test__/communityWatchRemoveComment.test.ts
@@ -186,9 +186,7 @@ describe('communityWatchRemoveComment', () => {
         originalState: COMMENT_STATE.active,
       })
     )
-    expect(insertedActions[0].contentExpiresAt.getTime()).toBeGreaterThan(
-      insertedActions[0].createdAt.getTime()
-    )
+    expect(insertedActions[0].contentExpiresAt).toBeNull()
     expect(
       context.dataSources.notificationService.trigger
     ).toHaveBeenCalledWith(

--- a/src/definitions/communityWatch.d.ts
+++ b/src/definitions/communityWatch.d.ts
@@ -39,7 +39,7 @@ export interface CommunityWatchAction {
   reviewerId: string | null
   reviewNote: string | null
   reviewedAt: Date | null
-  contentExpiresAt: Date
+  contentExpiresAt: Date | null
   createdAt: Date
   updatedAt: Date
 }

--- a/src/mutations/comment/communityWatchRemoveComment.ts
+++ b/src/mutations/comment/communityWatchRemoveComment.ts
@@ -24,8 +24,6 @@ import { fromGlobalId } from '#common/utils/index.js'
 import { invalidateFQC } from '@matters/apollo-response-cache'
 import { v4 } from 'uuid'
 
-const ORIGINAL_CONTENT_RETENTION_DAYS = 7
-
 const allowedCommentStates = [COMMENT_STATE.active, COMMENT_STATE.collapsed]
 const allowedCommentTypes = [COMMENT_TYPE.article, COMMENT_TYPE.moment]
 
@@ -87,11 +85,6 @@ const resolver = async (
       : undefined
 
   const now = new Date()
-  const contentExpiresAt = new Date(now)
-  contentExpiresAt.setDate(
-    contentExpiresAt.getDate() + ORIGINAL_CONTENT_RETENTION_DAYS
-  )
-
   const updatedComment = await connections.knex.transaction(
     async (trx: Knex.Transaction) => {
       const activeAction = await trx('community_watch_action')
@@ -137,7 +130,7 @@ const resolver = async (
         commentAuthorId: freshComment.authorId,
         originalContent: freshComment.content,
         originalState: freshComment.state,
-        contentExpiresAt,
+        contentExpiresAt: null,
         createdAt: now,
         updatedAt: now,
       })

--- a/src/types/__test__/2/comment.test.ts
+++ b/src/types/__test__/2/comment.test.ts
@@ -649,9 +649,7 @@ describe('community watch remove comment', () => {
       appealState: 'none',
       reviewState: 'pending',
     })
-    expect(auditAction.contentExpiresAt.getTime()).toBeGreaterThan(
-      auditAction.createdAt.getTime()
-    )
+    expect(auditAction.contentExpiresAt).toBeNull()
     expect(mockTrigger).toHaveBeenCalledWith(
       expect.objectContaining({
         event: OFFICIAL_NOTICE_EXTEND_TYPE.comment_banned,


### PR DESCRIPTION
## Summary
- stop assigning a seven-day expiry to new Community Watch original-content audit evidence
- allow existing community_watch_action.content_expires_at rows to be nullable
- cover the nullable migration and update Community Watch removal expectations

## Verification
- npm run build
- MATTERS_ENV=test node --experimental-vm-modules node_modules/.bin/jest build/common/utils/__test__/communityWatchRemoveComment.test.js build/common/utils/__test__/communityWatchContentExpiryMigration.test.js --runInBand --forceExit
- ./node_modules/.bin/prettier --check src/common/utils/__test__/communityWatchContentExpiryMigration.test.ts db/migrations/20260516000000_make_community_watch_content_expiry_nullable.js src/mutations/comment/communityWatchRemoveComment.ts src/definitions/communityWatch.d.ts src/common/utils/__test__/communityWatchRemoveComment.test.ts src/types/__test__/2/comment.test.ts

## Notes
- build/types/__test__/2/comment.test.js was attempted locally but requires the full test DB setup and failed before test execution with connection teardown errors in this clean worktree.
