### PR TITLE
Expose public viewer feature eligibility

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1276,6 +1276,9 @@ type User implements Node {
   """User-level federation opt-in setting."""
   federationSetting: UserFederationSetting
 
+  """Public-safe feature eligibility for current viewer."""
+  features: UserFeatures!
+
   """Recommendations for current user."""
   recommendation: Recommendation!
 
@@ -3168,6 +3171,14 @@ type UserOSS {
   score: Float!
   restrictions: [UserRestriction!]!
   featureFlags: [UserFeatureFlag!]!
+}
+
+type UserFeatures {
+  """Whether current viewer can access Fediverse beta controls."""
+  fediverseBeta: Boolean!
+
+  """Whether current viewer can use Community Watch controls."""
+  communityWatch: Boolean!
 }
 
 type Appreciation {

--- a/src/common/utils/__test__/userFeaturesResolver.test.ts
+++ b/src/common/utils/__test__/userFeaturesResolver.test.ts
@@ -1,0 +1,72 @@
+import { jest } from '@jest/globals'
+
+import { USER_FEATURE_FLAG_TYPE } from '#common/enums/index.js'
+import features from '#queries/user/features.js'
+
+describe('user public-safe features resolver', () => {
+  test('exposes selected feature flags for current viewer', async () => {
+    const userService = {
+      findFeatureFlags: jest.fn(async () => [
+        { type: USER_FEATURE_FLAG_TYPE.fediverseBeta },
+        { type: USER_FEATURE_FLAG_TYPE.communityWatch },
+        { type: USER_FEATURE_FLAG_TYPE.bypassSpamDetection },
+      ]),
+    }
+
+    const result = await features(
+      { id: '1' } as any,
+      {},
+      {
+        viewer: { id: '1' },
+        dataSources: { userService },
+      } as any
+    )
+
+    expect(result).toEqual({
+      fediverseBeta: true,
+      communityWatch: true,
+    })
+  })
+
+  test('does not expose another user feature eligibility', async () => {
+    const userService = {
+      findFeatureFlags: jest.fn(),
+    }
+
+    const result = await features(
+      { id: '2' } as any,
+      {},
+      {
+        viewer: { id: '1' },
+        dataSources: { userService },
+      } as any
+    )
+
+    expect(result).toEqual({
+      fediverseBeta: false,
+      communityWatch: false,
+    })
+    expect(userService.findFeatureFlags).not.toHaveBeenCalled()
+  })
+
+  test('returns default feature eligibility for anonymous viewer', async () => {
+    const userService = {
+      findFeatureFlags: jest.fn(),
+    }
+
+    const result = await features(
+      { id: '1' } as any,
+      {},
+      {
+        viewer: {},
+        dataSources: { userService },
+      } as any
+    )
+
+    expect(result).toEqual({
+      fediverseBeta: false,
+      communityWatch: false,
+    })
+    expect(userService.findFeatureFlags).not.toHaveBeenCalled()
+  })
+})

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -4513,6 +4513,8 @@ export type GQLUser = GQLNode & {
   displayName?: Maybe<Scalars['String']['output']>
   /** Drafts authored by current user. */
   drafts: GQLDraftConnection
+  /** Public-safe feature eligibility for current viewer. */
+  features: GQLUserFeatures
   /** User-level federation opt-in setting. */
   federationSetting?: Maybe<GQLUserFederationSetting>
   /** Followers of this user. */
@@ -4729,6 +4731,14 @@ export type GQLUserFeatureFlagType =
   | 'fediverseBeta'
   | 'readSpamStatus'
   | 'unlimitedArticleFetch'
+
+export type GQLUserFeatures = {
+  __typename?: 'UserFeatures'
+  /** Whether current viewer can use Community Watch controls. */
+  communityWatch: Scalars['Boolean']['output']
+  /** Whether current viewer can access Fediverse beta controls. */
+  fediverseBeta: Scalars['Boolean']['output']
+}
 
 export type GQLUserFederationSetting = {
   __typename?: 'UserFederationSetting'
@@ -6055,6 +6065,7 @@ export type GQLResolversTypes = ResolversObject<{
   >
   UserFeatureFlag: ResolverTypeWrapper<GQLUserFeatureFlag>
   UserFeatureFlagType: GQLUserFeatureFlagType
+  UserFeatures: ResolverTypeWrapper<GQLUserFeatures>
   UserFederationSetting: ResolverTypeWrapper<GQLUserFederationSetting>
   UserGroup: GQLUserGroup
   UserInfo: ResolverTypeWrapper<UserModel>
@@ -6677,6 +6688,7 @@ export type GQLResolversParentTypes = ResolversObject<{
     node: GQLResolversParentTypes['User']
   }
   UserFeatureFlag: GQLUserFeatureFlag
+  UserFeatures: GQLUserFeatures
   UserFederationSetting: GQLUserFederationSetting
   UserInfo: UserModel
   UserInput: GQLUserInput
@@ -11046,6 +11058,7 @@ export type GQLUserResolvers<
     ContextType,
     RequireFields<GQLUserDraftsArgs, 'input'>
   >
+  features?: Resolver<GQLResolversTypes['UserFeatures'], ParentType, ContextType>
   federationSetting?: Resolver<
     Maybe<GQLResolversTypes['UserFederationSetting']>,
     ParentType,
@@ -11256,6 +11269,23 @@ export type GQLUserFeatureFlagResolvers<
   createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
   type?: Resolver<
     GQLResolversTypes['UserFeatureFlagType'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLUserFeaturesResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UserFeatures'] = GQLResolversParentTypes['UserFeatures']
+> = ResolversObject<{
+  communityWatch?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  fediverseBeta?: Resolver<
+    GQLResolversTypes['Boolean'],
     ParentType,
     ContextType
   >
@@ -11848,6 +11878,7 @@ export type GQLResolvers<ContextType = Context> = ResolversObject<{
   UserCreateCircleActivity?: GQLUserCreateCircleActivityResolvers<ContextType>
   UserEdge?: GQLUserEdgeResolvers<ContextType>
   UserFeatureFlag?: GQLUserFeatureFlagResolvers<ContextType>
+  UserFeatures?: GQLUserFeaturesResolvers<ContextType>
   UserFederationSetting?: GQLUserFederationSettingResolvers<ContextType>
   UserInfo?: GQLUserInfoResolvers<ContextType>
   UserNotice?: GQLUserNoticeResolvers<ContextType>

--- a/src/queries/user/features.ts
+++ b/src/queries/user/features.ts
@@ -1,0 +1,28 @@
+import type { Context, User } from '#definitions/index.js'
+
+import { USER_FEATURE_FLAG_TYPE } from '#common/enums/index.js'
+
+const defaultFeatures = {
+  fediverseBeta: false,
+  communityWatch: false,
+}
+
+const resolver = async (
+  { id }: User,
+  _: unknown,
+  { viewer, dataSources: { userService } }: Context
+) => {
+  if (!id || id !== viewer.id) {
+    return defaultFeatures
+  }
+
+  const flags = await userService.findFeatureFlags(id)
+  const types = flags.map(({ type }) => type)
+
+  return {
+    fediverseBeta: types.includes(USER_FEATURE_FLAG_TYPE.fediverseBeta),
+    communityWatch: types.includes(USER_FEATURE_FLAG_TYPE.communityWatch),
+  }
+}
+
+export default resolver

--- a/src/queries/user/index.ts
+++ b/src/queries/user/index.ts
@@ -42,6 +42,7 @@ import commentCount from './commentCount.js'
 import cryptoWallet from './cryptoWallet.js'
 import donatedArticleCount from './donatedArticleCount.js'
 import featuredTags from './featuredTags.js'
+import features from './features.js'
 import federationSetting from './federationSetting.js'
 import followers from './followers.js'
 import Following from './following/index.js'
@@ -124,6 +125,7 @@ const user: {
     wallet: (root) => root,
     settings: (root) => root,
     federationSetting,
+    features,
     status: (root) => (root.id ? root : null),
     activity: (root) => root,
     following: (root) => root,

--- a/src/types/__test__/2/system.test.ts
+++ b/src/types/__test__/2/system.test.ts
@@ -305,6 +305,30 @@ const PUT_USER_FEATURE_FLAGS = /* GraphQL */ `
   }
 `
 
+const GET_VIEWER_FEATURES = /* GraphQL */ `
+  query {
+    viewer {
+      id
+      features {
+        fediverseBeta
+        communityWatch
+      }
+    }
+  }
+`
+
+const GET_USER_FEATURES = /* GraphQL */ `
+  query ($input: UserInput!) {
+    user(input: $input) {
+      id
+      features {
+        fediverseBeta
+        communityWatch
+      }
+    }
+  }
+`
+
 const PUT_USER_FEDERATION_SETTING = /* GraphQL */ `
   mutation ($input: PutUserFederationSettingInput!) {
     putUserFederationSetting(input: $input) {
@@ -1106,6 +1130,48 @@ describe('user feature flags', () => {
         ({ type }: { type: GQLUserFeatureFlagType }) => type
       )
     ).toEqual(['bypassSpamDetection'])
+  })
+
+  test('exposes only current viewer public-safe features outside OSS', async () => {
+    const adminServer = await testClient({
+      isAuth: true,
+      isAdmin: true,
+      connections,
+    })
+    await adminServer.executeOperation({
+      query: PUT_USER_FEATURE_FLAGS,
+      variables: {
+        input: { ids: [userId1], flags: ['fediverseBeta', 'communityWatch'] },
+      },
+    })
+
+    const ownerServer = await testClient({
+      userId: '2',
+      isAuth: true,
+      connections,
+    })
+    const { data: ownerData, errors } = await ownerServer.executeOperation({
+      query: GET_VIEWER_FEATURES,
+    })
+    expect(errors).toBeUndefined()
+    expect(ownerData!.viewer.features).toEqual({
+      fediverseBeta: true,
+      communityWatch: true,
+    })
+
+    const otherServer = await testClient({
+      userId: '3',
+      isAuth: true,
+      connections,
+    })
+    const { data: otherData } = await otherServer.executeOperation({
+      query: GET_USER_FEATURES,
+      variables: { input: { userName: userName1 } },
+    })
+    expect(otherData!.user.features).toEqual({
+      fediverseBeta: false,
+      communityWatch: false,
+    })
   })
 })
 

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -143,6 +143,9 @@ export default /* GraphQL */ `
     "User-level federation opt-in setting."
     federationSetting: UserFederationSetting
 
+    "Public-safe feature eligibility for current viewer."
+    features: UserFeatures!
+
     "Recommendations for current user."
     recommendation: Recommendation!
 
@@ -425,6 +428,14 @@ export default /* GraphQL */ `
     score: Float!
     restrictions: [UserRestriction!]!
     featureFlags: [UserFeatureFlag!]!
+  }
+
+  type UserFeatures @cacheControl(maxAge: ${CACHE_TTL.INSTANT}) {
+    "Whether current viewer can access Fediverse beta controls."
+    fediverseBeta: Boolean!
+
+    "Whether current viewer can use Community Watch controls."
+    communityWatch: Boolean!
   }
 
   type Appreciation {


### PR DESCRIPTION
## Summary
- add `User.features` for public-safe current-viewer feature eligibility
- expose only `fediverseBeta` and `communityWatch`, scoped to the current viewer
- keep admin-only feature flag inventory under `User.oss`

## Validation
- `npm run build`
- `npm run lint`
- `MATTERS_ENV=test node --experimental-vm-modules node_modules/.bin/jest build/common/utils/__test__/userFeaturesResolver.test.js --runInBand`

## Notes
- `src/definitions/schema.d.ts` is manually minimized to avoid codegen formatting churn.
- The broader system integration test was not rerun here because the local test DB setup fails during initialization in this workspace.