### PR TITLE
Sync Fediverse feature gates to develop

### DIFF
--- a/docs/Federation-Export.md
+++ b/docs/Federation-Export.md
@@ -68,19 +68,65 @@ G2-B adds two OAuth mutations gated by the `fediverseBeta` user feature flag:
 | `setViewerFederationSetting(input: { state })`      | Lets a pilot viewer set only their own author-level federation setting. |
 | `setArticleFederationSetting(input: { id, state })` | Lets a pilot author set only their own article federation override.     |
 
-The feature flag is assigned through the existing admin feature-flag tooling. These mutations do not publish, backfill, delete, or export content; they only record settings for the server-side gate.
+The feature flag is assigned through the existing admin-only `putUserFeatureFlags` mutation. These mutations do not publish, backfill, delete, or export content; they only record settings for the server-side gate.
+
+### Enabling a pilot account
+
+Do not update `user_feature_flag` manually for staging or production pilot setup. Use the existing admin API so authorization, cache invalidation, enum validation, and duplicate handling stay on the normal server path.
+
+Recommended pilot setup flow:
+
+1. Ask the pilot user to register, verify email, and confirm they can log in.
+2. Resolve the username to the user's GraphQL global ID through the existing admin/user query path.
+3. Call `putUserFeatureFlags` as an admin and include `fediverseBeta` in the user's complete desired flag list.
+4. Ask the pilot user to reload `/me/settings/misc` and confirm the Fediverse setting is visible.
+5. To remove pilot access, call the same mutation again with `fediverseBeta` removed from the complete desired flag list.
+
+Example:
+
+```graphql
+mutation EnableFediversePilot($input: PutUserFeatureFlagsInput!) {
+  putUserFeatureFlags(input: $input) {
+    id
+    userName
+    oss {
+      featureFlags {
+        type
+      }
+    }
+  }
+}
+```
+
+Variables:
+
+```json
+{
+  "input": {
+    "ids": ["USER_GLOBAL_ID"],
+    "flags": ["fediverseBeta"]
+  }
+}
+```
+
+`putUserFeatureFlags` sets the user's complete feature-flag list, not a single add/remove toggle. If the user already has other feature flags, preserve them in `flags` when adding or removing `fediverseBeta`.
+
+For matters.icu develop-only staging operations, the GitHub Actions workflow `Ensure Develop User Feature Flag` may be used as a controlled shortcut. It is limited to the `develop` environment, resolves the target user by email, inserts `fediverseBeta` idempotently with the `user_feature_flag (user_id, type)` uniqueness constraint, and invalidates the user's full-query cache. This workflow is for staging setup only; production pilot access should keep using the admin API path above.
 
 ## Read-side product fields
 
 G2-B adds read-side fields for Matters Web/App to display the current contract state without writing settings:
 
-| Field                           | Purpose                                                                  |
-| ------------------------------- | ------------------------------------------------------------------------ |
-| `User.federationSetting`        | Returns the author's explicit opt-in row, or `null` when default-off.    |
-| `Article.federationSetting`     | Returns the article override row, or `null` when it inherits.            |
-| `Article.federationEligibility` | Returns the computed server-side decision and effective article setting. |
+| Field                           | Purpose                                                                                             |
+| ------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `User.features.fediverseBeta`   | Public-safe current-viewer eligibility for showing Fediverse beta controls.                         |
+| `User.federationSetting`        | Returns the author's explicit opt-in row, or `null` when default-off.                               |
+| `Article.federationSetting`     | Returns the article override row, or `null` when it inherits.                                       |
+| `Article.federationEligibility` | Returns the computed server-side decision and effective article setting.                            |
 
 `Article.federationEligibility` uses the same server gate as export runs. Matters Web may use it to show disabled states, but the UI must not treat its own state as authoritative.
+
+Matters Web should gate user-facing Fediverse controls with `User.features.fediverseBeta`, not `User.oss.featureFlags`. `User.oss` remains the admin-only feature flag inventory, while `User.features` exposes only the current viewer's public-safe feature eligibility.
 
 ## Durable state scaffold
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1276,6 +1276,9 @@ type User implements Node {
   """User-level federation opt-in setting."""
   federationSetting: UserFederationSetting
 
+  """Public-safe feature eligibility for current viewer."""
+  features: UserFeatures!
+
   """Recommendations for current user."""
   recommendation: Recommendation!
 
@@ -3168,6 +3171,14 @@ type UserOSS {
   score: Float!
   restrictions: [UserRestriction!]!
   featureFlags: [UserFeatureFlag!]!
+}
+
+type UserFeatures {
+  """Whether current viewer can access Fediverse beta controls."""
+  fediverseBeta: Boolean!
+
+  """Whether current viewer can use Community Watch controls."""
+  communityWatch: Boolean!
 }
 
 type Appreciation {

--- a/src/common/utils/__test__/userFeaturesResolver.test.ts
+++ b/src/common/utils/__test__/userFeaturesResolver.test.ts
@@ -1,0 +1,72 @@
+import { jest } from '@jest/globals'
+
+import { USER_FEATURE_FLAG_TYPE } from '#common/enums/index.js'
+import features from '#queries/user/features.js'
+
+describe('user public-safe features resolver', () => {
+  test('exposes selected feature flags for current viewer', async () => {
+    const userService = {
+      findFeatureFlags: jest.fn(async () => [
+        { type: USER_FEATURE_FLAG_TYPE.fediverseBeta },
+        { type: USER_FEATURE_FLAG_TYPE.communityWatch },
+        { type: USER_FEATURE_FLAG_TYPE.bypassSpamDetection },
+      ]),
+    }
+
+    const result = await features(
+      { id: '1' } as any,
+      {},
+      {
+        viewer: { id: '1' },
+        dataSources: { userService },
+      } as any
+    )
+
+    expect(result).toEqual({
+      fediverseBeta: true,
+      communityWatch: true,
+    })
+  })
+
+  test('does not expose another user feature eligibility', async () => {
+    const userService = {
+      findFeatureFlags: jest.fn(),
+    }
+
+    const result = await features(
+      { id: '2' } as any,
+      {},
+      {
+        viewer: { id: '1' },
+        dataSources: { userService },
+      } as any
+    )
+
+    expect(result).toEqual({
+      fediverseBeta: false,
+      communityWatch: false,
+    })
+    expect(userService.findFeatureFlags).not.toHaveBeenCalled()
+  })
+
+  test('returns default feature eligibility for anonymous viewer', async () => {
+    const userService = {
+      findFeatureFlags: jest.fn(),
+    }
+
+    const result = await features(
+      { id: '1' } as any,
+      {},
+      {
+        viewer: {},
+        dataSources: { userService },
+      } as any
+    )
+
+    expect(result).toEqual({
+      fediverseBeta: false,
+      communityWatch: false,
+    })
+    expect(userService.findFeatureFlags).not.toHaveBeenCalled()
+  })
+})

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -4513,6 +4513,8 @@ export type GQLUser = GQLNode & {
   displayName?: Maybe<Scalars['String']['output']>
   /** Drafts authored by current user. */
   drafts: GQLDraftConnection
+  /** Public-safe feature eligibility for current viewer. */
+  features: GQLUserFeatures
   /** User-level federation opt-in setting. */
   federationSetting?: Maybe<GQLUserFederationSetting>
   /** Followers of this user. */
@@ -4729,6 +4731,14 @@ export type GQLUserFeatureFlagType =
   | 'fediverseBeta'
   | 'readSpamStatus'
   | 'unlimitedArticleFetch'
+
+export type GQLUserFeatures = {
+  __typename?: 'UserFeatures'
+  /** Whether current viewer can use Community Watch controls. */
+  communityWatch: Scalars['Boolean']['output']
+  /** Whether current viewer can access Fediverse beta controls. */
+  fediverseBeta: Scalars['Boolean']['output']
+}
 
 export type GQLUserFederationSetting = {
   __typename?: 'UserFederationSetting'
@@ -6055,6 +6065,7 @@ export type GQLResolversTypes = ResolversObject<{
   >
   UserFeatureFlag: ResolverTypeWrapper<GQLUserFeatureFlag>
   UserFeatureFlagType: GQLUserFeatureFlagType
+  UserFeatures: ResolverTypeWrapper<GQLUserFeatures>
   UserFederationSetting: ResolverTypeWrapper<GQLUserFederationSetting>
   UserGroup: GQLUserGroup
   UserInfo: ResolverTypeWrapper<UserModel>
@@ -6677,6 +6688,7 @@ export type GQLResolversParentTypes = ResolversObject<{
     node: GQLResolversParentTypes['User']
   }
   UserFeatureFlag: GQLUserFeatureFlag
+  UserFeatures: GQLUserFeatures
   UserFederationSetting: GQLUserFederationSetting
   UserInfo: UserModel
   UserInput: GQLUserInput
@@ -11046,6 +11058,7 @@ export type GQLUserResolvers<
     ContextType,
     RequireFields<GQLUserDraftsArgs, 'input'>
   >
+  features?: Resolver<GQLResolversTypes['UserFeatures'], ParentType, ContextType>
   federationSetting?: Resolver<
     Maybe<GQLResolversTypes['UserFederationSetting']>,
     ParentType,
@@ -11256,6 +11269,23 @@ export type GQLUserFeatureFlagResolvers<
   createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
   type?: Resolver<
     GQLResolversTypes['UserFeatureFlagType'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLUserFeaturesResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UserFeatures'] = GQLResolversParentTypes['UserFeatures']
+> = ResolversObject<{
+  communityWatch?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  fediverseBeta?: Resolver<
+    GQLResolversTypes['Boolean'],
     ParentType,
     ContextType
   >
@@ -11848,6 +11878,7 @@ export type GQLResolvers<ContextType = Context> = ResolversObject<{
   UserCreateCircleActivity?: GQLUserCreateCircleActivityResolvers<ContextType>
   UserEdge?: GQLUserEdgeResolvers<ContextType>
   UserFeatureFlag?: GQLUserFeatureFlagResolvers<ContextType>
+  UserFeatures?: GQLUserFeaturesResolvers<ContextType>
   UserFederationSetting?: GQLUserFederationSettingResolvers<ContextType>
   UserInfo?: GQLUserInfoResolvers<ContextType>
   UserNotice?: GQLUserNoticeResolvers<ContextType>

--- a/src/queries/user/features.ts
+++ b/src/queries/user/features.ts
@@ -1,0 +1,28 @@
+import type { Context, User } from '#definitions/index.js'
+
+import { USER_FEATURE_FLAG_TYPE } from '#common/enums/index.js'
+
+const defaultFeatures = {
+  fediverseBeta: false,
+  communityWatch: false,
+}
+
+const resolver = async (
+  { id }: User,
+  _: unknown,
+  { viewer, dataSources: { userService } }: Context
+) => {
+  if (!id || id !== viewer.id) {
+    return defaultFeatures
+  }
+
+  const flags = await userService.findFeatureFlags(id)
+  const types = flags.map(({ type }) => type)
+
+  return {
+    fediverseBeta: types.includes(USER_FEATURE_FLAG_TYPE.fediverseBeta),
+    communityWatch: types.includes(USER_FEATURE_FLAG_TYPE.communityWatch),
+  }
+}
+
+export default resolver

--- a/src/queries/user/index.ts
+++ b/src/queries/user/index.ts
@@ -42,6 +42,7 @@ import commentCount from './commentCount.js'
 import cryptoWallet from './cryptoWallet.js'
 import donatedArticleCount from './donatedArticleCount.js'
 import featuredTags from './featuredTags.js'
+import features from './features.js'
 import federationSetting from './federationSetting.js'
 import followers from './followers.js'
 import Following from './following/index.js'
@@ -124,6 +125,7 @@ const user: {
     wallet: (root) => root,
     settings: (root) => root,
     federationSetting,
+    features,
     status: (root) => (root.id ? root : null),
     activity: (root) => root,
     following: (root) => root,

--- a/src/types/__test__/2/system.test.ts
+++ b/src/types/__test__/2/system.test.ts
@@ -305,6 +305,30 @@ const PUT_USER_FEATURE_FLAGS = /* GraphQL */ `
   }
 `
 
+const GET_VIEWER_FEATURES = /* GraphQL */ `
+  query {
+    viewer {
+      id
+      features {
+        fediverseBeta
+        communityWatch
+      }
+    }
+  }
+`
+
+const GET_USER_FEATURES = /* GraphQL */ `
+  query ($input: UserInput!) {
+    user(input: $input) {
+      id
+      features {
+        fediverseBeta
+        communityWatch
+      }
+    }
+  }
+`
+
 const PUT_USER_FEDERATION_SETTING = /* GraphQL */ `
   mutation ($input: PutUserFederationSettingInput!) {
     putUserFederationSetting(input: $input) {
@@ -1106,6 +1130,48 @@ describe('user feature flags', () => {
         ({ type }: { type: GQLUserFeatureFlagType }) => type
       )
     ).toEqual(['bypassSpamDetection'])
+  })
+
+  test('exposes only current viewer public-safe features outside OSS', async () => {
+    const adminServer = await testClient({
+      isAuth: true,
+      isAdmin: true,
+      connections,
+    })
+    await adminServer.executeOperation({
+      query: PUT_USER_FEATURE_FLAGS,
+      variables: {
+        input: { ids: [userId1], flags: ['fediverseBeta', 'communityWatch'] },
+      },
+    })
+
+    const ownerServer = await testClient({
+      userId: '2',
+      isAuth: true,
+      connections,
+    })
+    const { data: ownerData, errors } = await ownerServer.executeOperation({
+      query: GET_VIEWER_FEATURES,
+    })
+    expect(errors).toBeUndefined()
+    expect(ownerData!.viewer.features).toEqual({
+      fediverseBeta: true,
+      communityWatch: true,
+    })
+
+    const otherServer = await testClient({
+      userId: '3',
+      isAuth: true,
+      connections,
+    })
+    const { data: otherData } = await otherServer.executeOperation({
+      query: GET_USER_FEATURES,
+      variables: { input: { userName: userName1 } },
+    })
+    expect(otherData!.user.features).toEqual({
+      fediverseBeta: false,
+      communityWatch: false,
+    })
   })
 })
 

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -143,6 +143,9 @@ export default /* GraphQL */ `
     "User-level federation opt-in setting."
     federationSetting: UserFederationSetting
 
+    "Public-safe feature eligibility for current viewer."
+    features: UserFeatures!
+
     "Recommendations for current user."
     recommendation: Recommendation!
 
@@ -425,6 +428,14 @@ export default /* GraphQL */ `
     score: Float!
     restrictions: [UserRestriction!]!
     featureFlags: [UserFeatureFlag!]!
+  }
+
+  type UserFeatures @cacheControl(maxAge: ${CACHE_TTL.INSTANT}) {
+    "Whether current viewer can access Fediverse beta controls."
+    fediverseBeta: Boolean!
+
+    "Whether current viewer can use Community Watch controls."
+    communityWatch: Boolean!
   }
 
   type Appreciation {


### PR DESCRIPTION
## Summary
- cherry-pick the public-safe `User.features.fediverseBeta` contract from master into develop
- keep `User.oss.featureFlags` admin-only and document the develop staging flow
- unblock matters.icu from validating Fediverse controls against `viewer.features.fediverseBeta`

## Verification
- `npx -y -p node@18 -c 'node node_modules/typescript/bin/tsc -p .'`\n- `npx -y -p node@18 -c 'MATTERS_ENV=test node --experimental-vm-modules --no-experimental-fetch node_modules/.bin/jest build/common/utils/__test__/userFeaturesResolver.test.js --runInBand'`\n\n## Not Run\n- full `system.test.js` suite: local PostgreSQL was not available (`connect ECONNREFUSED ::1:5432`)\n- `npm ci`: current shell Node is v24; repo requires Node 18 and npm also reported existing lockfile optional-dependency sync issues in this local environment