### PR TITLE
Fix Community Watch restore states

### DIFF
--- a/src/common/utils/__test__/communityWatchStaffReview.test.ts
+++ b/src/common/utils/__test__/communityWatchStaffReview.test.ts
@@ -266,16 +266,29 @@ describe('community watch staff review service', () => {
     expect(actionUpdates[0]).toEqual(
       expect.objectContaining({
         actionState: 'restored',
+        appealState: 'resolved',
         reviewState: 'reversed',
         reviewerId: '9',
       })
     )
-    expect(eventInserts[0]).toEqual(
-      expect.objectContaining({
-        eventType: 'comment_restored',
-        oldValue: COMMENT_STATE.banned,
-        newValue: COMMENT_STATE.active,
-      })
+    expect(eventInserts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: 'comment_restored',
+          oldValue: COMMENT_STATE.banned,
+          newValue: COMMENT_STATE.active,
+        }),
+        expect.objectContaining({
+          eventType: 'review_reversed',
+          oldValue: 'pending',
+          newValue: 'reversed',
+        }),
+        expect.objectContaining({
+          eventType: 'appeal_resolved',
+          oldValue: 'none',
+          newValue: 'resolved',
+        }),
+      ])
     )
   })
 

--- a/src/connectors/commentService.ts
+++ b/src/connectors/commentService.ts
@@ -285,6 +285,7 @@ export class CommentService extends BaseService<Comment> {
         .where({ id: action.id })
         .update({
           actionState: 'restored',
+          appealState: 'resolved',
           reviewState: 'reversed',
           reviewerId: actorId,
           reviewNote: note || null,
@@ -293,17 +294,39 @@ export class CommentService extends BaseService<Comment> {
         })
         .returning('*')
 
+      const events: Array<{
+        eventType: CommunityWatchReviewEventType
+        oldValue: string | null
+        newValue: string | null
+      }> = [
+        {
+          eventType: 'comment_restored',
+          oldValue: comment.state,
+          newValue: action.originalState,
+        },
+      ]
+
+      if (action.reviewState !== 'reversed') {
+        events.push({
+          eventType: 'review_reversed',
+          oldValue: action.reviewState,
+          newValue: 'reversed',
+        })
+      }
+
+      if (action.appealState !== 'resolved') {
+        events.push({
+          eventType: 'appeal_resolved',
+          oldValue: action.appealState,
+          newValue: 'resolved',
+        })
+      }
+
       await this.insertCommunityWatchReviewEvents(trx, {
         actionId: action.id,
         actorId,
         note,
-        events: [
-          {
-            eventType: 'comment_restored',
-            oldValue: comment.state,
-            newValue: action.originalState,
-          },
-        ],
+        events,
       })
 
       return { action: updatedAction, comment: updatedComment }


### PR DESCRIPTION
## Summary
- mark Community Watch restore actions as appeal resolved and review reversed
- write separate review events for restored comment, reversed review, and resolved appeal
- cover restore state updates in Community Watch staff review tests

## Tests
- npm run build
- MATTERS_ENV=test node --experimental-vm-modules node_modules/.bin/jest build/common/utils/__test__/communityWatchStaffReview.test.js --runInBand

Note: npm run testcmd currently uses --no-experimental-fetch, which this local Node rejects, so the targeted Jest command was run without that deprecated flag.