### PR TITLE
Expose Community Watch source comment URL

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1844,6 +1844,11 @@ type CommunityWatchAction {
   sourceType: CommunityWatchActionSourceType!
   sourceTitle: String!
   sourceId: ID!
+
+  """
+  Public Matters URL for the removed comment when the source still has a public route.
+  """
+  sourceUrl: String
   actorDisplayName: String!
   reason: CommunityWatchRemoveCommentReason!
   actionState: CommunityWatchActionState!

--- a/src/common/utils/__test__/communityWatchPublicQueries.test.ts
+++ b/src/common/utils/__test__/communityWatchPublicQueries.test.ts
@@ -145,6 +145,12 @@ describe('Community Watch public queries', () => {
       createContext(),
       {} as any
     )
+    const sourceUrl = await communityWatchActionPublic.sourceUrl!(
+      actions[0],
+      {},
+      createContext(),
+      {} as any
+    )
     const sourceType = await communityWatchActionPublic.sourceType!(
       actions[0],
       {},
@@ -173,6 +179,12 @@ describe('Community Watch public queries', () => {
 
     expect(commentId).toBe(toGlobalId({ type: NODE_TYPES.Comment, id: '102' }))
     expect(sourceId).toBe(toGlobalId({ type: NODE_TYPES.Moment, id: '202' }))
+    expect(sourceUrl).toBe(
+      `https://matters.town/m/moment-hash#${toGlobalId({
+        type: NODE_TYPES.Comment,
+        id: '102',
+      })}`
+    )
     expect(sourceType).toBe('moment')
     expect(sourceTitle).toBe('202')
     expect(actorDisplayName).toBe('隊員一號')

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -1478,6 +1478,8 @@ export type GQLCommunityWatchAction = {
   sourceId: Scalars['ID']['output']
   sourceTitle: Scalars['String']['output']
   sourceType: GQLCommunityWatchActionSourceType
+  /** Public Matters URL for the removed comment when the source still has a public route. */
+  sourceUrl?: Maybe<Scalars['String']['output']>
   /** Public identifier used by the Community Watch transparency page. */
   uuid: Scalars['ID']['output']
 }
@@ -8313,6 +8315,7 @@ export type GQLCommunityWatchActionResolvers<
     ParentType,
     ContextType
   >
+  sourceUrl?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
   uuid?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }>

--- a/src/queries/comment/communityWatchActionPublic.ts
+++ b/src/queries/comment/communityWatchActionPublic.ts
@@ -4,8 +4,8 @@ import type {
   GQLCommunityWatchActionResolvers,
 } from '#definitions/index.js'
 
-import { environment } from '#common/environment.js'
 import { COMMENT_TYPE, NODE_TYPES } from '#common/enums/index.js'
+import { environment } from '#common/environment.js'
 import { toGlobalId } from '#common/utils/index.js'
 
 const getSourceNodeType = ({ targetType }: CommunityWatchAction) =>

--- a/src/queries/comment/communityWatchActionPublic.ts
+++ b/src/queries/comment/communityWatchActionPublic.ts
@@ -4,6 +4,7 @@ import type {
   GQLCommunityWatchActionResolvers,
 } from '#definitions/index.js'
 
+import { environment } from '#common/environment.js'
 import { COMMENT_TYPE, NODE_TYPES } from '#common/enums/index.js'
 import { toGlobalId } from '#common/utils/index.js'
 
@@ -18,6 +19,19 @@ const communityWatchActionPublic: GQLCommunityWatchActionResolvers = {
     targetTitle || targetId,
   sourceId: (action: CommunityWatchAction) =>
     toGlobalId({ type: getSourceNodeType(action), id: action.targetId }),
+  sourceUrl: (action: CommunityWatchAction) => {
+    if (!action.targetShortHash) {
+      return null
+    }
+
+    const path = action.targetType === COMMENT_TYPE.article ? 'a' : 'm'
+    const commentId = toGlobalId({
+      type: NODE_TYPES.Comment,
+      id: action.commentId,
+    })
+
+    return `https://${environment.siteDomain}/${path}/${action.targetShortHash}#${commentId}`
+  },
   actorDisplayName: async (
     { actorId }: CommunityWatchAction,
     _: unknown,

--- a/src/types/__test__/2/comment.test.ts
+++ b/src/types/__test__/2/comment.test.ts
@@ -95,6 +95,7 @@ const COMMUNITY_WATCH_ACTIONS = /* GraphQL */ `
           sourceType
           sourceTitle
           sourceId
+          sourceUrl
           actorDisplayName
           reason
           actionState
@@ -123,6 +124,7 @@ const COMMUNITY_WATCH_ACTION = /* GraphQL */ `
       sourceType
       sourceTitle
       sourceId
+      sourceUrl
       actorDisplayName
       reason
       actionState
@@ -731,6 +733,10 @@ describe('community watch public audit queries', () => {
       uuid,
       sourceType: COMMENT_TYPE.article,
       sourceTitle: 'Public API article',
+      sourceUrl: `https://matters.town/a/${article.shortHash}#${toGlobalId({
+        type: NODE_TYPES.Comment,
+        id: comment.id,
+      })}`,
       actorDisplayName: actor.displayName,
       reason: 'porn_ad',
       actionState: 'active',
@@ -804,6 +810,7 @@ describe('community watch public audit queries', () => {
       uuid,
       sourceType: COMMENT_TYPE.moment,
       sourceTitle: '1',
+      sourceUrl: null,
       actorDisplayName: actor.userName,
       reason: 'spam_ad',
       actionState: 'restored',

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -315,6 +315,8 @@ export default /* GraphQL */ `
     sourceType: CommunityWatchActionSourceType!
     sourceTitle: String!
     sourceId: ID!
+    "Public Matters URL for the removed comment when the source still has a public route."
+    sourceUrl: String
     actorDisplayName: String!
     reason: CommunityWatchRemoveCommentReason!
     actionState: CommunityWatchActionState!


### PR DESCRIPTION
## Summary
- add nullable CommunityWatchAction.sourceUrl for public audit records
- build article and moment source URLs with the removed comment global ID as the hash
- cover the public resolver and GraphQL query selection in tests

## Tests
- npm run build
- MATTERS_ENV=test node --experimental-vm-modules node_modules/.bin/jest build/common/utils/__test__/communityWatchPublicQueries.test.js --runInBand

## Notes
- I also attempted build/types/__test__/2/comment.test.js, but this local worktree does not have the test DB connections available and the suite failed with AggregateError before reaching the assertions. The generated query selection is still updated in that test file.