### PR TITLE
ci: fix production export query redaction

### DIFF
--- a/.github/workflows/query-production-federation-export-event.yml
+++ b/.github/workflows/query-production-federation-export-event.yml
@@ -79,7 +79,7 @@ jobs:
           if [ "${{ inputs.include_decision_report }}" = "true" ]; then
             DECISION_REPORT_SQL='decision_report'
           else
-            DECISION_REPORT_SQL='jsonb_build_object(''redacted'', true)'
+            DECISION_REPORT_SQL="jsonb_build_object('redacted', true)"
           fi
 
           psql \


### PR DESCRIPTION
## Summary\n- fix the redacted decision_report SQL expression in the production federation export event query workflow\n- keeps include_decision_report=false usable without exposing full decision_report JSON\n\n## Verification\n- YAML parsed successfully locally\n- Production workflow already proved VPN and DB connectivity; failed only on the redacted SQL quoting path\n- Reran the same workflow with include_decision_report=true and confirmed article 1225211 has record_only / recorded / eligible=true audit evidence\n\n## Rollout note\nWorkflow-only fix. Does not deploy application code and does not enable production outbound ActivityPub delivery.