### PR TITLE
Hotfix production export redaction SQL quoting

### DIFF
--- a/.github/workflows/query-production-federation-export-event.yml
+++ b/.github/workflows/query-production-federation-export-event.yml
@@ -79,7 +79,7 @@ jobs:
           if [ "${{ inputs.include_decision_report }}" = "true" ]; then
             DECISION_REPORT_SQL='decision_report'
           else
-            DECISION_REPORT_SQL='jsonb_build_object(''redacted'', true)'
+            DECISION_REPORT_SQL="jsonb_build_object('redacted', true)"
           fi
 
           psql \


### PR DESCRIPTION
## Summary\n- fix the production federation export event query workflow redaction expression quoting\n- make master match develop for this workflow line so release PR #4806 can merge cleanly\n\n## Why\nThe existing single-quoted shell assignment evaluates to jsonb_build_object(redacted, true), losing the SQL string quotes around redacted. The double-quoted shell assignment preserves jsonb_build_object('redacted', true).\n\n## Validation\n- git diff --check\n- Ruby YAML parser loads .github/workflows/query-production-federation-export-event.yml\n- extracted workflow run blocks pass bash -n\n- shell assignment prints jsonb_build_object('redacted', true)\n\n## Release note\nThis is a focused master hotfix because PR #4806 is blocked by an add/add conflict on this workflow file and master currently has the incorrect quoting.