### PR TITLE
feat(oss): include community_watch_action records in OSS reports list

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -2485,6 +2485,11 @@ type Report implements Node {
   reporter: User!
   target: Node!
   reason: ReportReason!
+
+  """
+  Whether this record originates from a direct in-site report or a community watch action.
+  """
+  source: ReportSource!
   createdAt: DateTime!
 }
 
@@ -2826,6 +2831,20 @@ enum ReportReason {
   discrimination_insult_hatred
   pornography_involving_minors
   other
+
+  """Pornographic/adult advertising flagged by a community watch member."""
+  community_watch_porn_ad
+
+  """Spam advertising flagged by a community watch member."""
+  community_watch_spam_ad
+}
+
+enum ReportSource {
+  """Submitted directly via the in-site report form."""
+  direct
+
+  """Created automatically when a community watch member removes a comment."""
+  community_watch
 }
 
 type IcymiTopic implements Node {

--- a/src/definitions/report.d.ts
+++ b/src/definitions/report.d.ts
@@ -11,6 +11,10 @@ export type ReportReason =
   | 'discrimination_insult_hatred'
   | 'pornography_involving_minors'
   | 'other'
+  | 'community_watch_porn_ad'
+  | 'community_watch_spam_ad'
+
+export type ReportSource = 'direct' | 'community_watch'
 
 export interface Report {
   id: string
@@ -20,4 +24,9 @@ export interface Report {
   momentId?: string
   reason: ReportReason
   createdAt: Date
+  /**
+   * Whether this Report row came from the `report` table or was synthesised
+   * from a `community_watch_action` row. Set by resolvers, not stored in DB.
+   */
+  source?: ReportSource
 }

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -3668,6 +3668,8 @@ export type GQLReport = GQLNode & {
   id: Scalars['ID']['output']
   reason: GQLReportReason
   reporter: GQLUser
+  /** Whether this record originates from a direct in-site report or a community watch action. */
+  source: GQLReportSource
   target: GQLNode
 }
 
@@ -3685,11 +3687,21 @@ export type GQLReportEdge = {
 }
 
 export type GQLReportReason =
+  /** Pornographic/adult advertising flagged by a community watch member. */
+  | 'community_watch_porn_ad'
+  /** Spam advertising flagged by a community watch member. */
+  | 'community_watch_spam_ad'
   | 'discrimination_insult_hatred'
   | 'illegal_advertising'
   | 'other'
   | 'pornography_involving_minors'
   | 'tort'
+
+export type GQLReportSource =
+  /** Created automatically when a community watch member removes a comment. */
+  | 'community_watch'
+  /** Submitted directly via the in-site report form. */
+  | 'direct'
 
 export type GQLResetLikerIdInput = {
   id: Scalars['ID']['input']
@@ -5863,6 +5875,7 @@ export type GQLResolversTypes = ResolversObject<{
     Omit<GQLReportEdge, 'node'> & { node: GQLResolversTypes['Report'] }
   >
   ReportReason: GQLReportReason
+  ReportSource: GQLReportSource
   ResetLikerIdInput: GQLResetLikerIdInput
   ResetPasswordInput: GQLResetPasswordInput
   ResetPasswordType: GQLResetPasswordType
@@ -10421,6 +10434,7 @@ export type GQLReportResolvers<
   id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
   reason?: Resolver<GQLResolversTypes['ReportReason'], ParentType, ContextType>
   reporter?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
+  source?: Resolver<GQLResolversTypes['ReportSource'], ParentType, ContextType>
   target?: Resolver<GQLResolversTypes['Node'], ParentType, ContextType>
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }>

--- a/src/queries/system/oss/reports.ts
+++ b/src/queries/system/oss/reports.ts
@@ -5,22 +5,91 @@ import {
   fromConnectionArgs,
 } from '#common/utils/index.js'
 
+/**
+ * OSS report listing.
+ *
+ * Returns a UNION of:
+ *   1. `report` table rows — reports submitted via the in-site report form.
+ *   2. `community_watch_action` table rows — comment removals performed by
+ *      community watch members. Surfaced here so OSS staff can take follow-up
+ *      action (e.g. account freeze) from a single triage list.
+ *
+ * Rows from each source are tagged with a `source` discriminator
+ * (`direct` / `community_watch`) which the OSS UI uses to render a badge.
+ *
+ * Pagination is done at the SQL layer (UNION ALL + ORDER BY + LIMIT/OFFSET)
+ * so we never load both tables in full into memory.
+ *
+ * NOTE: knex is configured with `knexSnakeCaseMappers`, so column names in
+ * the SELECT list use snake_case in raw SQL but the rows we hand to the
+ * Report resolver come back camelCased automatically.
+ */
 export const reports: GQLOssResolvers['reports'] = async (
   _,
   { input },
-  { dataSources: { atomService } }
+  {
+    dataSources: {
+      connections: { knex },
+    },
+  }
 ) => {
   const { take, skip } = fromConnectionArgs(input)
 
-  const table = 'report'
-  const countQuery = atomService.count({ table, where: {} })
-  const reportsQuery = atomService.findMany({
-    table,
-    skip,
-    take,
-    orderBy: [{ column: 'created_at', order: 'desc' }],
-  })
-  const [totalCount, items] = await Promise.all([countQuery, reportsQuery])
+  // Direct reports: select native columns; tag with source='direct'.
+  const directQuery = knex
+    .select(
+      knex.raw(`'direct' as source`),
+      knex.raw(`id::text as id`),
+      'reporter_id',
+      'article_id',
+      'comment_id',
+      'moment_id',
+      'reason',
+      'created_at'
+    )
+    .from('report')
+
+  // Community-watch derived rows:
+  //   - id is synthesised as 'cw:{id}' so it can't collide with real report.id
+  //   - reporter_id maps to actor_id (the watcher)
+  //   - target is always a comment; article_id/moment_id are null
+  //   - reason is namespaced to make it visually distinct in OSS UI
+  const communityWatchQuery = knex
+    .select(
+      knex.raw(`'community_watch' as source`),
+      knex.raw(`'cw:' || id::text as id`),
+      knex.raw(`actor_id as reporter_id`),
+      knex.raw(`null::bigint as article_id`),
+      'comment_id',
+      knex.raw(`null::bigint as moment_id`),
+      knex.raw(
+        `case reason
+           when 'porn_ad' then 'community_watch_porn_ad'
+           when 'spam_ad' then 'community_watch_spam_ad'
+         end as reason`
+      ),
+      'created_at'
+    )
+    .from('community_watch_action')
+
+  // Wrap the UNION in a subquery so we can ORDER BY / LIMIT / OFFSET across
+  // both halves without affecting either half's selection.
+  const unioned = knex
+    .select('*')
+    .from(directQuery.unionAll(communityWatchQuery).as('reports_union'))
+
+  const [countResult, items] = await Promise.all([
+    knex
+      .count('* as count')
+      .from(directQuery.unionAll(communityWatchQuery).as('reports_union_count'))
+      .first(),
+    unioned.orderBy('created_at', 'desc').limit(take).offset(skip),
+  ])
+
+  const totalCount = parseInt(
+    countResult ? (countResult.count as string) : '0',
+    10
+  )
 
   return connectionFromPromisedArray(items, input, totalCount)
 }

--- a/src/queries/system/report.ts
+++ b/src/queries/system/report.ts
@@ -1,11 +1,21 @@
-import type { GQLReportResolvers } from '#definitions/index.js'
+import type { GQLReportResolvers, ReportSource } from '#definitions/index.js'
 
 import { NODE_TYPES } from '#common/enums/index.js'
 import { ServerError } from '#common/errors.js'
 import { toGlobalId } from '#common/utils/index.js'
 
 const report: GQLReportResolvers = {
-  id: ({ id }) => toGlobalId({ type: NODE_TYPES.Report, id }),
+  id: ({ id, source }) => {
+    // For rows derived from `community_watch_action` the union resolver
+    // synthesises an id like `cw:42`. Keep the prefix in the inner id so the
+    // global id stays distinct from a real report.id and clients can tell
+    // them apart if they ever decode it.
+    if (source === 'community_watch') {
+      const inner = id.startsWith('cw:') ? id : `cw:${id}`
+      return toGlobalId({ type: NODE_TYPES.Report, id: inner })
+    }
+    return toGlobalId({ type: NODE_TYPES.Report, id })
+  },
   reporter: ({ reporterId }, _, { dataSources: { atomService } }) =>
     atomService.userIdLoader.load(reporterId),
   target: async (
@@ -32,6 +42,12 @@ const report: GQLReportResolvers = {
       throw new ServerError('target not found')
     }
   },
+  // Defaults to `direct` so rows coming from the legacy `report` table (which
+  // never carried this column) are still reported correctly.
+  // Parent is typed explicitly here to avoid a chicken-and-egg with codegen:
+  // `gen:schema` invokes `tsc` which would otherwise complain about `source`
+  // not yet existing on the auto-generated GQLReportResolvers type.
+  source: (parent: { source?: ReportSource }) => parent.source ?? 'direct',
 }
 
 export default report

--- a/src/types/__test__/2/system.test.ts
+++ b/src/types/__test__/2/system.test.ts
@@ -1389,11 +1389,16 @@ describe('submitReport', () => {
           edges {
             node {
               id
+              source
+              reason
               reporter {
                 id
               }
               target {
                 ... on Article {
+                  id
+                }
+                ... on Comment {
                   id
                 }
                 ... on Moment {
@@ -1460,6 +1465,69 @@ describe('submitReport', () => {
     expect(dataQuery.oss.reports.totalCount).toBe(2)
     expect(dataQuery.oss.reports.edges[0].node.reporter.id).toBeDefined()
     expect(dataQuery.oss.reports.edges[0].node.target.id).toBeDefined()
+    // Reports created via submitReport originate from the legacy `report`
+    // table and must be reported as `direct`.
+    expect(dataQuery.oss.reports.edges[0].node.source).toBe('direct')
+    expect(dataQuery.oss.reports.edges[1].node.source).toBe('direct')
+  })
+
+  test('reports query unions community_watch_action rows', async () => {
+    // Seed: insert a community_watch_action on an existing comment so the
+    // OSS reports list can surface it alongside direct reports.
+    const comment = await connections
+      .knex('comment')
+      .select('id', 'target_id')
+      .first()
+    const contentExpiresAt = new Date()
+    contentExpiresAt.setFullYear(contentExpiresAt.getFullYear() + 1)
+
+    await connections.knex('community_watch_action').insert({
+      uuid: '11111111-1111-1111-1111-111111111111',
+      commentId: comment.id,
+      commentType: 'article',
+      targetType: 'article',
+      targetId: comment.targetId,
+      targetTitle: 'seed',
+      targetShortHash: 'seed',
+      reason: 'porn_ad',
+      actorId: '1',
+      commentAuthorId: '2',
+      originalContent: '<p>banned</p>',
+      originalState: 'active',
+      actionState: 'active',
+      appealState: 'none',
+      reviewState: 'pending',
+      contentExpiresAt,
+    })
+
+    const server = await testClient({
+      isAuth: true,
+      isAdmin: true,
+      connections,
+    })
+    const { data, errors } = await server.executeOperation({
+      query: GET_REPORTS,
+      variables: { input: { first: null } },
+    })
+    expect(errors).toBeUndefined()
+
+    // The previous test in this describe block inserted 2 direct reports;
+    // this one adds 1 community_watch row, so totalCount should be 3.
+    expect(data.oss.reports.totalCount).toBe(3)
+
+    const sources = data.oss.reports.edges.map(
+      (e: { node: { source: string } }) => e.node.source
+    )
+    expect(sources).toContain('community_watch')
+    expect(sources).toContain('direct')
+
+    const watchEdge = data.oss.reports.edges.find(
+      (e: { node: { source: string } }) => e.node.source === 'community_watch'
+    )
+    // Reason is namespaced for community-watch rows.
+    expect(watchEdge.node.reason).toBe('community_watch_porn_ad')
+    // The target resolves to the underlying Comment.
+    expect(watchEdge.node.target.id).toBeDefined()
   })
 })
 

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -243,6 +243,8 @@ export default /* GraphQL */ `
     reporter: User!
     target: Node!
     reason: ReportReason!
+    "Whether this record originates from a direct in-site report or a community watch action."
+    source: ReportSource!
     createdAt: DateTime!
   }
 
@@ -587,6 +589,17 @@ export default /* GraphQL */ `
     discrimination_insult_hatred
     pornography_involving_minors
     other
+    "Pornographic/adult advertising flagged by a community watch member."
+    community_watch_porn_ad
+    "Spam advertising flagged by a community watch member."
+    community_watch_spam_ad
+  }
+
+  enum ReportSource {
+    "Submitted directly via the in-site report form."
+    direct
+    "Created automatically when a community watch member removes a comment."
+    community_watch
   }
 
   type IcymiTopic implements Node {


### PR DESCRIPTION
## Summary

OSS staff currently only see direct in-site reports under `oss.reports`. Community watch members can already remove comments via `communityWatchRemoveComment`, but those actions live in a separate table and never surface in the OSS triage list — so staff lose visibility of comments that may warrant follow-up (account freeze, deletion, etc.).

This PR UNIONs `report` and `community_watch_action` at the SQL layer and exposes both through the existing `oss.reports` connection. Pagination, `totalCount` and ordering are computed across the combined set, so existing callers don't need to change.

### Schema additions

- **`Report.source: ReportSource!`** — discriminator (`direct` or `community_watch`) so the OSS UI can render a badge to distinguish the two flows.
- **`ReportReason`** gains `community_watch_porn_ad` and `community_watch_spam_ad`. The existing five reasons are unchanged, so `submitReport` callers are not affected.

### Field mapping for community-watch derived rows

| Report field | Source column |
|---|---|
| `id` | synthetic `cw:{id}` (encoded in global id to avoid collisions with real `report.id`) |
| `reporter` | `community_watch_action.actor_id` — the watcher who removed the comment |
| `target` | resolves via `comment_id` to the underlying `Comment` (always a Comment) |
| `reason` | mapped: `porn_ad` → `community_watch_porn_ad`, `spam_ad` → `community_watch_spam_ad` |
| `createdAt` | `community_watch_action.created_at` |
| `source` | `community_watch` |

All `community_watch_action` rows are included regardless of `action_state` (`active` / `restored` / `voided`) — let me know if we should filter on the backend instead of leaving it to the OSS UI.

### Background

Originally raised as a request to integrate the "近期處理紀錄" list from [community-watch.matters.town](https://community-watch.matters.town/#watch-log) into the OSS report list at `oss.matters.town/reports`, so OSS staff can triage both flows from a single place.

## Test plan

- [ ] CI: lint, build, existing tests pass
- [ ] CI: new test `reports query unions community_watch_action rows` passes
- [ ] Manual: query `oss.reports` on develop, verify rows from both tables appear with correct `source`
- [ ] Manual: verify OSS UI rendering once the frontend lands the `source` column

## Out of scope

- OSS frontend changes (separate internal repo). Frontend needs to add a "來源" column rendering `source` (e.g. badge: 「站內檢舉」/ 「守望相助」), and translations for the two new `ReportReason` values.
- Filtering / search by source — happy to add as a follow-up if staff want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)