### PR TITLE
[codex] batch archive Community Watch report users in OSS

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -2490,6 +2490,11 @@ type Report implements Node {
   Whether this record originates from a direct in-site report or a community watch action.
   """
   source: ReportSource!
+
+  """
+  The audit record when this report originates from a community watch action.
+  """
+  communityWatchAction: CommunityWatchAction
   createdAt: DateTime!
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -2485,6 +2485,11 @@ type Report implements Node {
   reporter: User!
   target: Node!
   reason: ReportReason!
+
+  """
+  Whether this record originates from a direct in-site report or a community watch action.
+  """
+  source: ReportSource!
   createdAt: DateTime!
 }
 
@@ -2826,6 +2831,20 @@ enum ReportReason {
   discrimination_insult_hatred
   pornography_involving_minors
   other
+
+  """Pornographic/adult advertising flagged by a community watch member."""
+  community_watch_porn_ad
+
+  """Spam advertising flagged by a community watch member."""
+  community_watch_spam_ad
+}
+
+enum ReportSource {
+  """Submitted directly via the in-site report form."""
+  direct
+
+  """Created automatically when a community watch member removes a comment."""
+  community_watch
 }
 
 type IcymiTopic implements Node {

--- a/schema.graphql
+++ b/schema.graphql
@@ -265,6 +265,9 @@ type Mutation {
   """Update state of a user, used in OSS."""
   updateUserState(input: UpdateUserStateInput!): [User!]
 
+  """Archive multiple users from OSS with per-user results."""
+  archiveUsers(input: ArchiveUsersInput!): ArchiveUsersResult!
+
   """Update state of a user, used in OSS."""
   updateUserRole(input: UpdateUserRoleInput!): User!
 
@@ -1854,6 +1857,11 @@ type CommunityWatchAction {
   actionState: CommunityWatchActionState!
   appealState: CommunityWatchAppealState!
   reviewState: CommunityWatchReviewState!
+
+  """
+  SHA-256 hash of normalized original content for OSS clustering without re-spreading spam text.
+  """
+  contentHash: String
   originalContent: String
   contentCleared: Boolean!
   createdAt: DateTime!
@@ -2398,7 +2406,7 @@ type OSS {
   seedingUsers(input: ConnectionArgs!): UserConnection!
   badgedUsers(input: BadgedUsersInput!): UserConnection!
   restrictedUsers(input: ConnectionArgs!): UserConnection!
-  reports(input: ConnectionArgs!): ReportConnection!
+  reports(input: OSSReportsInput!): ReportConnection!
   icymiTopics(input: ConnectionArgs!): IcymiTopicConnection!
   topicChannelFeedbacks(input: TopicChannelFeedbacksInput!): TopicChannelFeedbackConnection!
 }
@@ -2507,6 +2515,16 @@ type ReportConnection implements Connection {
 type ReportEdge {
   cursor: String!
   node: Report!
+}
+
+input OSSReportsInput {
+  after: String
+  first: Int
+  filter: OSSReportsFilter
+}
+
+input OSSReportsFilter {
+  source: ReportSource
 }
 
 input NodeInput {
@@ -3555,6 +3573,21 @@ input UpdateUserStateInput {
   state: UserState!
   banDays: Int
   password: String
+}
+
+input ArchiveUsersInput {
+  ids: [ID!]!
+  password: String!
+}
+
+type ArchiveUsersResult {
+  archived: [User!]!
+  skipped: [ArchiveUserFailure!]!
+}
+
+type ArchiveUserFailure {
+  id: ID!
+  message: String!
 }
 
 input UpdateUserRoleInput {

--- a/src/common/utils/__test__/archiveUsersResolver.test.ts
+++ b/src/common/utils/__test__/archiveUsersResolver.test.ts
@@ -1,0 +1,167 @@
+import { jest } from '@jest/globals'
+
+import { NODE_TYPES, USER_STATE } from '#common/enums/index.js'
+import { toGlobalId } from '#common/utils/index.js'
+import archiveUsers from '#mutations/user/archiveUsers.js'
+
+const makeUser = (id: string, overrides: Record<string, unknown> = {}) => ({
+  id,
+  email: null,
+  displayName: `User ${id}`,
+  language: 'zh_hant',
+  state: USER_STATE.active,
+  ...overrides,
+})
+
+const makeUserId = (id: string) => toGlobalId({ type: NODE_TYPES.User, id })
+
+const makeContext = ({
+  users = {},
+  archive = async (id: string) => ({
+    ...(users as Record<string, any>)[id],
+    state: USER_STATE.archived,
+  }),
+  viewer = { id: '99', passwordHash: 'hash' },
+}: {
+  users?: Record<string, any>
+  archive?: (id: string) => Promise<any>
+  viewer?: Record<string, unknown>
+} = {}) => {
+  const context = {
+    viewer,
+    dataSources: {
+      atomService: {
+        userIdLoader: {
+          load: jest.fn(async (id: string) => users[id] ?? null),
+        },
+      },
+      notificationService: {
+        mail: {
+          sendUserDeletedByAdmin: jest.fn(),
+        },
+      },
+      userService: {
+        verifyPassword: jest.fn(),
+        archive: jest.fn(archive),
+      },
+      queues: {
+        userQueue: {
+          archiveUser: jest.fn(),
+        },
+      },
+    },
+  }
+
+  return context
+}
+
+const runArchiveUsers = (
+  ids: string[],
+  password: string,
+  context = makeContext()
+) =>
+  (archiveUsers as any)(
+    null,
+    { input: { ids, password } },
+    context as any,
+    {} as any
+  )
+
+describe('archiveUsers resolver', () => {
+  test('validates input before archiving', async () => {
+    await expect(runArchiveUsers([], 'admin-password')).rejects.toThrow(
+      'at least one user id is required'
+    )
+
+    await expect(
+      runArchiveUsers(
+        Array.from({ length: 51 }, (_, index) => makeUserId(`${index + 1}`)),
+        'admin-password'
+      )
+    ).rejects.toThrow('cannot archive more than 50 users')
+
+    await expect(runArchiveUsers([makeUserId('1')], '')).rejects.toThrow(
+      '`password` is required for archiving users'
+    )
+
+    await expect(
+      runArchiveUsers(
+        [makeUserId('1')],
+        'admin-password',
+        makeContext({
+          viewer: { passwordHash: 'hash' },
+        })
+      )
+    ).rejects.toThrow('`password` is required for archiving users')
+  })
+
+  test('archives valid users and reports per-user skips', async () => {
+    const users: Record<string, any> = {
+      '1': makeUser('1'),
+      '2': makeUser('2', { state: USER_STATE.archived }),
+      '4': makeUser('4', {
+        email: 'archive-user-4@matters.news',
+        displayName: 'Archive User 4',
+      }),
+      '5': makeUser('5'),
+      '6': makeUser('6'),
+    }
+    const context = makeContext({
+      users,
+      archive: async (id: string) => {
+        if (id === '5') {
+          throw new Error('archive service failed')
+        }
+        if (id === '6') {
+          throw 'unexpected failure'
+        }
+        return { ...users[id], state: USER_STATE.archived }
+      },
+    })
+
+    const result = await runArchiveUsers(
+      [
+        makeUserId('1'),
+        makeUserId('1'),
+        makeUserId('2'),
+        makeUserId('3'),
+        makeUserId('4'),
+        makeUserId('5'),
+        makeUserId('6'),
+      ],
+      'admin-password',
+      context
+    )
+
+    expect(context.dataSources.userService.verifyPassword).toHaveBeenCalledWith(
+      { password: 'admin-password', hash: 'hash' }
+    )
+    expect((result.archived as any[]).map((user) => user.id)).toEqual([
+      '1',
+      '4',
+    ])
+    expect(result.skipped).toEqual([
+      { id: makeUserId('2'), message: 'user has already been archived' },
+      { id: makeUserId('3'), message: 'user not found' },
+      { id: makeUserId('5'), message: 'archive service failed' },
+      { id: makeUserId('6'), message: 'archive failed' },
+    ])
+    expect(context.dataSources.userService.archive).toHaveBeenCalledTimes(4)
+    expect(
+      context.dataSources.queues.userQueue.archiveUser
+    ).toHaveBeenCalledWith({ userId: '1' })
+    expect(
+      context.dataSources.queues.userQueue.archiveUser
+    ).toHaveBeenCalledWith({ userId: '4' })
+    expect(
+      context.dataSources.notificationService.mail.sendUserDeletedByAdmin
+    ).toHaveBeenCalledTimes(1)
+    expect(
+      context.dataSources.notificationService.mail.sendUserDeletedByAdmin
+    ).toHaveBeenCalledWith({
+      to: 'archive-user-4@matters.news',
+      recipient: { displayName: 'Archive User 4' },
+      language: 'zh_hant',
+    })
+  })
+})

--- a/src/common/utils/__test__/communityWatchPublicQueries.test.ts
+++ b/src/common/utils/__test__/communityWatchPublicQueries.test.ts
@@ -163,14 +163,25 @@ describe('Community Watch public queries', () => {
       createContext(),
       {} as any
     )
-    const actorDisplayName =
-      await communityWatchActionPublic.actorDisplayName!(
-        actions[1],
-        {},
-        createContext(),
-        {} as any
-      )
+    const actorDisplayName = await communityWatchActionPublic.actorDisplayName!(
+      actions[1],
+      {},
+      createContext(),
+      {} as any
+    )
     const contentCleared = await communityWatchActionPublic.contentCleared!(
+      actions[0],
+      {},
+      createContext(),
+      {} as any
+    )
+    const contentHash = await communityWatchActionPublic.contentHash!(
+      actions[1],
+      {},
+      createContext(),
+      {} as any
+    )
+    const clearedContentHash = await communityWatchActionPublic.contentHash!(
       actions[0],
       {},
       createContext(),
@@ -189,5 +200,9 @@ describe('Community Watch public queries', () => {
     expect(sourceTitle).toBe('202')
     expect(actorDisplayName).toBe('隊員一號')
     expect(contentCleared).toBe(true)
+    expect(contentHash).toBe(
+      '60bf9b9a635d3ffb5dd8229ab0c541243643e252588a7e65e47a6338cc991e02'
+    )
+    expect(clearedContentHash).toBeNull()
   })
 })

--- a/src/common/utils/__test__/reportResolver.test.ts
+++ b/src/common/utils/__test__/reportResolver.test.ts
@@ -1,0 +1,79 @@
+import { jest } from '@jest/globals'
+
+import { NODE_TYPES } from '#common/enums/index.js'
+import report from '#queries/system/report.js'
+import { Base64 } from 'js-base64'
+
+const reportResolver = report as any
+
+describe('report resolver', () => {
+  test('keeps community watch report ids distinct', () => {
+    const prefixed = reportResolver.id(
+      { id: 'cw:42', source: 'community_watch' },
+      {},
+      {},
+      {}
+    )
+    const unprefixed = reportResolver.id(
+      { id: '42', source: 'community_watch' },
+      {},
+      {},
+      {}
+    )
+    const direct = reportResolver.id({ id: '42' }, {}, {}, {})
+
+    expect(Base64.decode(prefixed)).toBe(`${NODE_TYPES.Report}:cw:42`)
+    expect(Base64.decode(unprefixed)).toBe(`${NODE_TYPES.Report}:cw:42`)
+    expect(Base64.decode(direct)).toBe(`${NODE_TYPES.Report}:42`)
+  })
+
+  test('resolves report source and community watch audit record', async () => {
+    const findCommunityWatchActionById = jest.fn(async (id: string) => ({
+      id,
+      uuid: 'action-42',
+    }))
+    const context = {
+      dataSources: {
+        commentService: {
+          findCommunityWatchActionById,
+        },
+      },
+    }
+
+    expect(reportResolver.source({ id: '1' }, {}, {}, {})).toBe('direct')
+    expect(
+      reportResolver.source(
+        { id: 'cw:42', source: 'community_watch' },
+        {},
+        {},
+        {}
+      )
+    ).toBe('community_watch')
+    expect(
+      reportResolver.communityWatchAction(
+        { id: '1', source: 'direct' },
+        {},
+        context as any,
+        {}
+      )
+    ).toBeNull()
+    await expect(
+      reportResolver.communityWatchAction(
+        { id: 'cw:42', source: 'community_watch' },
+        {},
+        context as any,
+        {}
+      )
+    ).resolves.toMatchObject({ id: '42', uuid: 'action-42' })
+    await expect(
+      reportResolver.communityWatchAction(
+        { id: '43', source: 'community_watch' },
+        {},
+        context as any,
+        {}
+      )
+    ).resolves.toMatchObject({ id: '43', uuid: 'action-42' })
+    expect(findCommunityWatchActionById).toHaveBeenCalledWith('42')
+    expect(findCommunityWatchActionById).toHaveBeenCalledWith('43')
+  })
+})

--- a/src/connectors/commentService.ts
+++ b/src/connectors/commentService.ts
@@ -97,6 +97,16 @@ export class CommentService extends BaseService<Comment> {
     return action ?? null
   }
 
+  public findCommunityWatchActionById = async (
+    id: string
+  ): Promise<CommunityWatchAction | null> => {
+    const action = await this.knex('community_watch_action')
+      .select()
+      .where({ id })
+      .first()
+    return action ?? null
+  }
+
   public findCommunityWatchActions = async ({
     filter,
     skip,

--- a/src/definitions/report.d.ts
+++ b/src/definitions/report.d.ts
@@ -11,6 +11,10 @@ export type ReportReason =
   | 'discrimination_insult_hatred'
   | 'pornography_involving_minors'
   | 'other'
+  | 'community_watch_porn_ad'
+  | 'community_watch_spam_ad'
+
+export type ReportSource = 'direct' | 'community_watch'
 
 export interface Report {
   id: string
@@ -20,4 +24,9 @@ export interface Report {
   momentId?: string
   reason: ReportReason
   createdAt: Date
+  /**
+   * Whether this Report row came from the `report` table or was synthesised
+   * from a `community_watch_action` row. Set by resolvers, not stored in DB.
+   */
+  source?: ReportSource
 }

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -3668,6 +3668,8 @@ export type GQLReport = GQLNode & {
   id: Scalars['ID']['output']
   reason: GQLReportReason
   reporter: GQLUser
+  /** Whether this record originates from a direct in-site report or a community watch action. */
+  source: GQLReportSource
   target: GQLNode
 }
 
@@ -3685,11 +3687,21 @@ export type GQLReportEdge = {
 }
 
 export type GQLReportReason =
+  /** Pornographic/adult advertising flagged by a community watch member. */
+  | 'community_watch_porn_ad'
+  /** Spam advertising flagged by a community watch member. */
+  | 'community_watch_spam_ad'
   | 'discrimination_insult_hatred'
   | 'illegal_advertising'
   | 'other'
   | 'pornography_involving_minors'
   | 'tort'
+
+export type GQLReportSource =
+  /** Created automatically when a community watch member removes a comment. */
+  | 'community_watch'
+  /** Submitted directly via the in-site report form. */
+  | 'direct'
 
 export type GQLResetLikerIdInput = {
   id: Scalars['ID']['input']
@@ -5863,6 +5875,7 @@ export type GQLResolversTypes = ResolversObject<{
     Omit<GQLReportEdge, 'node'> & { node: GQLResolversTypes['Report'] }
   >
   ReportReason: GQLReportReason
+  ReportSource: GQLReportSource
   ResetLikerIdInput: GQLResetLikerIdInput
   ResetPasswordInput: GQLResetPasswordInput
   ResetPasswordType: GQLResetPasswordType
@@ -10421,6 +10434,7 @@ export type GQLReportResolvers<
   id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
   reason?: Resolver<GQLResolversTypes['ReportReason'], ParentType, ContextType>
   reporter?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
+  source?: Resolver<GQLResolversTypes['ReportSource'], ParentType, ContextType>
   target?: Resolver<GQLResolversTypes['Node'], ParentType, ContextType>
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }>

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -3664,6 +3664,8 @@ export type GQLReorderMoveInput = {
 
 export type GQLReport = GQLNode & {
   __typename?: 'Report'
+  /** The audit record when this report originates from a community watch action. */
+  communityWatchAction?: Maybe<GQLCommunityWatchAction>
   createdAt: Scalars['DateTime']['output']
   id: Scalars['ID']['output']
   reason: GQLReportReason
@@ -10430,6 +10432,11 @@ export type GQLReportResolvers<
   ContextType = Context,
   ParentType extends GQLResolversParentTypes['Report'] = GQLResolversParentTypes['Report']
 > = ResolversObject<{
+  communityWatchAction?: Resolver<
+    Maybe<GQLResolversTypes['CommunityWatchAction']>,
+    ParentType,
+    ContextType
+  >
   createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
   id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
   reason?: Resolver<GQLResolversTypes['ReportReason'], ParentType, ContextType>

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -208,6 +208,23 @@ export type GQLAppreciationPurpose =
   | 'joinByTask'
   | 'systemSubsidy'
 
+export type GQLArchiveUserFailure = {
+  __typename?: 'ArchiveUserFailure'
+  id: Scalars['ID']['output']
+  message: Scalars['String']['output']
+}
+
+export type GQLArchiveUsersInput = {
+  ids: Array<Scalars['ID']['input']>
+  password: Scalars['String']['input']
+}
+
+export type GQLArchiveUsersResult = {
+  __typename?: 'ArchiveUsersResult'
+  archived: Array<GQLUser>
+  skipped: Array<GQLArchiveUserFailure>
+}
+
 /**
  * This type contains metadata, content, hash and related data of an article. If you
  * want information about article's comments. Please check Comment type.
@@ -1471,6 +1488,8 @@ export type GQLCommunityWatchAction = {
   appealState: GQLCommunityWatchAppealState
   commentId: Scalars['ID']['output']
   contentCleared: Scalars['Boolean']['output']
+  /** SHA-256 hash of normalized original content for OSS clustering without re-spreading spam text. */
+  contentHash?: Maybe<Scalars['String']['output']>
   createdAt: Scalars['DateTime']['output']
   originalContent?: Maybe<Scalars['String']['output']>
   reason: GQLCommunityWatchRemoveCommentReason
@@ -2181,6 +2200,8 @@ export type GQLMutation = {
   applyCampaign: GQLCampaign
   /** Appreciate an article. */
   appreciateArticle: GQLArticle
+  /** Archive multiple users from OSS with per-user results. */
+  archiveUsers: GQLArchiveUsersResult
   banCampaignArticles: GQLCampaign
   /** Let Traveloggers owner claims a Logbook, returns transaction hash */
   claimLogbooks: GQLClaimLogbooksResult
@@ -2408,6 +2429,10 @@ export type GQLMutationApplyCampaignArgs = {
 
 export type GQLMutationAppreciateArticleArgs = {
   input: GQLAppreciateArticleInput
+}
+
+export type GQLMutationArchiveUsersArgs = {
+  input: GQLArchiveUsersInput
 }
 
 export type GQLMutationBanCampaignArticlesArgs = {
@@ -3035,7 +3060,7 @@ export type GQLOssOauthClientsArgs = {
 }
 
 export type GQLOssReportsArgs = {
-  input: GQLConnectionArgs
+  input: GQLOssReportsInput
 }
 
 export type GQLOssRestrictedUsersArgs = {
@@ -3073,6 +3098,16 @@ export type GQLOssArticlesInput = {
   filter?: InputMaybe<GQLOssArticlesFilterInput>
   first?: InputMaybe<Scalars['Int']['input']>
   sort?: InputMaybe<GQLArticlesSort>
+}
+
+export type GQLOssReportsFilter = {
+  source?: InputMaybe<GQLReportSource>
+}
+
+export type GQLOssReportsInput = {
+  after?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<GQLOssReportsFilter>
+  first?: InputMaybe<Scalars['Int']['input']>
 }
 
 export type GQLOauth1CredentialInput = {
@@ -5359,6 +5394,13 @@ export type GQLResolversTypes = ResolversObject<{
     }
   >
   AppreciationPurpose: GQLAppreciationPurpose
+  ArchiveUserFailure: ResolverTypeWrapper<GQLArchiveUserFailure>
+  ArchiveUsersInput: GQLArchiveUsersInput
+  ArchiveUsersResult: ResolverTypeWrapper<
+    Omit<GQLArchiveUsersResult, 'archived'> & {
+      archived: Array<GQLResolversTypes['User']>
+    }
+  >
   Article: ResolverTypeWrapper<ArticleModel>
   ArticleAccess: ResolverTypeWrapper<ArticleModel>
   ArticleAccessType: GQLArticleAccessType
@@ -5786,6 +5828,8 @@ export type GQLResolversTypes = ResolversObject<{
   >
   OSSArticlesFilterInput: GQLOssArticlesFilterInput
   OSSArticlesInput: GQLOssArticlesInput
+  OSSReportsFilter: GQLOssReportsFilter
+  OSSReportsInput: GQLOssReportsInput
   Oauth1CredentialInput: GQLOauth1CredentialInput
   Official: ResolverTypeWrapper<
     Omit<GQLOfficial, 'announcements'> & {
@@ -6165,6 +6209,11 @@ export type GQLResolversParentTypes = ResolversObject<{
   AppreciationEdge: Omit<GQLAppreciationEdge, 'node'> & {
     node: GQLResolversParentTypes['Appreciation']
   }
+  ArchiveUserFailure: GQLArchiveUserFailure
+  ArchiveUsersInput: GQLArchiveUsersInput
+  ArchiveUsersResult: Omit<GQLArchiveUsersResult, 'archived'> & {
+    archived: Array<GQLResolversParentTypes['User']>
+  }
   Article: ArticleModel
   ArticleAccess: ArticleModel
   ArticleArticleNotice: NoticeItemModel
@@ -6476,6 +6525,8 @@ export type GQLResolversParentTypes = ResolversObject<{
   }
   OSSArticlesFilterInput: GQLOssArticlesFilterInput
   OSSArticlesInput: GQLOssArticlesInput
+  OSSReportsFilter: GQLOssReportsFilter
+  OSSReportsInput: GQLOssReportsInput
   Oauth1CredentialInput: GQLOauth1CredentialInput
   Official: Omit<GQLOfficial, 'announcements'> & {
     announcements?: Maybe<Array<GQLResolversParentTypes['Announcement']>>
@@ -6997,6 +7048,28 @@ export type GQLAppreciationEdgeResolvers<
 > = ResolversObject<{
   cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
   node?: Resolver<GQLResolversTypes['Appreciation'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArchiveUserFailureResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArchiveUserFailure'] = GQLResolversParentTypes['ArchiveUserFailure']
+> = ResolversObject<{
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  message?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArchiveUsersResultResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArchiveUsersResult'] = GQLResolversParentTypes['ArchiveUsersResult']
+> = ResolversObject<{
+  archived?: Resolver<Array<GQLResolversTypes['User']>, ParentType, ContextType>
+  skipped?: Resolver<
+    Array<GQLResolversTypes['ArchiveUserFailure']>,
+    ParentType,
+    ContextType
+  >
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }>
 
@@ -8307,6 +8380,11 @@ export type GQLCommunityWatchActionResolvers<
     ParentType,
     ContextType
   >
+  contentHash?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
   createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
   originalContent?: Resolver<
     Maybe<GQLResolversTypes['String']>,
@@ -9071,6 +9149,12 @@ export type GQLMutationResolvers<
     ParentType,
     ContextType,
     RequireFields<GQLMutationAppreciateArticleArgs, 'input'>
+  >
+  archiveUsers?: Resolver<
+    GQLResolversTypes['ArchiveUsersResult'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationArchiveUsersArgs, 'input'>
   >
   banCampaignArticles?: Resolver<
     GQLResolversTypes['Campaign'],
@@ -11740,6 +11824,8 @@ export type GQLResolvers<ContextType = Context> = ResolversObject<{
   Appreciation?: GQLAppreciationResolvers<ContextType>
   AppreciationConnection?: GQLAppreciationConnectionResolvers<ContextType>
   AppreciationEdge?: GQLAppreciationEdgeResolvers<ContextType>
+  ArchiveUserFailure?: GQLArchiveUserFailureResolvers<ContextType>
+  ArchiveUsersResult?: GQLArchiveUsersResultResolvers<ContextType>
   Article?: GQLArticleResolvers<ContextType>
   ArticleAccess?: GQLArticleAccessResolvers<ContextType>
   ArticleArticleNotice?: GQLArticleArticleNoticeResolvers<ContextType>

--- a/src/mutations/user/archiveUsers.ts
+++ b/src/mutations/user/archiveUsers.ts
@@ -1,0 +1,86 @@
+import type { GQLMutationResolvers, User } from '#definitions/index.js'
+import type { GlobalId } from '#definitions/nominal.js'
+
+import { NODE_TYPES, USER_STATE } from '#common/enums/index.js'
+import { UserInputError } from '#common/errors.js'
+import { fromGlobalId, toGlobalId } from '#common/utils/index.js'
+
+const MAX_ARCHIVE_USERS = 50
+
+const resolver: GQLMutationResolvers['archiveUsers'] = async (
+  _,
+  { input: { ids, password } },
+  {
+    viewer,
+    dataSources: {
+      atomService,
+      notificationService,
+      userService,
+      queues: { userQueue },
+    },
+  }
+) => {
+  const innerIds = Array.from(
+    new Set(ids.map((id) => fromGlobalId(id).id).filter(Boolean))
+  )
+
+  if (innerIds.length === 0) {
+    throw new UserInputError('at least one user id is required')
+  }
+  if (innerIds.length > MAX_ARCHIVE_USERS) {
+    throw new UserInputError(
+      `cannot archive more than ${MAX_ARCHIVE_USERS} users`
+    )
+  }
+  if (!password || !viewer.id) {
+    throw new UserInputError('`password` is required for archiving users')
+  }
+
+  await userService.verifyPassword({ password, hash: viewer.passwordHash })
+
+  const archived: User[] = []
+  const skipped: Array<{ id: GlobalId; message: string }> = []
+
+  for (const id of innerIds) {
+    const globalId = toGlobalId({ type: NODE_TYPES.User, id })
+
+    try {
+      const user = (await atomService.userIdLoader.load(id)) as User | null
+      if (!user) {
+        skipped.push({ id: globalId, message: 'user not found' })
+        continue
+      }
+      if (user.state === USER_STATE.archived) {
+        skipped.push({
+          id: globalId,
+          message: 'user has already been archived',
+        })
+        continue
+      }
+
+      const archivedUser = await userService.archive(id)
+      userQueue.archiveUser({ userId: id })
+
+      if (user.email) {
+        notificationService.mail.sendUserDeletedByAdmin({
+          to: user.email,
+          recipient: {
+            displayName: user.displayName,
+          },
+          language: user.language,
+        })
+      }
+
+      archived.push(archivedUser)
+    } catch (error) {
+      skipped.push({
+        id: globalId,
+        message: error instanceof Error ? error.message : 'archive failed',
+      })
+    }
+  }
+
+  return { archived, skipped }
+}
+
+export default resolver

--- a/src/mutations/user/index.ts
+++ b/src/mutations/user/index.ts
@@ -1,4 +1,5 @@
 import addCredit from './addCredit.js'
+import archiveUsers from './archiveUsers.js'
 import claimLogbooks from './claimLogbooks.js'
 import clearReadHistory from './clearReadHistory.js'
 import clearSearchHistory from './clearSearchHistory.js'
@@ -64,6 +65,7 @@ export default {
     toggleFollowUser,
     clearReadHistory,
     clearSearchHistory,
+    archiveUsers,
     updateUserState,
     updateUserRole,
     updateUserExtra,

--- a/src/queries/comment/communityWatchActionPublic.ts
+++ b/src/queries/comment/communityWatchActionPublic.ts
@@ -7,6 +7,7 @@ import type {
 import { COMMENT_TYPE, NODE_TYPES } from '#common/enums/index.js'
 import { environment } from '#common/environment.js'
 import { toGlobalId } from '#common/utils/index.js'
+import crypto from 'node:crypto'
 
 const getSourceNodeType = ({ targetType }: CommunityWatchAction) =>
   targetType === COMMENT_TYPE.article ? NODE_TYPES.Article : NODE_TYPES.Moment
@@ -39,6 +40,13 @@ const communityWatchActionPublic: GQLCommunityWatchActionResolvers = {
   ) => {
     const actor = await atomService.userIdLoader.load(actorId)
     return actor.displayName || actor.userName || actor.id
+  },
+  contentHash: ({ originalContent }: CommunityWatchAction) => {
+    if (originalContent == null) {
+      return null
+    }
+    const normalized = originalContent.replace(/\s+/g, ' ').trim()
+    return crypto.createHash('sha256').update(normalized).digest('hex')
   },
   contentCleared: ({ originalContent }: CommunityWatchAction) =>
     originalContent === null,

--- a/src/queries/system/oss/reports.ts
+++ b/src/queries/system/oss/reports.ts
@@ -71,6 +71,7 @@ export const reports: GQLOssResolvers['reports'] = async (
       'created_at'
     )
     .from('community_watch_action')
+    .where('action_state', 'active')
 
   // Wrap the UNION in a subquery so we can ORDER BY / LIMIT / OFFSET across
   // both halves without affecting either half's selection.

--- a/src/queries/system/oss/reports.ts
+++ b/src/queries/system/oss/reports.ts
@@ -34,56 +34,67 @@ export const reports: GQLOssResolvers['reports'] = async (
   }
 ) => {
   const { take, skip } = fromConnectionArgs(input)
+  const source = input.filter?.source
 
-  // Direct reports: select native columns; tag with source='direct'.
-  const directQuery = knex
-    .select(
-      knex.raw(`'direct' as source`),
-      knex.raw(`id::text as id`),
-      'reporter_id',
-      'article_id',
-      'comment_id',
-      'moment_id',
-      'reason',
-      'created_at'
-    )
-    .from('report')
+  const buildDirectQuery = () =>
+    // Direct reports: select native columns; tag with source='direct'.
+    knex
+      .select(
+        knex.raw(`'direct' as source`),
+        knex.raw(`id::text as id`),
+        'reporter_id',
+        'article_id',
+        'comment_id',
+        'moment_id',
+        'reason',
+        'created_at'
+      )
+      .from('report')
 
-  // Community-watch derived rows:
-  //   - id is synthesised as 'cw:{id}' so it can't collide with real report.id
-  //   - reporter_id maps to actor_id (the watcher)
-  //   - target is always a comment; article_id/moment_id are null
-  //   - reason is namespaced to make it visually distinct in OSS UI
-  const communityWatchQuery = knex
-    .select(
-      knex.raw(`'community_watch' as source`),
-      knex.raw(`'cw:' || id::text as id`),
-      knex.raw(`actor_id as reporter_id`),
-      knex.raw(`null::bigint as article_id`),
-      'comment_id',
-      knex.raw(`null::bigint as moment_id`),
-      knex.raw(
-        `case reason
-           when 'porn_ad' then 'community_watch_porn_ad'
-           when 'spam_ad' then 'community_watch_spam_ad'
-         end as reason`
-      ),
-      'created_at'
-    )
-    .from('community_watch_action')
-    .where('action_state', 'active')
+  const buildCommunityWatchQuery = () =>
+    // Community-watch derived rows:
+    //   - id is synthesised as 'cw:{id}' so it can't collide with real report.id
+    //   - reporter_id maps to actor_id (the watcher)
+    //   - target is always a comment; article_id/moment_id are null
+    //   - reason is namespaced to make it visually distinct in OSS UI
+    knex
+      .select(
+        knex.raw(`'community_watch' as source`),
+        knex.raw(`'cw:' || id::text as id`),
+        knex.raw(`actor_id as reporter_id`),
+        knex.raw(`null::bigint as article_id`),
+        'comment_id',
+        knex.raw(`null::bigint as moment_id`),
+        knex.raw(
+          `case reason
+             when 'porn_ad' then 'community_watch_porn_ad'
+             when 'spam_ad' then 'community_watch_spam_ad'
+           end as reason`
+        ),
+        'created_at'
+      )
+      .from('community_watch_action')
+      .where('action_state', 'active')
 
-  // Wrap the UNION in a subquery so we can ORDER BY / LIMIT / OFFSET across
-  // both halves without affecting either half's selection.
-  const unioned = knex
-    .select('*')
-    .from(directQuery.unionAll(communityWatchQuery).as('reports_union'))
+  const buildUnionQuery = () => {
+    const queries = []
+    if (!source || source === 'direct') {
+      queries.push(buildDirectQuery())
+    }
+    if (!source || source === 'community_watch') {
+      queries.push(buildCommunityWatchQuery())
+    }
+
+    return queries.length === 1 ? queries[0] : queries[0].unionAll(queries[1])
+  }
+
+  const itemsUnion = buildUnionQuery()
+  const countUnion = buildUnionQuery()
+
+  const unioned = knex.select('*').from(itemsUnion.as('reports_union'))
 
   const [countResult, items] = await Promise.all([
-    knex
-      .count('* as count')
-      .from(directQuery.unionAll(communityWatchQuery).as('reports_union_count'))
-      .first(),
+    knex.count('* as count').from(countUnion.as('reports_union_count')).first(),
     unioned.orderBy('created_at', 'desc').limit(take).offset(skip),
   ])
 

--- a/src/queries/system/oss/reports.ts
+++ b/src/queries/system/oss/reports.ts
@@ -5,22 +5,91 @@ import {
   fromConnectionArgs,
 } from '#common/utils/index.js'
 
+/**
+ * OSS report listing.
+ *
+ * Returns a UNION of:
+ *   1. `report` table rows — reports submitted via the in-site report form.
+ *   2. `community_watch_action` table rows — comment removals performed by
+ *      community watch members. Surfaced here so OSS staff can take follow-up
+ *      action (e.g. account freeze) from a single triage list.
+ *
+ * Rows from each source are tagged with a `source` discriminator
+ * (`direct` / `community_watch`) which the OSS UI uses to render a badge.
+ *
+ * Pagination is done at the SQL layer (UNION ALL + ORDER BY + LIMIT/OFFSET)
+ * so we never load both tables in full into memory.
+ *
+ * NOTE: knex is configured with `knexSnakeCaseMappers`, so column names in
+ * the SELECT list use snake_case in raw SQL but the rows we hand to the
+ * Report resolver come back camelCased automatically.
+ */
 export const reports: GQLOssResolvers['reports'] = async (
   _,
   { input },
-  { dataSources: { atomService } }
+  {
+    dataSources: {
+      connections: { knex },
+    },
+  }
 ) => {
   const { take, skip } = fromConnectionArgs(input)
 
-  const table = 'report'
-  const countQuery = atomService.count({ table, where: {} })
-  const reportsQuery = atomService.findMany({
-    table,
-    skip,
-    take,
-    orderBy: [{ column: 'created_at', order: 'desc' }],
-  })
-  const [totalCount, items] = await Promise.all([countQuery, reportsQuery])
+  // Direct reports: select native columns; tag with source='direct'.
+  const directQuery = knex
+    .select(
+      knex.raw(`'direct' as source`),
+      knex.raw(`id::text as id`),
+      'reporter_id',
+      'article_id',
+      'comment_id',
+      'moment_id',
+      'reason',
+      'created_at'
+    )
+    .from('report')
+
+  // Community-watch derived rows:
+  //   - id is synthesised as 'cw:{id}' so it can't collide with real report.id
+  //   - reporter_id maps to actor_id (the watcher)
+  //   - target is always a comment; article_id/moment_id are null
+  //   - reason is namespaced to make it visually distinct in OSS UI
+  const communityWatchQuery = knex
+    .select(
+      knex.raw(`'community_watch' as source`),
+      knex.raw(`'cw:' || id::text as id`),
+      knex.raw(`actor_id as reporter_id`),
+      knex.raw(`null::bigint as article_id`),
+      'comment_id',
+      knex.raw(`null::bigint as moment_id`),
+      knex.raw(
+        `case reason
+           when 'porn_ad' then 'community_watch_porn_ad'
+           when 'spam_ad' then 'community_watch_spam_ad'
+         end as reason`
+      ),
+      'created_at'
+    )
+    .from('community_watch_action')
+
+  // Wrap the UNION in a subquery so we can ORDER BY / LIMIT / OFFSET across
+  // both halves without affecting either half's selection.
+  const unioned = knex
+    .select('*')
+    .from(directQuery.unionAll(communityWatchQuery).as('reports_union'))
+
+  const [countResult, items] = await Promise.all([
+    knex
+      .count('* as count')
+      .from(directQuery.unionAll(communityWatchQuery).as('reports_union_count'))
+      .first(),
+    unioned.orderBy('created_at', 'desc').limit(take).offset(skip),
+  ])
+
+  const totalCount = parseInt(
+    countResult ? (countResult.count as string) : '0',
+    10
+  )
 
   return connectionFromPromisedArray(items, input, totalCount)
 }

--- a/src/queries/system/report.ts
+++ b/src/queries/system/report.ts
@@ -1,4 +1,8 @@
-import type { GQLReportResolvers, ReportSource } from '#definitions/index.js'
+import type {
+  Context,
+  GQLReportResolvers,
+  ReportSource,
+} from '#definitions/index.js'
 
 import { NODE_TYPES } from '#common/enums/index.js'
 import { ServerError } from '#common/errors.js'
@@ -48,6 +52,20 @@ const report: GQLReportResolvers = {
   // `gen:schema` invokes `tsc` which would otherwise complain about `source`
   // not yet existing on the auto-generated GQLReportResolvers type.
   source: (parent: { source?: ReportSource }) => parent.source ?? 'direct',
+  communityWatchAction: (
+    parent: { id: string; source?: ReportSource },
+    _: unknown,
+    { dataSources: { commentService } }: Context
+  ) => {
+    if (parent.source !== 'community_watch') {
+      return null
+    }
+
+    const id = parent.id.startsWith('cw:')
+      ? parent.id.replace(/^cw:/, '')
+      : parent.id
+    return commentService.findCommunityWatchActionById(id)
+  },
 }
 
 export default report

--- a/src/queries/system/report.ts
+++ b/src/queries/system/report.ts
@@ -1,11 +1,21 @@
-import type { GQLReportResolvers } from '#definitions/index.js'
+import type { GQLReportResolvers, ReportSource } from '#definitions/index.js'
 
 import { NODE_TYPES } from '#common/enums/index.js'
 import { ServerError } from '#common/errors.js'
 import { toGlobalId } from '#common/utils/index.js'
 
 const report: GQLReportResolvers = {
-  id: ({ id }) => toGlobalId({ type: NODE_TYPES.Report, id }),
+  id: ({ id, source }) => {
+    // For rows derived from `community_watch_action` the union resolver
+    // synthesises an id like `cw:42`. Keep the prefix in the inner id so the
+    // global id stays distinct from a real report.id and clients can tell
+    // them apart if they ever decode it.
+    if (source === 'community_watch') {
+      const inner = id.startsWith('cw:') ? id : `cw:${id}`
+      return toGlobalId({ type: NODE_TYPES.Report, id: inner })
+    }
+    return toGlobalId({ type: NODE_TYPES.Report, id })
+  },
   reporter: ({ reporterId }, _, { dataSources: { atomService } }) =>
     atomService.userIdLoader.load(reporterId),
   target: async (
@@ -32,6 +42,12 @@ const report: GQLReportResolvers = {
       throw new ServerError('target not found')
     }
   },
+  // Defaults to `direct` so rows coming from the legacy `report` table (which
+  // never carried this column) are still reported correctly.
+  // Parent is typed explicitly here to avoid a chicken-and-egg with codegen:
+  // `gen:schema` invokes `tsc` which would otherwise complain about `source`
+  // not yet existing on the auto-generated GQLReportResolvers type.
+  source: (parent: { source?: ReportSource }) => parent.source ?? 'direct',
 }
 
 export default report

--- a/src/types/__test__/2/system.test.ts
+++ b/src/types/__test__/2/system.test.ts
@@ -1396,6 +1396,11 @@ describe('submitReport', () => {
               id
               source
               reason
+              communityWatchAction {
+                uuid
+                actionState
+                reviewState
+              }
               reporter {
                 id
               }
@@ -1474,6 +1479,8 @@ describe('submitReport', () => {
     // table and must be reported as `direct`.
     expect(dataQuery.oss.reports.edges[0].node.source).toBe('direct')
     expect(dataQuery.oss.reports.edges[1].node.source).toBe('direct')
+    expect(dataQuery.oss.reports.edges[0].node.communityWatchAction).toBeNull()
+    expect(dataQuery.oss.reports.edges[1].node.communityWatchAction).toBeNull()
   })
 
   test('reports query unions community_watch_action rows', async () => {
@@ -1563,6 +1570,11 @@ describe('submitReport', () => {
     )
     // Reason is namespaced for community-watch rows.
     expect(watchEdge.node.reason).toBe('community_watch_porn_ad')
+    expect(watchEdge.node.communityWatchAction).toMatchObject({
+      uuid: '11111111-1111-1111-1111-111111111111',
+      actionState: 'active',
+      reviewState: 'pending',
+    })
     // The target resolves to the underlying Comment.
     expect(watchEdge.node.target.id).toBeDefined()
   })

--- a/src/types/__test__/2/system.test.ts
+++ b/src/types/__test__/2/system.test.ts
@@ -1565,26 +1565,39 @@ describe('submitReport', () => {
     expect(sources).toContain('community_watch')
     expect(sources).toContain('direct')
 
-    const watchEdges = data.oss.reports.edges.filter(
-      (e: { node: { communityWatchAction?: { uuid?: string } | null } }) =>
-        [
-          '11111111-1111-1111-1111-111111111111',
-          '22222222-2222-2222-2222-222222222222',
-        ].includes(e.node.communityWatchAction?.uuid ?? '')
-    )
+    const seededWatchUuids = [
+      ...new Set(
+        data.oss.reports.edges
+          .map(
+            (e: {
+              node: { communityWatchAction?: { uuid?: string } | null }
+            }) => e.node.communityWatchAction?.uuid
+          )
+          .filter((uuid?: string) =>
+            [
+              '11111111-1111-1111-1111-111111111111',
+              '22222222-2222-2222-2222-222222222222',
+            ].includes(uuid ?? '')
+          )
+      ),
+    ]
     // Restored community_watch rows are excluded so OSS staff don't act on
     // reversed removals when triaging accounts.
-    expect(watchEdges).toHaveLength(1)
-    const watchEdge = watchEdges[0]
+    expect(seededWatchUuids).toEqual(['11111111-1111-1111-1111-111111111111'])
+    const watchEdge = data.oss.reports.edges.find(
+      (e: { node: { communityWatchAction?: { uuid?: string } | null } }) =>
+        e.node.communityWatchAction?.uuid === seededWatchUuids[0]
+    )
+    expect(watchEdge).toBeDefined()
     // Reason is namespaced for community-watch rows.
-    expect(watchEdge.node.reason).toBe('community_watch_porn_ad')
-    expect(watchEdge.node.communityWatchAction).toMatchObject({
+    expect(watchEdge?.node.reason).toBe('community_watch_porn_ad')
+    expect(watchEdge?.node.communityWatchAction).toMatchObject({
       uuid: '11111111-1111-1111-1111-111111111111',
       actionState: 'active',
       reviewState: 'pending',
     })
     // The target resolves to the underlying Comment.
-    expect(watchEdge.node.target.id).toBeDefined()
+    expect(watchEdge?.node.target.id).toBeDefined()
   })
 })
 

--- a/src/types/__test__/2/system.test.ts
+++ b/src/types/__test__/2/system.test.ts
@@ -1389,11 +1389,16 @@ describe('submitReport', () => {
           edges {
             node {
               id
+              source
+              reason
               reporter {
                 id
               }
               target {
                 ... on Article {
+                  id
+                }
+                ... on Comment {
                   id
                 }
                 ... on Moment {
@@ -1460,6 +1465,69 @@ describe('submitReport', () => {
     expect(dataQuery.oss.reports.totalCount).toBe(2)
     expect(dataQuery.oss.reports.edges[0].node.reporter.id).toBeDefined()
     expect(dataQuery.oss.reports.edges[0].node.target.id).toBeDefined()
+    // Reports created via submitReport originate from the legacy `report`
+    // table and must be reported as `direct`.
+    expect(dataQuery.oss.reports.edges[0].node.source).toBe('direct')
+    expect(dataQuery.oss.reports.edges[1].node.source).toBe('direct')
+  })
+
+  test('reports query unions community_watch_action rows', async () => {
+    // Seed: insert a community_watch_action on an existing comment so the
+    // OSS reports list can surface it alongside direct reports.
+    const comment = await connections
+      .knex('comment')
+      .select('id', 'target_id')
+      .first()
+    const contentExpiresAt = new Date()
+    contentExpiresAt.setFullYear(contentExpiresAt.getFullYear() + 1)
+
+    await connections.knex('community_watch_action').insert({
+      uuid: '11111111-1111-1111-1111-111111111111',
+      commentId: comment.id,
+      commentType: 'article',
+      targetType: 'article',
+      targetId: comment.targetId,
+      targetTitle: 'seed',
+      targetShortHash: 'seed',
+      reason: 'porn_ad',
+      actorId: '1',
+      commentAuthorId: '2',
+      originalContent: '<p>banned</p>',
+      originalState: 'active',
+      actionState: 'active',
+      appealState: 'none',
+      reviewState: 'pending',
+      contentExpiresAt,
+    })
+
+    const server = await testClient({
+      isAuth: true,
+      isAdmin: true,
+      connections,
+    })
+    const { data, errors } = await server.executeOperation({
+      query: GET_REPORTS,
+      variables: { input: { first: null } },
+    })
+    expect(errors).toBeUndefined()
+
+    // The previous test in this describe block inserted 2 direct reports;
+    // this one adds 1 community_watch row, so totalCount should be 3.
+    expect(data.oss.reports.totalCount).toBe(3)
+
+    const sources = data.oss.reports.edges.map(
+      (e: { node: { source: string } }) => e.node.source
+    )
+    expect(sources).toContain('community_watch')
+    expect(sources).toContain('direct')
+
+    const watchEdge = data.oss.reports.edges.find(
+      (e: { node: { source: string } }) => e.node.source === 'community_watch'
+    )
+    // Reason is namespaced for community-watch rows.
+    expect(watchEdge.node.reason).toBe('community_watch_porn_ad')
+    // The target resolves to the underlying Comment.
+    expect(watchEdge.node.target.id).toBeDefined()
   })
 })
 

--- a/src/types/__test__/2/system.test.ts
+++ b/src/types/__test__/2/system.test.ts
@@ -1362,6 +1362,11 @@ describe('federation settings', () => {
 })
 
 describe('submitReport', () => {
+  beforeEach(async () => {
+    await connections.knex('report').delete()
+    await connections.knex('community_watch_action').delete()
+  })
+
   const SUBMIT_REPORT = /* GraphQL */ `
     mutation ($input: SubmitReportInput!) {
       submitReport(input: $input) {
@@ -1472,48 +1477,80 @@ describe('submitReport', () => {
   })
 
   test('reports query unions community_watch_action rows', async () => {
-    // Seed: insert a community_watch_action on an existing comment so the
-    // OSS reports list can surface it alongside direct reports.
-    const comment = await connections
-      .knex('comment')
-      .select('id', 'target_id')
-      .first()
-    const contentExpiresAt = new Date()
-    contentExpiresAt.setFullYear(contentExpiresAt.getFullYear() + 1)
-
-    await connections.knex('community_watch_action').insert({
-      uuid: '11111111-1111-1111-1111-111111111111',
-      commentId: comment.id,
-      commentType: 'article',
-      targetType: 'article',
-      targetId: comment.targetId,
-      targetTitle: 'seed',
-      targetShortHash: 'seed',
-      reason: 'porn_ad',
-      actorId: '1',
-      commentAuthorId: '2',
-      originalContent: '<p>banned</p>',
-      originalState: 'active',
-      actionState: 'active',
-      appealState: 'none',
-      reviewState: 'pending',
-      contentExpiresAt,
-    })
-
     const server = await testClient({
       isAuth: true,
       isAdmin: true,
       connections,
     })
+    await server.executeOperation({
+      query: SUBMIT_REPORT,
+      variables: {
+        input: {
+          targetId: toGlobalId({ type: NODE_TYPES.Article, id: 1 }),
+          reason: 'other',
+        },
+      },
+    })
+
+    // Seed: insert community_watch_action rows on an existing comment so the
+    // OSS reports list can surface active rows alongside direct reports.
+    const comment = await connections
+      .knex('comment')
+      .select('id', 'target_id')
+      .where('type', 'article')
+      .first()
+    const contentExpiresAt = new Date()
+    contentExpiresAt.setFullYear(contentExpiresAt.getFullYear() + 1)
+
+    await connections.knex('community_watch_action').insert([
+      {
+        uuid: '11111111-1111-1111-1111-111111111111',
+        commentId: comment.id,
+        commentType: 'article',
+        targetType: 'article',
+        targetId: comment.targetId,
+        targetTitle: 'seed',
+        targetShortHash: 'seed',
+        reason: 'porn_ad',
+        actorId: '1',
+        commentAuthorId: '2',
+        originalContent: '<p>banned</p>',
+        originalState: 'active',
+        actionState: 'active',
+        appealState: 'none',
+        reviewState: 'pending',
+        contentExpiresAt,
+      },
+      {
+        uuid: '22222222-2222-2222-2222-222222222222',
+        commentId: comment.id,
+        commentType: 'article',
+        targetType: 'article',
+        targetId: comment.targetId,
+        targetTitle: 'restored seed',
+        targetShortHash: 'seed',
+        reason: 'spam_ad',
+        actorId: '1',
+        commentAuthorId: '2',
+        originalContent: '<p>restored</p>',
+        originalState: 'active',
+        actionState: 'restored',
+        appealState: 'resolved',
+        reviewState: 'reversed',
+        contentExpiresAt,
+      },
+    ])
+
     const { data, errors } = await server.executeOperation({
       query: GET_REPORTS,
       variables: { input: { first: null } },
     })
     expect(errors).toBeUndefined()
 
-    // The previous test in this describe block inserted 2 direct reports;
-    // this one adds 1 community_watch row, so totalCount should be 3.
-    expect(data.oss.reports.totalCount).toBe(3)
+    // One direct report plus one active community_watch row. Restored
+    // community_watch rows are excluded so OSS staff don't act on reversed
+    // removals when triaging accounts.
+    expect(data.oss.reports.totalCount).toBe(2)
 
     const sources = data.oss.reports.edges.map(
       (e: { node: { source: string } }) => e.node.source

--- a/src/types/__test__/2/system.test.ts
+++ b/src/types/__test__/2/system.test.ts
@@ -1554,10 +1554,10 @@ describe('submitReport', () => {
     })
     expect(errors).toBeUndefined()
 
-    // One direct report plus one active community_watch row. Restored
-    // community_watch rows are excluded so OSS staff don't act on reversed
-    // removals when triaging accounts.
-    expect(data.oss.reports.totalCount).toBe(2)
+    // At least one direct report plus the active community_watch row seeded
+    // here. Other test files may create direct reports in parallel against the
+    // same CI database, so avoid asserting an exact global count.
+    expect(data.oss.reports.totalCount).toBeGreaterThanOrEqual(2)
 
     const sources = data.oss.reports.edges.map(
       (e: { node: { source: string } }) => e.node.source
@@ -1565,9 +1565,17 @@ describe('submitReport', () => {
     expect(sources).toContain('community_watch')
     expect(sources).toContain('direct')
 
-    const watchEdge = data.oss.reports.edges.find(
-      (e: { node: { source: string } }) => e.node.source === 'community_watch'
+    const watchEdges = data.oss.reports.edges.filter(
+      (e: { node: { communityWatchAction?: { uuid?: string } | null } }) =>
+        [
+          '11111111-1111-1111-1111-111111111111',
+          '22222222-2222-2222-2222-222222222222',
+        ].includes(e.node.communityWatchAction?.uuid ?? '')
     )
+    // Restored community_watch rows are excluded so OSS staff don't act on
+    // reversed removals when triaging accounts.
+    expect(watchEdges).toHaveLength(1)
+    const watchEdge = watchEdges[0]
     // Reason is namespaced for community-watch rows.
     expect(watchEdge.node.reason).toBe('community_watch_porn_ad')
     expect(watchEdge.node.communityWatchAction).toMatchObject({

--- a/src/types/__test__/2/system.test.ts
+++ b/src/types/__test__/2/system.test.ts
@@ -1387,7 +1387,7 @@ describe('submitReport', () => {
     }
   `
   const GET_REPORTS = /* GraphQL */ `
-    query ($input: ConnectionArgs!) {
+    query ($input: OSSReportsInput!) {
       oss {
         reports(input: $input) {
           totalCount
@@ -1598,6 +1598,69 @@ describe('submitReport', () => {
     })
     // The target resolves to the underlying Comment.
     expect(watchEdge?.node.target.id).toBeDefined()
+  })
+
+  test('reports query filters by source', async () => {
+    const server = await testClient({
+      isAuth: true,
+      isAdmin: true,
+      connections,
+    })
+
+    await server.executeOperation({
+      query: SUBMIT_REPORT,
+      variables: {
+        input: {
+          targetId: toGlobalId({ type: NODE_TYPES.Article, id: 1 }),
+          reason: 'other',
+        },
+      },
+    })
+
+    const comment = await connections
+      .knex('comment')
+      .select('id', 'target_id')
+      .where('type', 'article')
+      .first()
+    const contentExpiresAt = new Date()
+    contentExpiresAt.setFullYear(contentExpiresAt.getFullYear() + 1)
+
+    await connections.knex('community_watch_action').insert({
+      uuid: '33333333-3333-3333-3333-333333333333',
+      commentId: comment.id,
+      commentType: 'article',
+      targetType: 'article',
+      targetId: comment.targetId,
+      targetTitle: 'source filter seed',
+      targetShortHash: 'seed',
+      reason: 'spam_ad',
+      actorId: '1',
+      commentAuthorId: '2',
+      originalContent: '<p>same spam body</p>',
+      originalState: 'active',
+      actionState: 'active',
+      appealState: 'none',
+      reviewState: 'pending',
+      contentExpiresAt,
+    })
+
+    const { data, errors } = await server.executeOperation({
+      query: GET_REPORTS,
+      variables: {
+        input: {
+          first: null,
+          filter: { source: 'community_watch' },
+        },
+      },
+    })
+    expect(errors).toBeUndefined()
+    expect(data.oss.reports.edges.length).toBeGreaterThanOrEqual(1)
+    expect(
+      data.oss.reports.edges.every(
+        (edge: { node: { source: string } }) =>
+          edge.node.source === 'community_watch'
+      )
+    ).toBe(true)
   })
 })
 

--- a/src/types/__test__/2/user/user.test.ts
+++ b/src/types/__test__/2/user/user.test.ts
@@ -1083,6 +1083,59 @@ describe('update user state', () => {
     )
     expect(data.updateUserState[0].status.state).toBe('banned')
   })
+
+  test('archive users in batch with per-user skipped results', async () => {
+    const batchUser1 = await userService.create({
+      email: 'batch-archive-1@matters.news',
+    })
+    const batchUser2 = await userService.create({
+      email: 'batch-archive-2@matters.news',
+    })
+    await userService.archive(batchUser2.id)
+
+    const ARCHIVE_USERS = /* GraphQL */ `
+      mutation ($input: ArchiveUsersInput!) {
+        archiveUsers(input: $input) {
+          archived {
+            id
+            status {
+              state
+            }
+          }
+          skipped {
+            id
+            message
+          }
+        }
+      }
+    `
+
+    const server = await testClient({
+      isAdmin: true,
+      isAuth: true,
+      connections,
+    })
+    const { data, errors } = await server.executeOperation({
+      query: ARCHIVE_USERS,
+      variables: {
+        input: {
+          ids: [
+            toGlobalId({ type: NODE_TYPES.User, id: batchUser1.id }),
+            toGlobalId({ type: NODE_TYPES.User, id: batchUser2.id }),
+          ],
+          password: '12345678',
+        },
+      },
+    })
+
+    expect(errors).toBeUndefined()
+    expect(data.archiveUsers.archived).toHaveLength(1)
+    expect(data.archiveUsers.archived[0].status.state).toBe('archived')
+    expect(data.archiveUsers.skipped).toHaveLength(1)
+    expect(data.archiveUsers.skipped[0].message).toBe(
+      'user has already been archived'
+    )
+  })
 })
 
 describe('query social accounts', () => {

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -322,6 +322,8 @@ export default /* GraphQL */ `
     actionState: CommunityWatchActionState!
     appealState: CommunityWatchAppealState!
     reviewState: CommunityWatchReviewState!
+    "SHA-256 hash of normalized original content for OSS clustering without re-spreading spam text."
+    contentHash: String
     originalContent: String
     contentCleared: Boolean!
     createdAt: DateTime!

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -245,6 +245,8 @@ export default /* GraphQL */ `
     reason: ReportReason!
     "Whether this record originates from a direct in-site report or a community watch action."
     source: ReportSource!
+    "The audit record when this report originates from a community watch action."
+    communityWatchAction: CommunityWatchAction
     createdAt: DateTime!
   }
 

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -152,7 +152,7 @@ export default /* GraphQL */ `
     seedingUsers(input: ConnectionArgs!): UserConnection!
     badgedUsers(input: BadgedUsersInput!): UserConnection!
     restrictedUsers(input: ConnectionArgs!): UserConnection!
-    reports(input: ConnectionArgs!): ReportConnection!
+    reports(input: OSSReportsInput!): ReportConnection!
     icymiTopics(input: ConnectionArgs!): IcymiTopicConnection!
     topicChannelFeedbacks(input: TopicChannelFeedbacksInput!): TopicChannelFeedbackConnection!
   }
@@ -259,6 +259,16 @@ export default /* GraphQL */ `
   type ReportEdge {
     cursor: String!
     node: Report!
+  }
+
+  input OSSReportsInput {
+    after: String
+    first: Int @constraint(min: 0)
+    filter: OSSReportsFilter
+  }
+
+  input OSSReportsFilter {
+    source: ReportSource
   }
 
   input NodeInput {

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -243,6 +243,8 @@ export default /* GraphQL */ `
     reporter: User!
     target: Node!
     reason: ReportReason!
+    "Whether this record originates from a direct in-site report or a community watch action."
+    source: ReportSource!
     createdAt: DateTime!
   }
 
@@ -587,6 +589,17 @@ export default /* GraphQL */ `
     discrimination_insult_hatred
     pornography_involving_minors
     other
+    "Pornographic/adult advertising flagged by a community watch member."
+    community_watch_porn_ad
+    "Spam advertising flagged by a community watch member."
+    community_watch_spam_ad
+  }
+
+  enum ReportSource {
+    "Submitted directly via the in-site report form."
+    direct
+    "Created automatically when a community watch member removes a comment."
+    community_watch
   }
 
   type IcymiTopic implements Node {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -104,6 +104,9 @@ export default /* GraphQL */ `
     "Update state of a user, used in OSS."
     updateUserState(input: UpdateUserStateInput!): [User!] @auth(mode: "${AUTH_MODE.admin}") @purgeCache(type: "${NODE_TYPES.User}")
 
+    "Archive multiple users from OSS with per-user results."
+    archiveUsers(input: ArchiveUsersInput!): ArchiveUsersResult! @auth(mode: "${AUTH_MODE.admin}") @purgeCache(type: "${NODE_TYPES.User}")
+
     "Update state of a user, used in OSS."
     updateUserRole(input: UpdateUserRoleInput!): User! @auth(mode: "${AUTH_MODE.admin}") @purgeCache(type: "${NODE_TYPES.User}")
 
@@ -795,6 +798,21 @@ export default /* GraphQL */ `
     state: UserState!
     banDays: Int @constraint(exclusiveMin: 0)
     password: String
+  }
+
+  input ArchiveUsersInput {
+    ids: [ID!]!
+    password: String!
+  }
+
+  type ArchiveUsersResult {
+    archived: [User!]!
+    skipped: [ArchiveUserFailure!]!
+  }
+
+  type ArchiveUserFailure {
+    id: ID!
+    message: String!
   }
 
   input UpdateUserRoleInput {


### PR DESCRIPTION
## Summary

- builds on `thematters/matters-server#4821` and keeps `oss.reports` as the OSS handoff surface
- adds `OSS.reports(input: OSSReportsInput!)` with optional `filter.source` so admins can switch between direct reports and Community Watch rows
- keeps active `community_watch_action` rows in OSS reports and exposes a privacy-preserving `CommunityWatchAction.contentHash` for same-content clustering without re-spreading spam text
- adds `archiveUsers(input:)` for OSS admins to archive up to 50 user accounts in one operation with per-user skipped results
- reuses the existing single-user archive behavior: admin password verification, `userService.archive`, archive queue dispatch, cache purge, and deletion email

## Rollout order

1. Merge and deploy this server PR to `develop` first.
2. Merge `thematters/matters-oss#892` after the schema is available.
3. Run the Matters Release Evaluation Agent E2E acceptance flow before production merge/deploy.
4. Promote through the repo's normal `develop` to `master` production flow after acceptance.

## Merge preflight

- [x] Codecov patch coverage passes after the resolver coverage tests in `3885bbc99`.
- [ ] Run Matters Release Evaluation Agent SOP from `/Users/mashbean/Documents/AI-Agent/docs/projects/matters-release-evaluation-agent/agent-sop.md`.
- [ ] Record separate evidence for repo/CI, automated E2E, `matters.icu` staging acceptance, production approval, and `matters.town` smoke state.
- [ ] Do not run production admin/moderation mutations without explicit human approval.

## Validation

- `npm run build`
- `npm run lint -- src/mutations/user/archiveUsers.ts src/queries/comment/communityWatchActionPublic.ts src/queries/system/oss/reports.ts src/common/utils/__test__/communityWatchPublicQueries.test.ts src/types/__test__/2/system.test.ts src/types/__test__/2/user/user.test.ts`
- `npx prettier --check src/mutations/user/archiveUsers.ts src/queries/comment/communityWatchActionPublic.ts src/queries/system/oss/reports.ts src/common/utils/__test__/communityWatchPublicQueries.test.ts src/types/__test__/2/system.test.ts src/types/__test__/2/user/user.test.ts src/types/comment.ts src/types/system.ts src/types/user.ts src/definitions/schema.d.ts`
- `MATTERS_ENV=test node --experimental-vm-modules --no-experimental-fetch node_modules/.bin/jest build/common/utils/__test__/communityWatchPublicQueries.test.js --runInBand`
- `MATTERS_ENV=test node --experimental-vm-modules --no-experimental-fetch node_modules/.bin/jest build/common/utils/__test__/archiveUsersResolver.test.js build/common/utils/__test__/reportResolver.test.js --runInBand --coverageDirectory coverage/utils-coverage-fix`

Attempted DB-backed targeted suites and full local `test:utils`, but this local workspace cannot initialize test DB connections, so they fail before target assertions run with `AggregateError` and `connections.knex` undefined:

- `MATTERS_ENV=test node --experimental-vm-modules --no-experimental-fetch node_modules/.bin/jest build/types/__test__/2/system.test.js --runInBand -t "reports query filters by source"`
- `MATTERS_ENV=test node --experimental-vm-modules --no-experimental-fetch node_modules/.bin/jest build/types/__test__/2/user/user.test.js --runInBand -t "archive users in batch"`
- `npm run testcmd -- build/common/utils/ --runInBand --coverageDirectory coverage/utils`
