### PR TITLE
[codex] Add carbon based badge type

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -2868,6 +2868,7 @@ enum ReportSource {
 
   """Created automatically when a community watch member removes a comment."""
   community_watch
+  carbon_based
 }
 
 type IcymiTopic implements Node {

--- a/src/common/enums/badges.ts
+++ b/src/common/enums/badges.ts
@@ -5,6 +5,7 @@ export const ALL_BADGE_TYPES = [
   'seed',
   'grand_slam',
   'community_watch',
+  'carbon_based',
   // user can only get 1 of the 4 nomad badges
   'nomad1',
   'nomad2',

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -777,6 +777,7 @@ export type GQLBadge = {
 
 export type GQLBadgeType =
   | 'architect'
+  | 'carbon_based'
   | 'community_watch'
   | 'golden_motor'
   | 'grand_slam'


### PR DESCRIPTION
## Summary
- add `carbon_based` to the GraphQL BadgeType enum
- allow the user badge resolver to return carbon based badges
- update generated GraphQL definitions for the new enum value

## Validation
- schema-only change, no database migration required because `user_badge.type` is string-backed