### PR TITLE
feat: sync community watch reports

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1864,6 +1864,11 @@ type CommunityWatchAction {
   contentHash: String
   originalContent: String
   contentCleared: Boolean!
+
+  """
+  Whether this Community Watch action also created the normal user report flow for staff review.
+  """
+  reportSynced: Boolean!
   createdAt: DateTime!
 }
 

--- a/src/common/utils/__test__/communityWatchRemoveComment.test.ts
+++ b/src/common/utils/__test__/communityWatchRemoveComment.test.ts
@@ -50,16 +50,19 @@ const createContext = ({
   comment = baseComment,
   lockedComment = comment,
   activeAction,
+  existingReport,
   featureFlags = [{ type: USER_FEATURE_FLAG_TYPE.communityWatch }],
   viewerState = USER_STATE.active,
 }: {
   comment?: Comment
   lockedComment?: Comment | null
   activeAction?: { id: string }
+  existingReport?: { id: string }
   featureFlags?: Array<{ type: string }>
   viewerState?: string
 } = {}) => {
   const insertedActions: any[] = []
+  const insertedReports: any[] = []
   const commentUpdates: any[] = []
   const updatedComment = { ...lockedComment, state: COMMENT_STATE.banned }
 
@@ -75,10 +78,18 @@ const createContext = ({
         if (table === 'comment') {
           return lockedComment
         }
+        if (table === 'report') {
+          return existingReport
+        }
         return undefined
       },
       insert: async (data: any) => {
-        insertedActions.push(data)
+        if (table === 'community_watch_action') {
+          insertedActions.push(data)
+        }
+        if (table === 'report') {
+          insertedReports.push(data)
+        }
       },
       update: (data: any) => {
         commentUpdates.push(data)
@@ -132,7 +143,7 @@ const createContext = ({
     },
   } as any
 
-  return { context, insertedActions, commentUpdates }
+  return { context, insertedActions, insertedReports, commentUpdates }
 }
 
 const removeComment = (
@@ -154,7 +165,8 @@ const removeComment = (
 
 describe('communityWatchRemoveComment', () => {
   test('removes an article comment and writes an audit action', async () => {
-    const { context, insertedActions, commentUpdates } = createContext()
+    const { context, insertedActions, insertedReports, commentUpdates } =
+      createContext()
 
     const result = await mutation(
       {},
@@ -171,6 +183,13 @@ describe('communityWatchRemoveComment', () => {
     expect(result.state).toBe(COMMENT_STATE.banned)
     expect(commentUpdates).toEqual([
       expect.objectContaining({ state: COMMENT_STATE.banned }),
+    ])
+    expect(insertedReports).toEqual([
+      {
+        commentId: baseComment.id,
+        reporterId: '2',
+        reason: 'illegal_advertising',
+      },
     ])
     expect(insertedActions[0]).toEqual(
       expect.objectContaining({
@@ -203,7 +222,9 @@ describe('communityWatchRemoveComment', () => {
       type: COMMENT_TYPE.moment,
       targetId: '12',
     }
-    const { context, insertedActions } = createContext({ comment })
+    const { context, insertedActions, insertedReports } = createContext({
+      comment,
+    })
 
     await mutation(
       {},
@@ -226,6 +247,23 @@ describe('communityWatchRemoveComment', () => {
         reason: 'spam_ad',
       })
     )
+    expect(insertedReports).toEqual([
+      {
+        commentId: comment.id,
+        reporterId: '2',
+        reason: 'illegal_advertising',
+      },
+    ])
+  })
+
+  test('does not duplicate an existing synced report', async () => {
+    const { context, insertedReports } = createContext({
+      existingReport: { id: 'report-1' },
+    })
+
+    await removeComment(context)
+
+    expect(insertedReports).toHaveLength(0)
   })
 
   test('rejects users without the communityWatch feature flag', async () => {

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -1494,6 +1494,8 @@ export type GQLCommunityWatchAction = {
   createdAt: Scalars['DateTime']['output']
   originalContent?: Maybe<Scalars['String']['output']>
   reason: GQLCommunityWatchRemoveCommentReason
+  /** Whether this Community Watch action also created the normal user report flow for staff review. */
+  reportSynced: Scalars['Boolean']['output']
   reviewState: GQLCommunityWatchReviewState
   sourceId: Scalars['ID']['output']
   sourceTitle: Scalars['String']['output']
@@ -8397,6 +8399,7 @@ export type GQLCommunityWatchActionResolvers<
     ParentType,
     ContextType
   >
+  reportSynced?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
   reviewState?: Resolver<
     GQLResolversTypes['CommunityWatchReviewState'],
     ParentType,

--- a/src/mutations/comment/communityWatchRemoveComment.ts
+++ b/src/mutations/comment/communityWatchRemoveComment.ts
@@ -26,6 +26,7 @@ import { v4 } from 'uuid'
 
 const allowedCommentStates = [COMMENT_STATE.active, COMMENT_STATE.collapsed]
 const allowedCommentTypes = [COMMENT_TYPE.article, COMMENT_TYPE.moment]
+const syncedReportReason = 'illegal_advertising'
 
 type CommunityWatchRemoveCommentReason = 'porn_ad' | 'spam_ad'
 
@@ -112,6 +113,22 @@ const resolver = async (
       }
       if (!allowedCommentStates.includes(freshComment.state)) {
         throw new UserInputError('comment is not removable by Community Watch')
+      }
+
+      const existingReport = await trx('report')
+        .select('id')
+        .where({
+          commentId: freshComment.id,
+          reporterId: viewer.id,
+          reason: syncedReportReason,
+        })
+        .first()
+      if (!existingReport) {
+        await trx('report').insert({
+          commentId: freshComment.id,
+          reporterId: viewer.id,
+          reason: syncedReportReason,
+        })
       }
 
       await trx('community_watch_action').insert({

--- a/src/queries/comment/communityWatchActionPublic.ts
+++ b/src/queries/comment/communityWatchActionPublic.ts
@@ -9,6 +9,8 @@ import { environment } from '#common/environment.js'
 import { toGlobalId } from '#common/utils/index.js'
 import crypto from 'node:crypto'
 
+const syncedReportReason = 'illegal_advertising'
+
 const getSourceNodeType = ({ targetType }: CommunityWatchAction) =>
   targetType === COMMENT_TYPE.article ? NODE_TYPES.Article : NODE_TYPES.Moment
 
@@ -50,6 +52,21 @@ const communityWatchActionPublic: GQLCommunityWatchActionResolvers = {
   },
   contentCleared: ({ originalContent }: CommunityWatchAction) =>
     originalContent === null,
+  reportSynced: async (
+    { actorId, commentId }: CommunityWatchAction,
+    _: unknown,
+    { dataSources: { connections } }: Context
+  ) => {
+    const report = await connections.knex('report')
+      .select('id')
+      .where({
+        commentId,
+        reporterId: actorId,
+        reason: syncedReportReason,
+      })
+      .first()
+    return Boolean(report)
+  },
 }
 
 export default communityWatchActionPublic

--- a/src/queries/system/oss/reports.ts
+++ b/src/queries/system/oss/reports.ts
@@ -50,6 +50,14 @@ export const reports: GQLOssResolvers['reports'] = async (
         'created_at'
       )
       .from('report')
+      .whereNotExists(function () {
+        this.select(knex.raw('1'))
+          .from('community_watch_action')
+          .whereRaw('community_watch_action.comment_id = report.comment_id')
+          .whereRaw('community_watch_action.actor_id = report.reporter_id')
+          .whereRaw('report.reason = ?', ['illegal_advertising'])
+          .where('community_watch_action.action_state', 'active')
+      })
 
   const buildCommunityWatchQuery = () =>
     // Community-watch derived rows:

--- a/src/types/__test__/2/comment.test.ts
+++ b/src/types/__test__/2/comment.test.ts
@@ -77,6 +77,7 @@ const COMMUNITY_WATCH_REMOVE_COMMENT = /* GraphQL */ `
       communityWatchAction {
         uuid
         reason
+        reportSynced
         createdAt
       }
     }
@@ -103,6 +104,7 @@ const COMMUNITY_WATCH_ACTIONS = /* GraphQL */ `
           reviewState
           originalContent
           contentCleared
+          reportSynced
           createdAt
         }
       }
@@ -626,6 +628,7 @@ describe('community watch remove comment', () => {
     expect(data.communityWatchRemoveComment.communityWatchAction).toEqual({
       uuid: expect.any(String),
       reason: 'spam_ad',
+      reportSynced: true,
       createdAt: expect.anything(),
     })
 
@@ -652,6 +655,15 @@ describe('community watch remove comment', () => {
       reviewState: 'pending',
     })
     expect(auditAction.contentExpiresAt).toBeNull()
+    const syncedReport = await atomService.findFirst({
+      table: 'report',
+      where: {
+        commentId: comment.id,
+        reporterId: watcher.id,
+        reason: 'illegal_advertising',
+      },
+    })
+    expect(syncedReport).toBeDefined()
     expect(mockTrigger).toHaveBeenCalledWith(
       expect.objectContaining({
         event: OFFICIAL_NOTICE_EXTEND_TYPE.comment_banned,
@@ -744,6 +756,7 @@ describe('community watch public audit queries', () => {
       reviewState: 'upheld',
       originalContent: '<p>spam ad</p>',
       contentCleared: false,
+      reportSynced: false,
       createdAt: expect.anything(),
     })
     expect(fromGlobalId(node.commentId)).toEqual({

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -326,6 +326,8 @@ export default /* GraphQL */ `
     contentHash: String
     originalContent: String
     contentCleared: Boolean!
+    "Whether this Community Watch action also created the normal user report flow for staff review."
+    reportSynced: Boolean!
     createdAt: DateTime!
   }
 


### PR DESCRIPTION
## Summary
- create the normal report row when a Community Watch member removes a comment
- expose reportSynced on public Community Watch actions
- avoid duplicate OSS report rows when the report came from Community Watch

## Validation
- npm run build
- npm run test:utils -- --runTestsByPath build/common/utils/__test__/communityWatchRemoveComment.test.js
- GitHub Actions Test passed before rebase: https://github.com/thematters/matters-server/actions/runs/26580143439

## Deployment scope
- develop staging only for E2E
- no master merge
- no production deploy