### PR TITLE
[codex] Add personhood badge claim mutations

### DIFF
--- a/db/migrations/20260528000000_add_carbon_based_user_badge.js
+++ b/db/migrations/20260528000000_add_carbon_based_user_badge.js
@@ -1,0 +1,23 @@
+import { alterEnumString } from '../utils.js'
+
+const table = 'user_badge'
+
+const previousBadgeTypes = [
+  'seed',
+  'golden_motor',
+  'architect',
+  'nomad',
+  'grand_slam',
+  'community_watch',
+]
+
+const badgeTypes = [...previousBadgeTypes, 'carbon_based']
+
+export const up = async (knex) => {
+  await knex.raw(alterEnumString(table, 'type', badgeTypes))
+}
+
+export const down = async (knex) => {
+  await knex(table).where({ type: 'carbon_based' }).del()
+  await knex.raw(alterEnumString(table, 'type', previousBadgeTypes))
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -184,6 +184,12 @@ type Mutation {
   """Confirm verification code from email."""
   confirmVerificationCode(input: ConfirmVerificationCodeInput!): ID!
 
+  """Create a short-lived token that binds a verifier challenge to the current viewer."""
+  createPersonhoodHandoff(input: CreatePersonhoodHandoffInput!): PersonhoodHandoff!
+
+  """Claim the carbon based badge with a verified zkID personhood proof."""
+  claimPersonhoodBadge(input: ClaimPersonhoodBadgeInput!): User!
+
   """Reset user or payment password."""
   resetPassword(input: ResetPasswordInput!): Boolean
 
@@ -3646,6 +3652,23 @@ input ClaimLogbooksInput {
   nonce: String!
 }
 
+input CreatePersonhoodHandoffInput {
+  challenge: String!
+  challengeExpiresAt: DateTime
+}
+
+type PersonhoodHandoff {
+  token: String!
+  expiresAt: DateTime!
+}
+
+input ClaimPersonhoodBadgeInput {
+  handoffToken: String!
+  certChainProof: String!
+  certChainType: String
+  userSigProof: String!
+}
+
 input FeaturedTagsInput {
   """ tagIds """
   ids: [ID!]!
@@ -3662,6 +3685,7 @@ enum BadgeType {
   architect
   grand_slam
   community_watch
+  carbon_based
   nomad1
   nomad2
   nomad3

--- a/src/common/environment.ts
+++ b/src/common/environment.ts
@@ -193,6 +193,7 @@ export const environment = {
     process.env.MATTERS_MOTOR_BADGE_THRESHOLD || '100',
     10
   ),
+  personhoodVerifierUrl: process.env.MATTERS_PERSONHOOD_VERIFIER_URL || '',
   ga4PropertyId: process.env.MATTERS_GA4_PROPERTY_ID || '',
   ga4ProjectId: process.env.MATTERS_GA4_PROJECT_ID || '',
   ga4ClientEmail: process.env.MATTERS_GA4_CLIENT_EMAIL || '',

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -1252,6 +1252,24 @@ export type GQLClaimLogbooksResult = {
   txHash: Scalars['String']['output']
 }
 
+export type GQLClaimPersonhoodBadgeInput = {
+  certChainProof: Scalars['String']['input']
+  certChainType?: InputMaybe<Scalars['String']['input']>
+  handoffToken: Scalars['String']['input']
+  userSigProof: Scalars['String']['input']
+}
+
+export type GQLCreatePersonhoodHandoffInput = {
+  challenge: Scalars['String']['input']
+  challengeExpiresAt?: InputMaybe<Scalars['DateTime']['input']>
+}
+
+export type GQLPersonhoodHandoff = {
+  __typename?: 'PersonhoodHandoff'
+  expiresAt: Scalars['DateTime']['output']
+  token: Scalars['String']['output']
+}
+
 export type GQLClassifyArticlesChannelsInput = {
   ids: Array<Scalars['ID']['input']>
 }
@@ -2208,6 +2226,8 @@ export type GQLMutation = {
   banCampaignArticles: GQLCampaign
   /** Let Traveloggers owner claims a Logbook, returns transaction hash */
   claimLogbooks: GQLClaimLogbooksResult
+  /** Claim the carbon based badge with a verified zkID personhood proof. */
+  claimPersonhoodBadge: GQLUser
   classifyArticlesChannels: Scalars['Boolean']['output']
   /** Clear stored original content for a Community Watch action as staff. */
   clearCommunityWatchOriginalContent: GQLCommunityWatchAction
@@ -2221,6 +2241,8 @@ export type GQLMutation = {
   confirmVerificationCode: Scalars['ID']['output']
   /** Create Stripe Connect account for Payout */
   connectStripeAccount: GQLConnectStripeAccountResult
+  /** Create a short-lived token that binds a verifier challenge to the current viewer. */
+  createPersonhoodHandoff: GQLPersonhoodHandoff
   deleteAnnouncements: Scalars['Boolean']['output']
   /** Delete blocked search keywords from search_history db */
   deleteBlockedSearchKeywords?: Maybe<Scalars['Boolean']['output']>
@@ -2446,6 +2468,10 @@ export type GQLMutationClaimLogbooksArgs = {
   input: GQLClaimLogbooksInput
 }
 
+export type GQLMutationClaimPersonhoodBadgeArgs = {
+  input: GQLClaimPersonhoodBadgeInput
+}
+
 export type GQLMutationClassifyArticlesChannelsArgs = {
   input: GQLClassifyArticlesChannelsInput
 }
@@ -2468,6 +2494,10 @@ export type GQLMutationConfirmVerificationCodeArgs = {
 
 export type GQLMutationConnectStripeAccountArgs = {
   input: GQLConnectStripeAccountInput
+}
+
+export type GQLMutationCreatePersonhoodHandoffArgs = {
+  input: GQLCreatePersonhoodHandoffInput
 }
 
 export type GQLMutationDeleteAnnouncementsArgs = {
@@ -5585,6 +5615,7 @@ export type GQLResolversTypes = ResolversObject<{
   CircleSubscriberAnalytics: ResolverTypeWrapper<CircleModel>
   ClaimLogbooksInput: GQLClaimLogbooksInput
   ClaimLogbooksResult: ResolverTypeWrapper<GQLClaimLogbooksResult>
+  ClaimPersonhoodBadgeInput: GQLClaimPersonhoodBadgeInput
   ClassifyArticlesChannelsInput: GQLClassifyArticlesChannelsInput
   ClearCommunityWatchOriginalContentInput: GQLClearCommunityWatchOriginalContentInput
   ClearReadHistoryInput: GQLClearReadHistoryInput
@@ -5646,6 +5677,7 @@ export type GQLResolversTypes = ResolversObject<{
     GQLResolversInterfaceTypes<GQLResolversTypes>['Connection']
   >
   ConnectionArgs: GQLConnectionArgs
+  CreatePersonhoodHandoffInput: GQLCreatePersonhoodHandoffInput
   CryptoWallet: ResolverTypeWrapper<ETHWalletModel>
   CryptoWalletSignaturePurpose: GQLCryptoWalletSignaturePurpose
   CurationChannel: ResolverTypeWrapper<CurationChannelModel>
@@ -5849,6 +5881,7 @@ export type GQLResolversTypes = ResolversObject<{
   >
   PayoutInput: GQLPayoutInput
   Person: ResolverTypeWrapper<GQLPerson>
+  PersonhoodHandoff: ResolverTypeWrapper<GQLPersonhoodHandoff>
   PinCommentInput: GQLPinCommentInput
   PinHistory: ResolverTypeWrapper<
     Omit<GQLPinHistory, 'feed'> & { feed: GQLResolversTypes['Node'] }
@@ -6346,6 +6379,7 @@ export type GQLResolversParentTypes = ResolversObject<{
   CircleSubscriberAnalytics: CircleModel
   ClaimLogbooksInput: GQLClaimLogbooksInput
   ClaimLogbooksResult: GQLClaimLogbooksResult
+  ClaimPersonhoodBadgeInput: GQLClaimPersonhoodBadgeInput
   ClassifyArticlesChannelsInput: GQLClassifyArticlesChannelsInput
   ClearCommunityWatchOriginalContentInput: GQLClearCommunityWatchOriginalContentInput
   ClearReadHistoryInput: GQLClearReadHistoryInput
@@ -6389,6 +6423,7 @@ export type GQLResolversParentTypes = ResolversObject<{
   ConnectStripeAccountResult: GQLConnectStripeAccountResult
   Connection: GQLResolversInterfaceTypes<GQLResolversParentTypes>['Connection']
   ConnectionArgs: GQLConnectionArgs
+  CreatePersonhoodHandoffInput: GQLCreatePersonhoodHandoffInput
   CryptoWallet: ETHWalletModel
   CurationChannel: CurationChannelModel
   DateTime: Scalars['DateTime']['output']
@@ -6542,6 +6577,7 @@ export type GQLResolversParentTypes = ResolversObject<{
   }
   PayoutInput: GQLPayoutInput
   Person: GQLPerson
+  PersonhoodHandoff: GQLPersonhoodHandoff
   PinCommentInput: GQLPinCommentInput
   PinHistory: Omit<GQLPinHistory, 'feed'> & {
     feed: GQLResolversParentTypes['Node']
@@ -9172,6 +9208,12 @@ export type GQLMutationResolvers<
     ContextType,
     RequireFields<GQLMutationClaimLogbooksArgs, 'input'>
   >
+  claimPersonhoodBadge?: Resolver<
+    GQLResolversTypes['User'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationClaimPersonhoodBadgeArgs, 'input'>
+  >
   classifyArticlesChannels?: Resolver<
     GQLResolversTypes['Boolean'],
     ParentType,
@@ -9212,6 +9254,12 @@ export type GQLMutationResolvers<
     ParentType,
     ContextType,
     RequireFields<GQLMutationConnectStripeAccountArgs, 'input'>
+  >
+  createPersonhoodHandoff?: Resolver<
+    GQLResolversTypes['PersonhoodHandoff'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationCreatePersonhoodHandoffArgs, 'input'>
   >
   deleteAnnouncements?: Resolver<
     GQLResolversTypes['Boolean'],
@@ -9873,6 +9921,15 @@ export type GQLNftAssetResolvers<
   >
   imageUrl?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
   name?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLPersonhoodHandoffResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['PersonhoodHandoff'] = GQLResolversParentTypes['PersonhoodHandoff']
+> = ResolversObject<{
+  expiresAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  token?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }>
 
@@ -11963,6 +12020,7 @@ export type GQLResolvers<ContextType = Context> = ResolversObject<{
   ResponseEdge?: GQLResponseEdgeResolvers<ContextType>
   SearchResultConnection?: GQLSearchResultConnectionResolvers<ContextType>
   SearchResultEdge?: GQLSearchResultEdgeResolvers<ContextType>
+  PersonhoodHandoff?: GQLPersonhoodHandoffResolvers<ContextType>
   SigningMessageResult?: GQLSigningMessageResultResolvers<ContextType>
   SkippedListItem?: GQLSkippedListItemResolvers<ContextType>
   SkippedListItemEdge?: GQLSkippedListItemEdgeResolvers<ContextType>

--- a/src/mutations/user/claimPersonhoodBadge.ts
+++ b/src/mutations/user/claimPersonhoodBadge.ts
@@ -1,0 +1,156 @@
+import type { GQLMutationResolvers } from '#definitions/index.js'
+
+import { environment } from '#common/environment.js'
+import { ForbiddenError, ServerError, UserInputError } from '#common/errors.js'
+import jwt, { type JwtPayload } from 'jsonwebtoken'
+
+const TOKEN_TYPE = 'personhood_handoff'
+
+type VerifyResponse = {
+  verified?: unknown
+  nullifier?: unknown
+  parsed_inputs?: {
+    challenge?: unknown
+  }
+  challenge?: {
+    expected?: unknown
+    observed?: unknown
+    match?: unknown
+  }
+  reason?: unknown
+  error?: unknown
+}
+
+type HandoffToken = JwtPayload & {
+  challenge?: unknown
+  type?: unknown
+}
+
+const resolver: GQLMutationResolvers['claimPersonhoodBadge'] = async (
+  _,
+  { input: { certChainProof, certChainType, handoffToken, userSigProof } },
+  { dataSources: { atomService } }
+) => {
+  if (!environment.personhoodVerifierUrl) {
+    throw new ServerError('personhood verifier is not configured')
+  }
+
+  const token = verifyHandoffToken(handoffToken)
+  if (!token.sub || typeof token.challenge !== 'string') {
+    throw new ForbiddenError('invalid personhood handoff token')
+  }
+
+  const result = await verifyProof({
+    certChainProof,
+    certChainType: certChainType || 'rs4096',
+    userSigProof,
+  })
+
+  if (result.verified !== true) {
+    const reason =
+      typeof result.reason === 'string'
+        ? result.reason
+        : typeof result.error === 'string'
+          ? result.error
+          : 'personhood proof verification failed'
+    throw new UserInputError(reason)
+  }
+
+  const observedChallenge = getObservedChallenge(result)
+  if (observedChallenge !== token.challenge) {
+    throw new ForbiddenError('personhood challenge mismatch')
+  }
+
+  await atomService.upsert({
+    table: 'user_badge',
+    where: { userId: token.sub, type: 'carbon_based' },
+    create: {
+      enabled: true,
+      type: 'carbon_based',
+      userId: token.sub,
+    },
+    update: {
+      enabled: true,
+    },
+  })
+
+  return atomService.findUnique({
+    table: 'user',
+    where: { id: token.sub },
+  })
+}
+
+const verifyHandoffToken = (handoffToken: string): HandoffToken => {
+  try {
+    const token = jwt.verify(
+      handoffToken,
+      environment.jwtSecret
+    ) as HandoffToken
+    if (token.type !== TOKEN_TYPE) {
+      throw new Error('unexpected token type')
+    }
+    return token
+  } catch {
+    throw new ForbiddenError('invalid personhood handoff token')
+  }
+}
+
+const verifyProof = async ({
+  certChainProof,
+  certChainType,
+  userSigProof,
+}: {
+  certChainProof: string
+  certChainType: string
+  userSigProof: string
+}) => {
+  const response = await fetch(
+    `${environment.personhoodVerifierUrl.replace(/\/$/, '')}/link-verify`,
+    {
+      body: JSON.stringify({
+        cert_chain_proof: certChainProof,
+        cert_chain_type: certChainType,
+        user_sig_proof: userSigProof,
+      }),
+      headers: {
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    }
+  )
+
+  const text = await response.text()
+  let body: VerifyResponse
+  try {
+    body = JSON.parse(text) as VerifyResponse
+  } catch {
+    throw new ServerError('invalid personhood verifier response')
+  }
+
+  if (!response.ok) {
+    const message =
+      typeof body.error === 'string'
+        ? body.error
+        : typeof body.reason === 'string'
+          ? body.reason
+          : 'personhood verifier rejected proof'
+    throw new UserInputError(message)
+  }
+
+  return body
+}
+
+const getObservedChallenge = (result: VerifyResponse) => {
+  if (typeof result.parsed_inputs?.challenge === 'string') {
+    return result.parsed_inputs.challenge
+  }
+  if (typeof result.challenge?.observed === 'string') {
+    return result.challenge.observed
+  }
+  if (typeof result.challenge?.expected === 'string') {
+    return result.challenge.expected
+  }
+  throw new ForbiddenError('personhood challenge missing')
+}
+
+export default resolver

--- a/src/mutations/user/createPersonhoodHandoff.ts
+++ b/src/mutations/user/createPersonhoodHandoff.ts
@@ -1,0 +1,59 @@
+import type { GQLMutationResolvers } from '#definitions/index.js'
+
+import { environment } from '#common/environment.js'
+import { AuthenticationError, UserInputError } from '#common/errors.js'
+import jwt from 'jsonwebtoken'
+
+const TOKEN_TYPE = 'personhood_handoff'
+const DEFAULT_TTL_SECONDS = 10 * 60
+
+const resolver: GQLMutationResolvers['createPersonhoodHandoff'] = async (
+  _,
+  { input: { challenge, challengeExpiresAt } },
+  { viewer }
+) => {
+  if (!viewer.id) {
+    throw new AuthenticationError('visitor has no permission')
+  }
+
+  if (!challenge) {
+    throw new UserInputError('"challenge" is required')
+  }
+
+  const now = Date.now()
+  const challengeExpiresAtMs = challengeExpiresAt
+    ? new Date(challengeExpiresAt).getTime()
+    : now + DEFAULT_TTL_SECONDS * 1000
+
+  if (!Number.isFinite(challengeExpiresAtMs) || challengeExpiresAtMs <= now) {
+    throw new UserInputError('"challengeExpiresAt" is expired or invalid')
+  }
+
+  const expiresIn = Math.max(
+    1,
+    Math.min(
+      DEFAULT_TTL_SECONDS,
+      Math.floor((challengeExpiresAtMs - now) / 1000)
+    )
+  )
+  const expiresAt = new Date(now + expiresIn * 1000)
+
+  const token = jwt.sign(
+    {
+      challenge,
+      type: TOKEN_TYPE,
+    },
+    environment.jwtSecret,
+    {
+      expiresIn,
+      subject: viewer.id,
+    }
+  )
+
+  return {
+    expiresAt,
+    token,
+  }
+}
+
+export default resolver

--- a/src/mutations/user/index.ts
+++ b/src/mutations/user/index.ts
@@ -1,10 +1,12 @@
 import addCredit from './addCredit.js'
 import archiveUsers from './archiveUsers.js'
 import claimLogbooks from './claimLogbooks.js'
+import claimPersonhoodBadge from './claimPersonhoodBadge.js'
 import clearReadHistory from './clearReadHistory.js'
 import clearSearchHistory from './clearSearchHistory.js'
 import confirmVerificationCode from './confirmVerificationCode.js'
 import connectStripeAccount from './connectStripeAccount.js'
+import createPersonhoodHandoff from './createPersonhoodHandoff.js'
 import emailLogin from './emailLogin.js'
 import generateSigningMessage from './generateSigningMessage.js'
 import migration from './migration.js'
@@ -50,6 +52,8 @@ export default {
     resetPassword,
     emailLogin,
     userLogout,
+    createPersonhoodHandoff,
+    claimPersonhoodBadge,
     walletLogin,
     addWalletLogin,
     removeWalletLogin,

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -19,6 +19,12 @@ export default /* GraphQL */ `
     "Confirm verification code from email."
     confirmVerificationCode(input: ConfirmVerificationCodeInput!): ID!
 
+    "Create a short-lived token that binds a verifier challenge to the current viewer."
+    createPersonhoodHandoff(input: CreatePersonhoodHandoffInput!): PersonhoodHandoff! @auth(mode: "${AUTH_MODE.oauth}", group: "${SCOPE_GROUP.level1}")
+
+    "Claim the carbon based badge with a verified zkID personhood proof."
+    claimPersonhoodBadge(input: ClaimPersonhoodBadgeInput!): User! @purgeCache(type: "${NODE_TYPES.User}")
+
     "Reset user or payment password."
     resetPassword(input: ResetPasswordInput!): Boolean
 
@@ -865,6 +871,23 @@ export default /* GraphQL */ `
     nonce: String!
   }
 
+  input CreatePersonhoodHandoffInput {
+    challenge: String!
+    challengeExpiresAt: DateTime
+  }
+
+  type PersonhoodHandoff {
+    token: String!
+    expiresAt: DateTime!
+  }
+
+  input ClaimPersonhoodBadgeInput {
+    handoffToken: String!
+    certChainProof: String!
+    certChainType: String
+    userSigProof: String!
+  }
+
   input FeaturedTagsInput {
     " tagIds "
     ids: [ID!]! # tagIds
@@ -884,6 +907,7 @@ export default /* GraphQL */ `
     architect
     grand_slam
     community_watch
+    carbon_based
     # can only have 1 of the 4 levels of nomad badges
     nomad1
     nomad2


### PR DESCRIPTION
## Summary
- add `createPersonhoodHandoff` to issue a short-lived token binding the verifier challenge to the logged-in viewer
- add `claimPersonhoodBadge` to verify zkID proofs, check the handoff challenge, and upsert the `carbon_based` badge
- add a migration for the `carbon_based` `user_badge.type` enum because the later community-watch merge left `develop` without the DB enum value

## Validation
- `git diff --check`
- local `tsc` and `eslint` were attempted in a temporary checkout but entered an idle state without output, so the full verification is left to GitHub CI

## Runtime config
- set `MATTERS_PERSONHOOD_VERIFIER_URL` to the deployed zkID verifier base URL on staging and production