### PR TITLE
test: cover Community Watch permission boundaries

### DIFF
--- a/src/common/utils/__test__/communityWatchRemoveComment.test.ts
+++ b/src/common/utils/__test__/communityWatchRemoveComment.test.ts
@@ -284,6 +284,15 @@ describe('communityWatchRemoveComment', () => {
     )
   })
 
+  test('rejects frozen community watch users before loading the comment', async () => {
+    const { context } = createContext({ viewerState: USER_STATE.frozen })
+
+    await expect(removeComment(context)).rejects.toHaveProperty(
+      'extensions.code',
+      'FORBIDDEN_BY_STATE'
+    )
+  })
+
   test('rejects non-comment targets', async () => {
     const { context } = createContext()
 

--- a/src/types/__test__/2/system.test.ts
+++ b/src/types/__test__/2/system.test.ts
@@ -1422,6 +1422,20 @@ describe('submitReport', () => {
     }
   `
 
+  test('rejects non-admin users from OSS reports', async () => {
+    const server = await testClient({
+      isAuth: true,
+      connections,
+    })
+    const { errors, data } = await server.executeOperation({
+      query: GET_REPORTS,
+      variables: { input: { first: 1, filter: { source: 'community_watch' } } },
+    })
+
+    expect(errors?.[0].extensions.code).toBe('FORBIDDEN')
+    expect(data).toBe(null)
+  })
+
   test('submit report successfully', async () => {
     const server = await testClient({
       isAuth: true,

--- a/src/types/__test__/2/user/user.test.ts
+++ b/src/types/__test__/2/user/user.test.ts
@@ -1028,6 +1028,29 @@ describe('update user state', () => {
   const activeUser1Email = 'test2@matters.news'
   const activeUser2Email = 'test3@matters.news'
 
+  test('non-admin users can not update user state', async () => {
+    const UPDATE_USER_STATE = /* GraphQL */ `
+      mutation ($input: UpdateUserStateInput!) {
+        updateUserState(input: $input) {
+          id
+        }
+      }
+    `
+    const server = await testClient({ isAuth: true, connections })
+    const { errors, data } = await server.executeOperation({
+      query: UPDATE_USER_STATE,
+      variables: {
+        input: {
+          id: activeUser1Id,
+          state: USER_STATE.frozen,
+        },
+      },
+    })
+
+    expect(errors?.[0].extensions.code).toBe('FORBIDDEN')
+    expect(data).toBe(null)
+  })
+
   test('archive user should provide viewer passwd', async () => {
     const { errors } = await updateUserState(
       { id, state: USER_STATE.archived },

--- a/src/types/__test__/2/user/user.test.ts
+++ b/src/types/__test__/2/user/user.test.ts
@@ -1048,7 +1048,7 @@ describe('update user state', () => {
     })
 
     expect(errors?.[0].extensions.code).toBe('FORBIDDEN')
-    expect(data).toBe(null)
+    expect(data.updateUserState).toBe(null)
   })
 
   test('archive user should provide viewer passwd', async () => {


### PR DESCRIPTION
## Summary
- add a frozen-user negative test for Community Watch takedown
- add an OSS reports negative test for non-admin users
- add an updateUserState negative test for non-admin users before using OSS batch freeze

## Validation
- npm run build
- npm run test:utils -- --runTestsByPath build/common/utils/__test__/communityWatchRemoveComment.test.js

## Notes
- The DB-backed type tests were attempted locally with `npm run test:types:2 -- --runTestsByPath build/types/__test__/2/system.test.js build/types/__test__/2/user/user.test.js`, but the local test DB connections were unavailable, so the suite failed before exercising these cases. CI should run them in the configured DB environment.