### PR TITLE
test: cover personhood badge release paths

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -184,7 +184,9 @@ type Mutation {
   """Confirm verification code from email."""
   confirmVerificationCode(input: ConfirmVerificationCodeInput!): ID!
 
-  """Create a short-lived token that binds a verifier challenge to the current viewer."""
+  """
+  Create a short-lived token that binds a verifier challenge to the current viewer.
+  """
   createPersonhoodHandoff(input: CreatePersonhoodHandoffInput!): PersonhoodHandoff!
 
   """Claim the carbon based badge with a verified zkID personhood proof."""
@@ -2879,7 +2881,6 @@ enum ReportSource {
 
   """Created automatically when a community watch member removes a comment."""
   community_watch
-  carbon_based
 }
 
 type IcymiTopic implements Node {

--- a/src/common/utils/__test__/carbonBasedBadgeMigration.test.ts
+++ b/src/common/utils/__test__/carbonBasedBadgeMigration.test.ts
@@ -1,0 +1,64 @@
+import { pathToFileURL } from 'url'
+
+type Migration = {
+  up: (knex: MockKnex) => Promise<void>
+  down: (knex: MockKnex) => Promise<void>
+}
+
+type MockKnex = {
+  (table: string): {
+    where: (query: Record<string, string>) => {
+      del: () => Promise<void>
+    }
+  }
+  raw: (sql: string) => Promise<void>
+}
+
+const migrationUrl = pathToFileURL(
+  `${process.cwd()}/db/migrations/20260528000000_add_carbon_based_user_badge.js`
+).href
+
+const createKnex = () => {
+  const rawCalls: string[] = []
+  const deletes: Array<{ table: string; query: Record<string, string> }> = []
+
+  const knex = ((table: string) => ({
+    where: (query: Record<string, string>) => ({
+      del: async () => {
+        deletes.push({ table, query })
+      },
+    }),
+  })) as unknown as MockKnex
+
+  knex.raw = async (sql: string) => {
+    rawCalls.push(sql)
+  }
+
+  return { knex, rawCalls, deletes }
+}
+
+describe('carbon based badge migration', () => {
+  test('adds carbon_based to user badge type', async () => {
+    const { up } = (await import(migrationUrl)) as Migration
+    const { knex, rawCalls } = createKnex()
+
+    await up(knex)
+
+    expect(rawCalls).toEqual([expect.stringContaining("'carbon_based'")])
+  })
+
+  test('removes carbon_based badges before restoring previous badge types', async () => {
+    const { down } = (await import(migrationUrl)) as Migration
+    const { knex, rawCalls, deletes } = createKnex()
+
+    await down(knex)
+
+    expect(deletes).toEqual([
+      {
+        table: 'user_badge',
+        query: { type: 'carbon_based' },
+      },
+    ])
+    expect(rawCalls).toEqual([expect.not.stringContaining('carbon_based')])
+  })
+})

--- a/src/common/utils/__test__/personhoodMutations.test.ts
+++ b/src/common/utils/__test__/personhoodMutations.test.ts
@@ -1,0 +1,191 @@
+import { jest } from '@jest/globals'
+import jwt from 'jsonwebtoken'
+
+import { environment } from '#common/environment.js'
+import { ForbiddenError, ServerError, UserInputError } from '#common/errors.js'
+import claimPersonhoodBadge from '#mutations/user/claimPersonhoodBadge.js'
+import createPersonhoodHandoff from '#mutations/user/createPersonhoodHandoff.js'
+
+const originalVerifierUrl = environment.personhoodVerifierUrl
+const originalFetch = global.fetch
+
+const makeVerifierResponse = ({
+  body,
+  ok = true,
+}: {
+  body: string
+  ok?: boolean
+}) =>
+  ({
+    ok,
+    text: async () => body,
+  } as Response)
+
+const runCreateHandoff = (
+  input: { challenge?: string; challengeExpiresAt?: string },
+  viewer: { id?: string } = { id: '42' }
+) => (createPersonhoodHandoff as any)(null, { input }, { viewer }, {} as any)
+
+const runClaimBadge = (
+  input: Record<string, unknown>,
+  atomService: Record<string, unknown> = {
+    findUnique: jest.fn(async () => ({ id: '42' })),
+    upsert: jest.fn(),
+  }
+) =>
+  (claimPersonhoodBadge as any)(
+    null,
+    { input },
+    { dataSources: { atomService } },
+    {} as any
+  )
+
+describe('personhood mutations', () => {
+  afterEach(() => {
+    environment.personhoodVerifierUrl = originalVerifierUrl
+    global.fetch = originalFetch
+    jest.restoreAllMocks()
+  })
+
+  test('creates a short-lived handoff token', async () => {
+    const expiresAt = new Date(Date.now() + 60_000).toISOString()
+
+    const result = await runCreateHandoff({
+      challenge: 'challenge-1',
+      challengeExpiresAt: expiresAt,
+    })
+
+    const decoded = jwt.verify(
+      result.token,
+      environment.jwtSecret
+    ) as jwt.JwtPayload
+    expect(decoded.sub).toBe('42')
+    expect(decoded.type).toBe('personhood_handoff')
+    expect(decoded.challenge).toBe('challenge-1')
+    expect(result.expiresAt).toBeInstanceOf(Date)
+  })
+
+  test('rejects invalid handoff input', async () => {
+    await expect(
+      runCreateHandoff({ challenge: 'challenge-1' }, {})
+    ).rejects.toThrow('visitor has no permission')
+    await expect(runCreateHandoff({ challenge: '' })).rejects.toThrow(
+      '"challenge" is required'
+    )
+    await expect(
+      runCreateHandoff({
+        challenge: 'challenge-1',
+        challengeExpiresAt: new Date(Date.now() - 1000).toISOString(),
+      })
+    ).rejects.toThrow('"challengeExpiresAt" is expired or invalid')
+  })
+
+  test('claims the carbon based badge after proof verification', async () => {
+    environment.personhoodVerifierUrl = 'https://verifier.example'
+    const token = jwt.sign(
+      { challenge: 'challenge-1', type: 'personhood_handoff' },
+      environment.jwtSecret,
+      { subject: '42' }
+    )
+    const atomService = {
+      findUnique: jest.fn(async () => ({ id: '42' })),
+      upsert: jest.fn(),
+    }
+    global.fetch = jest.fn(async (url: unknown, init?: RequestInit) => {
+      expect(url).toBe('https://verifier.example/link-verify')
+      expect(JSON.parse(init?.body as string)).toEqual({
+        cert_chain_proof: 'cert-proof',
+        cert_chain_type: 'rs4096',
+        user_sig_proof: 'sig-proof',
+      })
+      return makeVerifierResponse({
+        body: JSON.stringify({
+          parsed_inputs: { challenge: 'challenge-1' },
+          verified: true,
+        }),
+      })
+    }) as typeof fetch
+
+    await expect(
+      runClaimBadge(
+        {
+          certChainProof: 'cert-proof',
+          handoffToken: token,
+          userSigProof: 'sig-proof',
+        },
+        atomService
+      )
+    ).resolves.toEqual({ id: '42' })
+
+    expect(atomService.upsert).toHaveBeenCalledWith({
+      table: 'user_badge',
+      where: { type: 'carbon_based', userId: '42' },
+      create: {
+        enabled: true,
+        type: 'carbon_based',
+        userId: '42',
+      },
+      update: {
+        enabled: true,
+      },
+    })
+  })
+
+  test('rejects unconfigured, invalid, failed, and mismatched proofs', async () => {
+    await expect(runClaimBadge({ handoffToken: 'bad-token' })).rejects.toThrow(
+      ServerError
+    )
+
+    environment.personhoodVerifierUrl = 'https://verifier.example/'
+    await expect(runClaimBadge({ handoffToken: 'bad-token' })).rejects.toThrow(
+      ForbiddenError
+    )
+
+    const token = jwt.sign(
+      { challenge: 'challenge-1', type: 'personhood_handoff' },
+      environment.jwtSecret,
+      { subject: '42' }
+    )
+
+    global.fetch = jest.fn(async () =>
+      makeVerifierResponse({ body: 'not json' })
+    ) as typeof fetch
+    await expect(
+      runClaimBadge({
+        certChainProof: 'cert-proof',
+        handoffToken: token,
+        userSigProof: 'sig-proof',
+      })
+    ).rejects.toThrow('invalid personhood verifier response')
+
+    global.fetch = jest.fn(async () =>
+      makeVerifierResponse({
+        body: JSON.stringify({ reason: 'verifier says no' }),
+        ok: false,
+      })
+    ) as typeof fetch
+    await expect(
+      runClaimBadge({
+        certChainProof: 'cert-proof',
+        handoffToken: token,
+        userSigProof: 'sig-proof',
+      })
+    ).rejects.toThrow(UserInputError)
+
+    global.fetch = jest.fn(async () =>
+      makeVerifierResponse({
+        body: JSON.stringify({
+          challenge: { observed: 'different-challenge' },
+          verified: true,
+        }),
+      })
+    ) as typeof fetch
+    await expect(
+      runClaimBadge({
+        certChainProof: 'cert-proof',
+        handoffToken: token,
+        userSigProof: 'sig-proof',
+      })
+    ).rejects.toThrow('personhood challenge mismatch')
+  })
+})

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -1259,17 +1259,6 @@ export type GQLClaimPersonhoodBadgeInput = {
   userSigProof: Scalars['String']['input']
 }
 
-export type GQLCreatePersonhoodHandoffInput = {
-  challenge: Scalars['String']['input']
-  challengeExpiresAt?: InputMaybe<Scalars['DateTime']['input']>
-}
-
-export type GQLPersonhoodHandoff = {
-  __typename?: 'PersonhoodHandoff'
-  expiresAt: Scalars['DateTime']['output']
-  token: Scalars['String']['output']
-}
-
 export type GQLClassifyArticlesChannelsInput = {
   ids: Array<Scalars['ID']['input']>
 }
@@ -1594,6 +1583,11 @@ export type GQLConnectionArgs = {
   filter?: InputMaybe<GQLFilterInput>
   first?: InputMaybe<Scalars['Int']['input']>
   oss?: InputMaybe<Scalars['Boolean']['input']>
+}
+
+export type GQLCreatePersonhoodHandoffInput = {
+  challenge: Scalars['String']['input']
+  challengeExpiresAt?: InputMaybe<Scalars['DateTime']['input']>
 }
 
 export type GQLCryptoWallet = {
@@ -3214,6 +3208,12 @@ export type GQLPayoutInput = {
 export type GQLPerson = {
   __typename?: 'Person'
   email: Scalars['String']['output']
+}
+
+export type GQLPersonhoodHandoff = {
+  __typename?: 'PersonhoodHandoff'
+  expiresAt: Scalars['DateTime']['output']
+  token: Scalars['String']['output']
 }
 
 export type GQLPinCommentInput = {
@@ -9924,15 +9924,6 @@ export type GQLNftAssetResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }>
 
-export type GQLPersonhoodHandoffResolvers<
-  ContextType = Context,
-  ParentType extends GQLResolversParentTypes['PersonhoodHandoff'] = GQLResolversParentTypes['PersonhoodHandoff']
-> = ResolversObject<{
-  expiresAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
-  token?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
-}>
-
 export type GQLNodeResolvers<
   ContextType = Context,
   ParentType extends GQLResolversParentTypes['Node'] = GQLResolversParentTypes['Node']
@@ -10313,6 +10304,15 @@ export type GQLPersonResolvers<
   ParentType extends GQLResolversParentTypes['Person'] = GQLResolversParentTypes['Person']
 > = ResolversObject<{
   email?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLPersonhoodHandoffResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['PersonhoodHandoff'] = GQLResolversParentTypes['PersonhoodHandoff']
+> = ResolversObject<{
+  expiresAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  token?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }>
 
@@ -12002,6 +12002,7 @@ export type GQLResolvers<ContextType = Context> = ResolversObject<{
   PageInfo?: GQLPageInfoResolvers<ContextType>
   PayToResult?: GQLPayToResultResolvers<ContextType>
   Person?: GQLPersonResolvers<ContextType>
+  PersonhoodHandoff?: GQLPersonhoodHandoffResolvers<ContextType>
   PinHistory?: GQLPinHistoryResolvers<ContextType>
   PinnableWork?: GQLPinnableWorkResolvers<ContextType>
   Price?: GQLPriceResolvers<ContextType>
@@ -12020,7 +12021,6 @@ export type GQLResolvers<ContextType = Context> = ResolversObject<{
   ResponseEdge?: GQLResponseEdgeResolvers<ContextType>
   SearchResultConnection?: GQLSearchResultConnectionResolvers<ContextType>
   SearchResultEdge?: GQLSearchResultEdgeResolvers<ContextType>
-  PersonhoodHandoff?: GQLPersonhoodHandoffResolvers<ContextType>
   SigningMessageResult?: GQLSigningMessageResultResolvers<ContextType>
   SkippedListItem?: GQLSkippedListItemResolvers<ContextType>
   SkippedListItemEdge?: GQLSkippedListItemEdgeResolvers<ContextType>


### PR DESCRIPTION
## Summary\n- add focused unit coverage for personhood handoff and carbon-based badge claim paths\n- add migration coverage for the carbon_based badge enum migration\n- include generated schema/type consistency from the repo pre-commit hook\n\n## Test\n- npx -y -p node@18 -p npm@9 npm run build\n- npx -y -p node@18 -p npm@9 npm run testcmd -- build/common/utils/__test__/personhoodMutations.test.js build/common/utils/__test__/carbonBasedBadgeMigration.test.js build/common/utils/__test__/communityWatchPublicQueries.test.js build/common/utils/__test__/communityWatchRemoveComment.test.js build/common/utils/__test__/reportResolver.test.js --runInBand --forceExit --coverage=false\n\n## Release note\nThis PR is intended to lift Codecov for release PR #4828 before merging develop to master.