### PR TITLE
feat: add async federation export trigger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matters-server",
-  "version": "5.22.1",
+  "version": "5.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matters-server",
-      "version": "5.22.1",
+      "version": "5.25.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@alchemy/aa-accounts": "^3.19.0",
@@ -17,6 +17,7 @@
         "@apollo/utils.keyvadapter": "^3.0.0",
         "@apollo/utils.keyvaluecache": "^3.0.0",
         "@aws-sdk/client-cloudwatch": "^3.758.0",
+        "@aws-sdk/client-lambda": "3.758.0",
         "@aws-sdk/client-s3": "^3.758.0",
         "@aws-sdk/client-sqs": "^3.758.0",
         "@aws-sdk/client-ssm": "^3.812.0",
@@ -1255,6 +1256,61 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/client-lambda": {
+      "version": "3.758.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.758.0.tgz",
+      "integrity": "sha512-k7L9fe0NN1v2Vhg4ofA1pb26gTdGVFdkA6XUQyElLEdcKzJzoYiQ60faNLuMPfH0zsKNvy/xKfNOD6DFZWjgEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.758.0",
+        "@aws-sdk/credential-provider-node": "3.758.0",
+        "@aws-sdk/middleware-host-header": "3.734.0",
+        "@aws-sdk/middleware-logger": "3.734.0",
+        "@aws-sdk/middleware-recursion-detection": "3.734.0",
+        "@aws-sdk/middleware-user-agent": "3.758.0",
+        "@aws-sdk/region-config-resolver": "3.734.0",
+        "@aws-sdk/types": "3.734.0",
+        "@aws-sdk/util-endpoints": "3.743.0",
+        "@aws-sdk/util-user-agent-browser": "3.734.0",
+        "@aws-sdk/util-user-agent-node": "3.758.0",
+        "@smithy/config-resolver": "^4.0.1",
+        "@smithy/core": "^3.1.5",
+        "@smithy/eventstream-serde-browser": "^4.0.1",
+        "@smithy/eventstream-serde-config-resolver": "^4.0.1",
+        "@smithy/eventstream-serde-node": "^4.0.1",
+        "@smithy/fetch-http-handler": "^5.0.1",
+        "@smithy/hash-node": "^4.0.1",
+        "@smithy/invalid-dependency": "^4.0.1",
+        "@smithy/middleware-content-length": "^4.0.1",
+        "@smithy/middleware-endpoint": "^4.0.6",
+        "@smithy/middleware-retry": "^4.0.7",
+        "@smithy/middleware-serde": "^4.0.2",
+        "@smithy/middleware-stack": "^4.0.1",
+        "@smithy/node-config-provider": "^4.0.1",
+        "@smithy/node-http-handler": "^4.0.3",
+        "@smithy/protocol-http": "^5.0.1",
+        "@smithy/smithy-client": "^4.1.6",
+        "@smithy/types": "^4.1.0",
+        "@smithy/url-parser": "^4.0.1",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.7",
+        "@smithy/util-defaults-mode-node": "^4.0.7",
+        "@smithy/util-endpoints": "^3.0.1",
+        "@smithy/util-middleware": "^4.0.1",
+        "@smithy/util-retry": "^4.0.1",
+        "@smithy/util-stream": "^4.1.2",
+        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-waiter": "^4.0.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@aws-sdk/client-s3": {
       "version": "3.758.0",
@@ -3841,19 +3897,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@dabh/diagnostics": {
@@ -7332,6 +7375,58 @@
         "node": ">=6"
       }
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.2.tgz",
+      "integrity": "sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.2.tgz",
+      "integrity": "sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.2.tgz",
+      "integrity": "sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.2.tgz",
+      "integrity": "sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
       "version": "3.0.2",
       "cpu": [
@@ -7341,6 +7436,19 @@
       "optional": true,
       "os": [
         "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz",
+      "integrity": "sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@multiformats/base-x": {
@@ -9919,34 +10027,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.8",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.9",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@types/accepts": {
       "version": "1.3.5",
       "dev": true,
@@ -11439,13 +11519,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -13151,13 +13224,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "license": "MIT"
@@ -13586,16 +13652,6 @@
       },
       "engines": {
         "node": ">=4.5.0"
-      }
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {
@@ -15271,6 +15327,20 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -20433,13 +20503,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "dev": true,
@@ -25287,60 +25350,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/ts-node": {
-      "version": "10.9.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-node/node_modules/acorn-walk": {
-      "version": "8.2.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "dev": true,
@@ -25902,13 +25911,6 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -26703,16 +26705,6 @@
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@apollo/utils.keyvadapter": "^3.0.0",
     "@apollo/utils.keyvaluecache": "^3.0.0",
     "@aws-sdk/client-cloudwatch": "^3.758.0",
+    "@aws-sdk/client-lambda": "3.758.0",
     "@aws-sdk/client-s3": "^3.758.0",
     "@aws-sdk/client-sqs": "^3.758.0",
     "@aws-sdk/client-ssm": "^3.812.0",

--- a/src/common/environment.ts
+++ b/src/common/environment.ts
@@ -299,6 +299,14 @@ export const environment = {
     process.env.MATTERS_COMPLAINT_AREA_ARTICLE_ID || '8079',
   federationExportTriggerMode:
     process.env.MATTERS_FEDERATION_EXPORT_TRIGGER_MODE || 'off',
+  federationExportLambdaFunctionName:
+    process.env.MATTERS_FEDERATION_EXPORT_LAMBDA_FUNCTION_NAME || '',
+  federationExportS3Bucket:
+    process.env.MATTERS_FEDERATION_EXPORT_S3_BUCKET || '',
+  federationExportS3Prefix:
+    process.env.MATTERS_FEDERATION_EXPORT_S3_PREFIX || '',
+  federationExportWebfDomain:
+    process.env.MATTERS_FEDERATION_WEBF_DOMAIN || '',
 }
 
 export const contract = {

--- a/src/connectors/__test__/federationExportService.test.ts
+++ b/src/connectors/__test__/federationExportService.test.ts
@@ -3,6 +3,7 @@ import {
   ARTICLE_STATE,
   USER_STATE,
 } from '#common/enums/index.js'
+import { environment } from '#common/environment.js'
 import { jest } from '@jest/globals'
 import {
   buildMattersArticleUrl,
@@ -94,6 +95,21 @@ const createKnexFirst = (row: any) => {
 }
 
 describe('federationExportService', () => {
+  const originalFederationExportLambdaFunctionName =
+    environment.federationExportLambdaFunctionName
+  const originalFederationExportS3Bucket = environment.federationExportS3Bucket
+  const originalFederationExportS3Prefix = environment.federationExportS3Prefix
+  const originalFederationExportWebfDomain = environment.federationExportWebfDomain
+
+  afterEach(() => {
+    environment.federationExportLambdaFunctionName =
+      originalFederationExportLambdaFunctionName
+    environment.federationExportS3Bucket = originalFederationExportS3Bucket
+    environment.federationExportS3Prefix = originalFederationExportS3Prefix
+    environment.federationExportWebfDomain = originalFederationExportWebfDomain
+    jest.clearAllMocks()
+  })
+
   test('builds canonical Matters article URLs from short hashes', () => {
     expect(
       buildMattersArticleUrl({
@@ -629,6 +645,168 @@ describe('federationExportService', () => {
       eligible: true,
       reason: 'eligible',
     })
+  })
+
+  test('queues an eligible strict export decision through async Lambda mode', async () => {
+    environment.federationExportLambdaFunctionName = 'federation-export-prod'
+    environment.federationExportS3Bucket = 'matters-fediverse-prod-bundles'
+    environment.federationExportS3Prefix = 'pilot'
+    environment.federationExportWebfDomain = 'matters.town'
+
+    const { knexRO } = createKnexRO([
+      {
+        articleId: '101',
+        articleState: ARTICLE_STATE.active,
+        shortHash: 'abc123',
+        title: '公開長文',
+        summary: '一篇公開長文摘要',
+        content: '<p>公開內容</p>',
+        tags: ['Fediverse'],
+        access: ARTICLE_ACCESS_TYPE.public,
+        circleId: null,
+        createdAt: new Date('2026-05-02T00:00:00.000Z'),
+        updatedAt: new Date('2026-05-02T01:00:00.000Z'),
+        authorId: '1',
+        userName: 'mashbean',
+        displayName: 'Mashbean',
+        authorDescription: 'Matters author',
+        authorState: USER_STATE.active,
+        ipnsKey: 'k51example',
+        authorFederationSetting: FEDERATION_AUTHOR_SETTING.enabled,
+        articleFederationSetting: FEDERATION_ARTICLE_SETTING.inherit,
+      },
+    ])
+    const { knex, query } = createKnexInsert([
+      {
+        id: '888',
+        articleId: '101',
+        actorId: '99',
+        trigger: FEDERATION_EXPORT_TRIGGER.publishArticle,
+        mode: FEDERATION_EXPORT_TRIGGER_MODE.lambdaAsync,
+        status: 'queued',
+        eligible: true,
+        reason: 'eligible',
+        authorSetting: FEDERATION_AUTHOR_SETTING.enabled,
+        articleSetting: FEDERATION_ARTICLE_SETTING.inherit,
+        effectiveArticleSetting: FEDERATION_ARTICLE_SETTING.inherit,
+        decisionReport: {
+          enforceFederationGate: true,
+          selected: 1,
+          eligible: 1,
+          skipped: 0,
+          decisions: [],
+        },
+      },
+    ])
+    const aws = { invokeAsync: (jest.fn() as any).mockResolvedValue(undefined) }
+    const service = new FederationExportService(
+      { knex, knexRO } as any,
+      aws
+    )
+
+    const row = await service.recordExportTriggerDecision({
+      articleId: '101',
+      actorId: '99',
+      trigger: FEDERATION_EXPORT_TRIGGER.publishArticle,
+      mode: FEDERATION_EXPORT_TRIGGER_MODE.lambdaAsync,
+    })
+
+    expect(query.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: FEDERATION_EXPORT_TRIGGER_MODE.lambdaAsync,
+        status: 'queued',
+        eligible: true,
+      })
+    )
+    expect(aws.invokeAsync).toHaveBeenCalledWith({
+      functionName: 'federation-export-prod',
+      payload: expect.objectContaining({
+        forceRun: true,
+        articleIds: ['101'],
+        siteDomain: environment.siteDomain,
+        webfDomain: 'matters.town',
+        enforceFederationGate: true,
+        dryRun: false,
+        includeFileContents: false,
+        outputS3Bucket: 'matters-fediverse-prod-bundles',
+        outputS3Prefix: 'pilot',
+      }),
+    })
+    expect(row.status).toBe('queued')
+  })
+
+  test('skips async Lambda invocation when the strict gate rejects an article', async () => {
+    environment.federationExportLambdaFunctionName = 'federation-export-prod'
+    environment.federationExportS3Bucket = 'matters-fediverse-prod-bundles'
+
+    const { knexRO } = createKnexRO([
+      {
+        articleId: '101',
+        articleState: ARTICLE_STATE.active,
+        shortHash: 'abc123',
+        title: '付費長文',
+        summary: '付費長文摘要',
+        content: '<p>付費內容</p>',
+        tags: ['Fediverse'],
+        access: ARTICLE_ACCESS_TYPE.paywall,
+        circleId: null,
+        createdAt: new Date('2026-05-02T00:00:00.000Z'),
+        updatedAt: new Date('2026-05-02T01:00:00.000Z'),
+        authorId: '1',
+        userName: 'mashbean',
+        displayName: 'Mashbean',
+        authorDescription: 'Matters author',
+        authorState: USER_STATE.active,
+        ipnsKey: 'k51example',
+        authorFederationSetting: FEDERATION_AUTHOR_SETTING.enabled,
+        articleFederationSetting: FEDERATION_ARTICLE_SETTING.inherit,
+      },
+    ])
+    const { knex, query } = createKnexInsert([
+      {
+        id: '889',
+        articleId: '101',
+        actorId: '99',
+        trigger: FEDERATION_EXPORT_TRIGGER.publishArticle,
+        mode: FEDERATION_EXPORT_TRIGGER_MODE.lambdaAsync,
+        status: 'skipped',
+        eligible: false,
+        reason: 'article_not_public',
+        authorSetting: FEDERATION_AUTHOR_SETTING.enabled,
+        articleSetting: FEDERATION_ARTICLE_SETTING.inherit,
+        effectiveArticleSetting: FEDERATION_ARTICLE_SETTING.inherit,
+        decisionReport: {
+          enforceFederationGate: true,
+          selected: 1,
+          eligible: 0,
+          skipped: 1,
+          decisions: [],
+        },
+      },
+    ])
+    const aws = { invokeAsync: (jest.fn() as any).mockResolvedValue(undefined) }
+    const service = new FederationExportService(
+      { knex, knexRO } as any,
+      aws
+    )
+
+    const row = await service.recordExportTriggerDecision({
+      articleId: '101',
+      actorId: '99',
+      trigger: FEDERATION_EXPORT_TRIGGER.publishArticle,
+      mode: FEDERATION_EXPORT_TRIGGER_MODE.lambdaAsync,
+    })
+
+    expect(query.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: FEDERATION_EXPORT_TRIGGER_MODE.lambdaAsync,
+        status: 'skipped',
+        eligible: false,
+        reason: 'article_not_public',
+      })
+    )
+    expect(aws.invokeAsync).not.toHaveBeenCalled()
+    expect(row.status).toBe('skipped')
   })
 
   test('rejects unsupported trigger modes before writing an event', async () => {

--- a/src/connectors/article/federationExportService.ts
+++ b/src/connectors/article/federationExportService.ts
@@ -6,6 +6,9 @@ import {
   ARTICLE_STATE,
   USER_STATE,
 } from '#common/enums/index.js'
+import { environment } from '#common/environment.js'
+import { getLogger } from '#common/logger.js'
+import { InvocationType, InvokeCommand, Lambda } from '@aws-sdk/client-lambda'
 
 export type FederationExportAuthor = {
   id: string
@@ -55,6 +58,7 @@ export const FEDERATION_EXPORT_TRIGGER = {
 export const FEDERATION_EXPORT_TRIGGER_MODE = {
   off: 'off',
   recordOnly: 'record_only',
+  lambdaAsync: 'lambda_async',
 } as const
 
 export type FederationAuthorSetting =
@@ -104,8 +108,8 @@ export type FederationExportEvent = {
   articleId: string
   actorId: string | null
   trigger: FederationExportTrigger
-  mode: typeof FEDERATION_EXPORT_TRIGGER_MODE.recordOnly
-  status: 'recorded'
+  mode: FederationExportTriggerMode
+  status: 'recorded' | 'queued' | 'skipped' | 'failed'
   eligible: boolean
   reason: FederationExportDecision['reason']
   authorSetting: FederationAuthorSetting | null
@@ -130,7 +134,14 @@ export type RecordFederationExportTriggerInput = {
   articleId: string
   actorId?: string | null
   trigger: FederationExportTrigger
-  mode?: typeof FEDERATION_EXPORT_TRIGGER_MODE.recordOnly
+  mode?: FederationExportTriggerMode
+}
+
+type FederationExportInvoker = {
+  invokeAsync: (input: {
+    functionName: string
+    payload: unknown
+  }) => Promise<void>
 }
 
 type ArticleExportQueryRow = {
@@ -260,10 +271,15 @@ export const buildMattersArticleUrl = ({
 export class FederationExportService {
   private knex: Knex
   private knexRO: Knex
+  private invoker: FederationExportInvoker
 
-  public constructor(connections: Connections) {
+  public constructor(
+    connections: Connections,
+    invoker: FederationExportInvoker = createFederationExportLambdaInvoker()
+  ) {
     this.knex = connections.knex
     this.knexRO = connections.knexRO
+    this.invoker = invoker
   }
 
   public async upsertAuthorFederationSetting({
@@ -424,7 +440,10 @@ export class FederationExportService {
     trigger,
     mode = FEDERATION_EXPORT_TRIGGER_MODE.recordOnly,
   }: RecordFederationExportTriggerInput): Promise<FederationExportEvent> {
-    if (mode !== FEDERATION_EXPORT_TRIGGER_MODE.recordOnly) {
+    if (
+      mode !== FEDERATION_EXPORT_TRIGGER_MODE.recordOnly &&
+      mode !== FEDERATION_EXPORT_TRIGGER_MODE.lambdaAsync
+    ) {
       throw new Error(`Unsupported federation export trigger mode: ${mode}`)
     }
 
@@ -445,6 +464,12 @@ export class FederationExportService {
       enforceFederationGate: true,
     })
     const [decision] = decisionReport.decisions
+    const status =
+      mode === FEDERATION_EXPORT_TRIGGER_MODE.recordOnly
+        ? 'recorded'
+        : decision.eligible
+          ? 'queued'
+          : 'skipped'
 
     const [row] = await this.knex('federation_export_event')
       .insert({
@@ -452,7 +477,7 @@ export class FederationExportService {
         actorId,
         trigger,
         mode,
-        status: 'recorded',
+        status,
         eligible: decision.eligible,
         reason: decision.reason,
         authorSetting: decision.authorSetting,
@@ -475,6 +500,105 @@ export class FederationExportService {
         'decisionReport',
       ])
 
+    if (
+      mode === FEDERATION_EXPORT_TRIGGER_MODE.lambdaAsync &&
+      decision.eligible
+    ) {
+      try {
+        await this.invokeFederationExportLambda({ articleId, eventId: row.id })
+      } catch (error) {
+        const [failedRow] = await this.knex('federation_export_event')
+          .where({ id: row.id })
+          .update({
+            status: 'failed',
+            updatedAt: this.knex.fn.now(),
+          })
+          .returning([
+            'id',
+            'articleId',
+            'actorId',
+            'trigger',
+            'mode',
+            'status',
+            'eligible',
+            'reason',
+            'authorSetting',
+            'articleSetting',
+            'effectiveArticleSetting',
+            'decisionReport',
+          ])
+
+        throw new Error(
+          `Failed to enqueue federation export event ${failedRow.id}: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        )
+      }
+    }
+
     return row
+  }
+
+  private async invokeFederationExportLambda({
+    articleId,
+    eventId,
+  }: {
+    articleId: string
+    eventId: string
+  }) {
+    if (!environment.federationExportLambdaFunctionName) {
+      throw new Error('MATTERS_FEDERATION_EXPORT_LAMBDA_FUNCTION_NAME is required')
+    }
+    if (!environment.federationExportS3Bucket) {
+      throw new Error('MATTERS_FEDERATION_EXPORT_S3_BUCKET is required')
+    }
+
+    await this.invoker.invokeAsync({
+      functionName: environment.federationExportLambdaFunctionName,
+      payload: {
+        forceRun: true,
+        articleIds: [articleId],
+        siteDomain: environment.siteDomain,
+        webfDomain: environment.federationExportWebfDomain,
+        enforceFederationGate: true,
+        dryRun: false,
+        includeFileContents: false,
+        outputS3Bucket: environment.federationExportS3Bucket,
+        outputS3Prefix:
+          environment.federationExportS3Prefix ||
+          `federation/events/${eventId}`,
+      },
+    })
+  }
+}
+
+const logger = getLogger('federation-export-trigger')
+
+/* istanbul ignore next */
+const createFederationExportLambdaInvoker = (): FederationExportInvoker => {
+  const lambda = new Lambda({
+    credentials: {
+      accessKeyId: environment.awsAccessId,
+      secretAccessKey: environment.awsAccessKey,
+    },
+    region: environment.awsRegion,
+  })
+
+  return {
+    invokeAsync: async ({ functionName, payload }) => {
+      const res = await lambda.send(
+        new InvokeCommand({
+          FunctionName: functionName,
+          InvocationType: InvocationType.Event,
+          Payload: Buffer.from(JSON.stringify(payload)),
+        })
+      )
+      logger.debug(
+        'Lambda async invoke %s with status %s and request-id %s',
+        functionName,
+        res.StatusCode,
+        res.$metadata.requestId
+      )
+    },
   }
 }

--- a/src/mutations/article/__test__/federationExportTrigger.test.ts
+++ b/src/mutations/article/__test__/federationExportTrigger.test.ts
@@ -92,6 +92,7 @@ describe('article federation export trigger scaffold', () => {
       articleId: '101',
       actorId: viewer.id,
       trigger: 'publish_article',
+      mode: FEDERATION_EXPORT_TRIGGER_MODE.recordOnly,
     })
   })
 
@@ -185,6 +186,7 @@ describe('article federation export trigger scaffold', () => {
       articleId: article.id,
       actorId: viewer.id,
       trigger: 'revise_article',
+      mode: FEDERATION_EXPORT_TRIGGER_MODE.recordOnly,
     })
   })
 })

--- a/src/mutations/article/editArticle.ts
+++ b/src/mutations/article/editArticle.ts
@@ -32,6 +32,7 @@ import { fromGlobalId, stripHtml } from '#common/utils/index.js'
 import {
   FEDERATION_EXPORT_TRIGGER,
   FEDERATION_EXPORT_TRIGGER_MODE,
+  FederationExportTriggerMode,
 } from '#connectors/article/federationExportService.js'
 import {
   AtomService,
@@ -243,14 +244,16 @@ const resolver: GQLMutationResolvers['editArticle'] = async (
       })
 
       if (
-        environment.federationExportTriggerMode ===
-        FEDERATION_EXPORT_TRIGGER_MODE.recordOnly
+        environment.federationExportTriggerMode !==
+        FEDERATION_EXPORT_TRIGGER_MODE.off
       ) {
         try {
           await federationExportService.recordExportTriggerDecision({
             articleId: article.id,
             actorId: viewer.id,
             trigger: FEDERATION_EXPORT_TRIGGER.reviseArticle,
+            mode:
+              environment.federationExportTriggerMode as FederationExportTriggerMode,
           })
         } catch (error) {
           logger.error('Failed to record federation export trigger decision', {

--- a/src/mutations/article/publishArticle.ts
+++ b/src/mutations/article/publishArticle.ts
@@ -21,6 +21,7 @@ import { fromGlobalId } from '#common/utils/index.js'
 import {
   FEDERATION_EXPORT_TRIGGER,
   FEDERATION_EXPORT_TRIGGER_MODE,
+  FederationExportTriggerMode,
 } from '#connectors/article/federationExportService.js'
 import { AtomService } from '#connectors/index.js'
 import { createRequire } from 'node:module'
@@ -151,8 +152,8 @@ const resolver: GQLMutationResolvers['publishArticle'] = async (
     })
 
     if (
-      environment.federationExportTriggerMode ===
-        FEDERATION_EXPORT_TRIGGER_MODE.recordOnly &&
+      environment.federationExportTriggerMode !==
+        FEDERATION_EXPORT_TRIGGER_MODE.off &&
       publishedDraft.articleId
     ) {
       try {
@@ -160,6 +161,8 @@ const resolver: GQLMutationResolvers['publishArticle'] = async (
           articleId: publishedDraft.articleId,
           actorId: viewer.id,
           trigger: FEDERATION_EXPORT_TRIGGER.publishArticle,
+          mode:
+            environment.federationExportTriggerMode as FederationExportTriggerMode,
         })
       } catch (error) {
         logger.error('Failed to record federation export trigger decision', {


### PR DESCRIPTION
## Summary
- add `lambda_async` federation export trigger mode for publish/edit paths
- keep `off` and `record_only` behavior unchanged; `off` still means no trigger call
- enforce strict public-only + author/article federation gate before Lambda invocation
- invoke federation-export Lambda asynchronously only for eligible rows, with S3 output required
- record `queued`, `skipped`, or `failed` status in `federation_export_event`

## Safety
- this PR does not enable production outbound by itself
- rollback remains setting `MATTERS_FEDERATION_EXPORT_TRIGGER_MODE=record_only` or `off`
- missing Lambda function name or S3 bucket marks the event failed and is caught by existing publish/edit error handling
- private/paywalled/non-opt-in articles are recorded as skipped and do not invoke Lambda

## Required env for lambda_async
- `MATTERS_FEDERATION_EXPORT_TRIGGER_MODE=lambda_async`
- `MATTERS_FEDERATION_EXPORT_LAMBDA_FUNCTION_NAME`
- `MATTERS_FEDERATION_EXPORT_S3_BUCKET`
- optional: `MATTERS_FEDERATION_EXPORT_S3_PREFIX`
- optional: `MATTERS_FEDERATION_WEBF_DOMAIN`

## Verification
- `npm run build`
- `npm run lint`
- `npx -p node@18 node --experimental-vm-modules --no-experimental-fetch node_modules/.bin/jest build/connectors/__test__/federationExportService.test.js build/mutations/article/__test__/federationExportTrigger.test.js --runInBand --forceExit`

## Notes
- local Node is v24, so Jest was run through temporary Node 18 to match repo engine.
- `npm install` reported existing audit findings; no audit fix was run to avoid unrelated dependency churn.
