### PR TITLE
fix(report): allow community_watch_* reasons in DB check constraint

### DIFF
--- a/db/migrations/20260613000000_alter_report_reason_add_community_watch.js
+++ b/db/migrations/20260613000000_alter_report_reason_add_community_watch.js
@@ -1,0 +1,45 @@
+// The GraphQL `ReportReason` enum declares `community_watch_porn_ad` and
+// `community_watch_spam_ad`, but the `report.reason` check constraint (added in
+// 20231221154057_alter_report_add_reason) was never updated to allow them.
+// submitReport inserts the raw reason, so submitting either value failed with
+// `report_reason_check` violation. This realigns the DB constraint with the
+// schema. communityWatchRemoveComment is unaffected (it inserts
+// `illegal_advertising`).
+const constraint = 'report_reason_check'
+const withCommunityWatch = [
+  'tort',
+  'illegal_advertising',
+  'discrimination_insult_hatred',
+  'pornography_involving_minors',
+  'other',
+  'community_watch_porn_ad',
+  'community_watch_spam_ad',
+]
+const original = [
+  'tort',
+  'illegal_advertising',
+  'discrimination_insult_hatred',
+  'pornography_involving_minors',
+  'other',
+]
+
+const toCheck = (values) =>
+  values.map((v) => `'${v}'`).join(', ')
+
+export const up = async (knex) => {
+  await knex.raw(`ALTER TABLE report DROP CONSTRAINT IF EXISTS ${constraint}`)
+  await knex.raw(
+    `ALTER TABLE report ADD CONSTRAINT ${constraint} CHECK (reason IN (${toCheck(
+      withCommunityWatch
+    )}))`
+  )
+}
+
+export const down = async (knex) => {
+  await knex.raw(`ALTER TABLE report DROP CONSTRAINT IF EXISTS ${constraint}`)
+  await knex.raw(
+    `ALTER TABLE report ADD CONSTRAINT ${constraint} CHECK (reason IN (${toCheck(
+      original
+    )}))`
+  )
+}


### PR DESCRIPTION
## Problem

The GraphQL `ReportReason` enum (src/types/system.ts) declares `community_watch_porn_ad` and `community_watch_spam_ad`, but the `report.reason` DB check constraint (`report_reason_check`, from `20231221154057_alter_report_add_reason`) only allows the original five values. `submitReport` inserts the raw reason, so **any report submitted with either community_watch value fails in production**:

```
new row for relation "report" violates check constraint "report_reason_check"
(INTERNAL_SERVER_ERROR)
```

Surfaced live by the coastguard bot's Tier-1 reports (it sent `community_watch_porn_ad` and every insert was rejected).

## Fix

Migration realigns the DB check constraint with the schema — adds the two community_watch values. The enum is the contract; the constraint had drifted.

`communityWatchRemoveComment` is unaffected: it syncs `illegal_advertising` (not these values) into the report table.

## Notes / follow-up

- The OSS reports view (`src/queries/system/oss/reports.ts`) filters `reason = 'illegal_advertising'`; community_watch_* reports won't appear there. If those should surface in that view, that's a separate product decision.
- Alternative considered: map community_watch_* → illegal_advertising in the `submitReport` resolver, or drop them from the submittable enum. Chose the migration since the enum already advertises them as valid `ReportReason` values with doc comments — the DB was simply stale.

## Test plan

- [ ] Run migration on staging; `submitReport` with `community_watch_porn_ad`/`community_watch_spam_ad` succeeds
- [ ] `communityWatchRemoveComment` still works (illegal_advertising)
- [ ] `down` migration restores the original five-value constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)