### PR TITLE
[codex] Add Node 24 compatibility CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: boolean
         default: false
+      node_version:
+        description: 'Node.js version for install, lint, test, and build'
+        required: false
+        type: string
+        default: '18'
     outputs:
       environment:
         description: 'The environment that was processed'
@@ -54,19 +59,19 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: ${{ inputs.node_version }}
 
       - name: Cache NPM dependencies
         uses: actions/cache@v4
         id: node_modules_cache
         with:
           path: node_modules
-          key: ${{ runner.os }}-v18-npm-v3-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-v${{ inputs.node_version }}-npm-v3-${{ hashFiles('package-lock.json') }}
 
       - name: Install Dependencies
         if: steps.node_modules_cache.outputs.cache-hit != 'true'
@@ -83,7 +88,6 @@ jobs:
         if: inputs.skip_tests != true
         run: npm run test
         env:
-          NODE_OPTIONS: '--no-experimental-fetch'
           CODECOV_TOKEN: de5ab681-0837-4a24-b614-0a29225a7e4c
           MATTERS_ENV: test
           MATTERS_LOGGING_LEVEL: critical

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,16 @@ on:
 
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - '18'
+          - '24'
     uses: ./.github/workflows/build.yml
     with:
       environment: ''
       skip_tests: false
       skip_docker: true
+      node_version: ${{ matrix.node-version }}
     secrets: {}

--- a/bin/jest.cjs
+++ b/bin/jest.cjs
@@ -1,0 +1,21 @@
+const { spawnSync } = require('node:child_process')
+
+const major = Number.parseInt(process.versions.node.split('.')[0], 10)
+const args = ['--experimental-vm-modules']
+
+if (major < 24) {
+  args.push('--no-experimental-fetch')
+}
+
+args.push('node_modules/.bin/jest', ...process.argv.slice(2))
+
+const result = spawnSync(process.execPath, args, {
+  stdio: 'inherit',
+  env: process.env,
+})
+
+if (result.error) {
+  throw result.error
+}
+
+process.exit(result.status ?? 1)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -211,6 +211,11 @@ export default [
   },
   {
     files: ['**/*.cjs'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
     rules: {
       '@typescript-eslint/no-require-imports': 'off',
       'import/no-commonjs': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matters-server",
-  "version": "5.22.1",
+  "version": "5.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matters-server",
-      "version": "5.22.1",
+      "version": "5.25.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@alchemy/aa-accounts": "^3.19.0",
@@ -144,7 +144,7 @@
         "rimraf": "^5.0.1"
       },
       "engines": {
-        "node": ">=18.18.0 <19.0.0"
+        "node": ">=18.18.0 <19.0.0 || >=24.0.0 <25.0.0"
       },
       "optionalDependencies": {
         "bufferutil": "^4.0.7",
@@ -3843,19 +3843,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@dabh/diagnostics": {
       "version": "2.0.2",
       "license": "MIT",
@@ -7332,6 +7319,58 @@
         "node": ">=6"
       }
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.2.tgz",
+      "integrity": "sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.2.tgz",
+      "integrity": "sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.2.tgz",
+      "integrity": "sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.2.tgz",
+      "integrity": "sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
       "version": "3.0.2",
       "cpu": [
@@ -7341,6 +7380,19 @@
       "optional": true,
       "os": [
         "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz",
+      "integrity": "sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@multiformats/base-x": {
@@ -9919,34 +9971,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.8",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.9",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@types/accepts": {
       "version": "1.3.5",
       "dev": true,
@@ -11439,13 +11463,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -13151,13 +13168,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "license": "MIT"
@@ -13586,16 +13596,6 @@
       },
       "engines": {
         "node": ">=4.5.0"
-      }
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {
@@ -15271,6 +15271,20 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -20433,13 +20447,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "dev": true,
@@ -25287,60 +25294,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/ts-node": {
-      "version": "10.9.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-node/node_modules/acorn-walk": {
-      "version": "8.2.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "dev": true,
@@ -25902,13 +25855,6 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -26703,16 +26649,6 @@
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "main": "build/index.js",
   "engines": {
-    "node": ">=18.18.0 <19.0.0"
+    "node": ">=18.18.0 <19.0.0 || >=24.0.0 <25.0.0"
   },
   "license": "Apache-2.0",
   "scripts": {
@@ -21,7 +21,7 @@
     "watch:server": "nodemon build/index.js",
     "start": "node build/index.js",
     "start:dev": "npm-run-all clean build --parallel watch:build watch:server --print-label",
-    "testcmd": "MATTERS_ENV=test node --experimental-vm-modules --no-experimental-fetch node_modules/.bin/jest",
+    "testcmd": "MATTERS_ENV=test node bin/jest.cjs",
     "test:connectors": "npm run testcmd -- build/connectors/ --forceExit --coverageDirectory coverage/connectors",
     "test:utils": "npm run testcmd -- build/common/utils/ --coverageDirectory coverage/utils",
     "test:routes": "npm run testcmd -- build/routes/ --forceExit --coverageDirectory coverage/routes",


### PR DESCRIPTION
## Summary

Adds a Node 24 compatibility lane to the existing reusable build workflow while keeping the default runtime on Node 18.

Changes:

- widens `engines.node` to allow Node 18 and Node 24
- adds a `node_version` input to `.github/workflows/build.yml`, defaulting to `18`
- runs the PR test workflow with a Node 18 and Node 24 matrix
- updates the workflow checkout action to `actions/checkout@v4`
- refreshes lockfile metadata with npm 11 so `npm ci` can run under Node 24

## Why

This is the compatibility PR only. Deploy workflows that do not pass `node_version` still use the default Node 18 path, and the Dockerfile remains on `node:18-alpine`. That preserves the current production rollback line while allowing CI to prove Node 24 compatibility.

## Validation

- `npx -p node@24 -p npm@11 npm ci`, passed with an existing `@matters/matters-editor@0.3.0-alpha.4` engine warning
- `npx -y node@24 -e "import('bcrypt').then(...)"`, confirmed bcrypt loads
- `npx -y node@24 node_modules/typescript/bin/tsc -p .`, passed
- `npx -p node@24 -p npm@11 npm run lint`, passed
- `npx -p node@18 -p npm@10 npm ci --ignore-scripts`, passed as lockfile rollback-line check

Full test execution is left to GitHub Actions because the workflow provides Redis, Postgres, and stripe-mock services.

## Known follow-up

`@matters/matters-editor@0.3.0-alpha.4` declares `node >=18.19 <19.0`, so npm emits an engine warning under Node 24. It is not a hard install failure. The shared-package follow-up should publish or consume a Node 24-compatible editor package before production runtime cutover.

## Rollback

Revert this PR, or leave it merged and omit `node_version` from deployment workflow calls. The reusable workflow defaults to Node 18, and the Dockerfile still uses Node 18.
