### PR TITLE
feat(oss): rank content lists by spam score (last-N-days triage)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -968,6 +968,9 @@ enum ArticlesSort {
   mostComments
   mostDonations
   mostReadTime
+
+  """Order by spam score from high to low (only scored articles)"""
+  mostSpam
 }
 
 input CampaignInput {
@@ -2437,8 +2440,8 @@ type TranslatedAnnouncement {
 
 type OSS {
   users(input: ConnectionArgs!): UserConnection!
-  comments(input: ConnectionArgs!): CommentConnection!
-  moments(input: ConnectionArgs!): MomentConnection!
+  comments(input: OSSCommentsInput!): CommentConnection!
+  moments(input: OSSMomentsInput!): MomentConnection!
   articles(input: OSSArticlesInput!): ArticleConnection!
   tags(input: TagsInput!): TagConnection!
   oauthClients(input: ConnectionArgs!): OAuthClientConnection!
@@ -3026,6 +3029,32 @@ input OSSArticlesFilterInput {
   isSpam: Boolean
   datetimeRange: DatetimeRangeInput
   searchKey: String
+}
+
+"""Sort options shared by OSS comment/moment lists for spam triage."""
+enum OSSContentSpamSort {
+  newest
+
+  """Order by spam score from high to low (only scored items)"""
+  mostSpam
+}
+
+input OSSSpamDatetimeFilterInput {
+  datetimeRange: DatetimeRangeInput
+}
+
+input OSSCommentsInput {
+  after: String
+  first: Int
+  sort: OSSContentSpamSort = newest
+  filter: OSSSpamDatetimeFilterInput
+}
+
+input OSSMomentsInput {
+  after: String
+  first: Int
+  sort: OSSContentSpamSort = newest
+  filter: OSSSpamDatetimeFilterInput
 }
 
 enum CacheControlScope {

--- a/src/connectors/commentService.ts
+++ b/src/connectors/commentService.ts
@@ -81,6 +81,9 @@ export class CommentService extends BaseService<Comment> {
     super('comment', connections)
   }
 
+  // Query builder for the OSS comment list (sortable / filterable).
+  public findComments = () => this.knexRO(this.table).select('*')
+
   public findActiveCommunityWatchAction = async (
     commentId: string
   ): Promise<CommunityWatchAction | null> => {

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -729,6 +729,7 @@ export type GQLArticlesSort =
   | 'mostComments'
   | 'mostDonations'
   | 'mostReadTime'
+  | 'mostSpam'
   | 'newest'
 
 /** This type contains type, link and related data of an asset. */
@@ -3131,7 +3132,7 @@ export type GQLOssBadgedUsersArgs = {
 }
 
 export type GQLOssCommentsArgs = {
-  input: GQLConnectionArgs
+  input: GQLOssCommentsInput
 }
 
 export type GQLOssIcymiTopicsArgs = {
@@ -3143,7 +3144,7 @@ export type GQLOssMomentFeedUsersArgs = {
 }
 
 export type GQLOssMomentsArgs = {
-  input: GQLConnectionArgs
+  input: GQLOssMomentsInput
 }
 
 export type GQLOssOauthClientsArgs = {
@@ -3189,6 +3190,27 @@ export type GQLOssArticlesInput = {
   filter?: InputMaybe<GQLOssArticlesFilterInput>
   first?: InputMaybe<Scalars['Int']['input']>
   sort?: InputMaybe<GQLArticlesSort>
+}
+
+export type GQLOssCommentsInput = {
+  after?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<GQLOssSpamDatetimeFilterInput>
+  first?: InputMaybe<Scalars['Int']['input']>
+  sort?: InputMaybe<GQLOssContentSpamSort>
+}
+
+/** Sort options shared by OSS comment/moment lists for spam triage. */
+export type GQLOssContentSpamSort = 'mostSpam' | 'newest'
+
+export type GQLOssMomentsInput = {
+  after?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<GQLOssSpamDatetimeFilterInput>
+  first?: InputMaybe<Scalars['Int']['input']>
+  sort?: InputMaybe<GQLOssContentSpamSort>
+}
+
+export type GQLOssSpamDatetimeFilterInput = {
+  datetimeRange?: InputMaybe<GQLDatetimeRangeInput>
 }
 
 export type GQLOssReportsFilter = {
@@ -6000,6 +6022,10 @@ export type GQLResolversTypes = ResolversObject<{
   >
   OSSArticlesFilterInput: GQLOssArticlesFilterInput
   OSSArticlesInput: GQLOssArticlesInput
+  OSSCommentsInput: GQLOssCommentsInput
+  OSSContentSpamSort: GQLOssContentSpamSort
+  OSSMomentsInput: GQLOssMomentsInput
+  OSSSpamDatetimeFilterInput: GQLOssSpamDatetimeFilterInput
   OSSReportsFilter: GQLOssReportsFilter
   OSSReportsInput: GQLOssReportsInput
   Oauth1CredentialInput: GQLOauth1CredentialInput
@@ -6717,6 +6743,9 @@ export type GQLResolversParentTypes = ResolversObject<{
   }
   OSSArticlesFilterInput: GQLOssArticlesFilterInput
   OSSArticlesInput: GQLOssArticlesInput
+  OSSCommentsInput: GQLOssCommentsInput
+  OSSMomentsInput: GQLOssMomentsInput
+  OSSSpamDatetimeFilterInput: GQLOssSpamDatetimeFilterInput
   OSSReportsFilter: GQLOssReportsFilter
   OSSReportsInput: GQLOssReportsInput
   Oauth1CredentialInput: GQLOauth1CredentialInput

--- a/src/queries/system/oss/articles.ts
+++ b/src/queries/system/oss/articles.ts
@@ -93,6 +93,12 @@ export const articles: GQLOssResolvers['articles'] = async (
       orderBy = { column, order: 'desc' }
       break
     }
+    case 'mostSpam': {
+      // rank scored articles by spam score, high to low
+      query = query.whereNotNull('spam_score')
+      orderBy = { column: 'spamScore', order: 'desc' }
+      break
+    }
     default:
       break
   }

--- a/src/queries/system/oss/comments.ts
+++ b/src/queries/system/oss/comments.ts
@@ -1,26 +1,31 @@
 import type { GQLOssResolvers } from '#definitions/index.js'
 
-import {
-  connectionFromPromisedArray,
-  fromConnectionArgs,
-} from '#common/utils/index.js'
+import { connectionFromQuery } from '#common/utils/index.js'
 
 export const comments: GQLOssResolvers['comments'] = async (
   _,
   { input },
   { dataSources: { commentService } }
 ) => {
-  const { take, skip } = fromConnectionArgs(input)
+  let query = commentService.findComments()
 
-  const totalCount = await commentService.baseCount()
+  const range = input?.filter?.datetimeRange
+  if (range?.start) {
+    query = query.where('created_at', '>=', range.start)
+  }
+  if (range?.end) {
+    query = query.where('created_at', '<=', range.end)
+  }
 
-  return connectionFromPromisedArray(
-    commentService.baseFind({
-      skip,
-      take,
-      orderBy: [{ column: 'id', order: 'desc' }],
-    }),
-    input,
-    totalCount
-  )
+  let orderBy: { column: string; order: 'asc' | 'desc' } = {
+    column: 'id',
+    order: 'desc',
+  }
+  if (input?.sort === 'mostSpam') {
+    // rank scored comments by spam score, high to low
+    query = query.whereNotNull('spam_score')
+    orderBy = { column: 'spamScore', order: 'desc' }
+  }
+
+  return connectionFromQuery({ query, args: input, orderBy })
 }

--- a/src/queries/system/oss/moments.ts
+++ b/src/queries/system/oss/moments.ts
@@ -7,9 +7,25 @@ export const moments: GQLOssResolvers['moments'] = async (
   { input },
   { dataSources: { momentService } }
 ) => {
-  return connectionFromQuery({
-    query: momentService.findMoments(),
-    orderBy: { column: 'id', order: 'desc' },
-    args: input,
-  })
+  let query = momentService.findMoments()
+
+  const range = input?.filter?.datetimeRange
+  if (range?.start) {
+    query = query.where('created_at', '>=', range.start)
+  }
+  if (range?.end) {
+    query = query.where('created_at', '<=', range.end)
+  }
+
+  let orderBy: { column: string; order: 'asc' | 'desc' } = {
+    column: 'id',
+    order: 'desc',
+  }
+  if (input?.sort === 'mostSpam') {
+    // rank scored moments by spam score, high to low
+    query = query.whereNotNull('spam_score')
+    orderBy = { column: 'spamScore', order: 'desc' }
+  }
+
+  return connectionFromQuery({ query, args: input, orderBy })
 }

--- a/src/types/__test__/2/system.test.ts
+++ b/src/types/__test__/2/system.test.ts
@@ -1907,7 +1907,7 @@ describe('setWritingAdStatus', () => {
 
 describe('query OSS moments', () => {
   const QUERY_MOMENTS = `
-    query($input: ConnectionArgs!) {
+    query($input: OSSMomentsInput!) {
       oss {
         moments(input: $input) {
           totalCount

--- a/src/types/__test__/2/system.test.ts
+++ b/src/types/__test__/2/system.test.ts
@@ -1975,4 +1975,90 @@ describe('query OSS moments', () => {
 
     expect(errors).toBeDefined()
   })
+
+  test('query moments by spam score within a datetime range', async () => {
+    const serverAdmin = await testClient({
+      isAuth: true,
+      isAdmin: true,
+      connections,
+    })
+    const { data, errors } = await serverAdmin.executeOperation({
+      query: QUERY_MOMENTS,
+      variables: {
+        input: {
+          first: 10,
+          sort: 'mostSpam',
+          filter: { datetimeRange: { start: '2020-01-01T00:00:00.000Z' } },
+        },
+      },
+    })
+    expect(errors).toBeUndefined()
+    expect(_get(data, 'oss.moments.edges')).toBeDefined()
+  })
+})
+
+describe('query OSS comments', () => {
+  const QUERY_COMMENTS = `
+    query ($input: OSSCommentsInput!) {
+      oss {
+        comments(input: $input) {
+          totalCount
+          edges {
+            node {
+              id
+              content
+              createdAt
+            }
+          }
+        }
+      }
+    }
+  `
+
+  test('query comments successfully (newest)', async () => {
+    const serverAdmin = await testClient({
+      isAuth: true,
+      isAdmin: true,
+      connections,
+    })
+    const { data, errors } = await serverAdmin.executeOperation({
+      query: QUERY_COMMENTS,
+      variables: { input: { first: 10 } },
+    })
+    expect(errors).toBeUndefined()
+    expect(_get(data, 'oss.comments.edges')).toBeDefined()
+  })
+
+  test('query comments by spam score within a datetime range', async () => {
+    const serverAdmin = await testClient({
+      isAuth: true,
+      isAdmin: true,
+      connections,
+    })
+    const { data, errors } = await serverAdmin.executeOperation({
+      query: QUERY_COMMENTS,
+      variables: {
+        input: {
+          first: 10,
+          sort: 'mostSpam',
+          filter: { datetimeRange: { start: '2020-01-01T00:00:00.000Z' } },
+        },
+      },
+    })
+    expect(errors).toBeUndefined()
+    expect(_get(data, 'oss.comments.edges')).toBeDefined()
+  })
+
+  test('non-admin user cannot query comments', async () => {
+    const serverUser = await testClient({
+      isAuth: true,
+      isAdmin: false,
+      connections,
+    })
+    const { errors } = await serverUser.executeOperation({
+      query: QUERY_COMMENTS,
+      variables: { input: { first: 10 } },
+    })
+    expect(errors).toBeDefined()
+  })
 })

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -661,5 +661,7 @@ export default /* GraphQL */ `
     mostComments
     mostDonations
     mostReadTime
+    "Order by spam score from high to low (only scored articles)"
+    mostSpam
   }
 `

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -144,8 +144,8 @@ export default /* GraphQL */ `
 
   type OSS @cacheControl(maxAge: ${CACHE_TTL.INSTANT}) {
     users(input: ConnectionArgs!): UserConnection!
-    comments(input: ConnectionArgs!): CommentConnection!
-    moments(input: ConnectionArgs!): MomentConnection!
+    comments(input: OSSCommentsInput!): CommentConnection!
+    moments(input: OSSMomentsInput!): MomentConnection!
     articles(input: OSSArticlesInput!): ArticleConnection!
     tags(input: TagsInput!): TagConnection!
     oauthClients(input: ConnectionArgs!): OAuthClientConnection!
@@ -729,6 +729,31 @@ export default /* GraphQL */ `
     isSpam: Boolean
     datetimeRange: DatetimeRangeInput
     searchKey: String
+  }
+
+  "Sort options shared by OSS comment/moment lists for spam triage."
+  enum OSSContentSpamSort {
+    newest
+    "Order by spam score from high to low (only scored items)"
+    mostSpam
+  }
+
+  input OSSSpamDatetimeFilterInput {
+    datetimeRange: DatetimeRangeInput
+  }
+
+  input OSSCommentsInput {
+    after: String
+    first: Int @constraint(min: 0)
+    sort: OSSContentSpamSort = newest
+    filter: OSSSpamDatetimeFilterInput
+  }
+
+  input OSSMomentsInput {
+    after: String
+    first: Int @constraint(min: 0)
+    sort: OSSContentSpamSort = newest
+    filter: OSSSpamDatetimeFilterInput
   }
 
   ####################


### PR DESCRIPTION
## 背景

OSS 後台要能「一週內垃圾機率由高到低」檢視文章/動態/留言。但 comment/moment 清單原本只支援 `id desc`、article 清單沒有依 spam 分數排序。

## 變更

- `ArticlesSort.mostSpam`：依 `spam_score` 由高到低排序（只含已評分文章）。
- 新增 `OSSCommentsInput` / `OSSMomentsInput`：`sort`（`OSSContentSpamSort`：newest / mostSpam）＋ `filter.datetimeRange`（近 7 天窗）。
- comments / moments resolver 改用 `connectionFromQuery` 可排序/篩選；新增 `commentService.findComments()` 查詢建構子。
- `mostSpam` 以 `whereNotNull(spam_score)` 排除未評分項，避免 NULLS-first 排序污染排行。
- schema 產物（schema.graphql / schema.d.ts）手動同步（本機 codegen 版本與 committed 版本漂移，避免無關重排）。

## 備註

- 未加 DB 級排序測試（需帶 spam_score 的 fixture）；查詢建構簡單，建議於 staging 實測。
- 對應前端 PR：thematters/matters-oss `feat/oss-spam-ranking`。
- **本 PR 需先於前端部署**（前端送出新的 input 欄位，舊 schema 會拒）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)