### PR TITLE
feat(campaign): enableQuoteWall flag to gate the quote wall

### DIFF
--- a/db/migrations/20260617000000_alter_campaign_to_add_enable_quote_wall.js
+++ b/db/migrations/20260617000000_alter_campaign_to_add_enable_quote_wall.js
@@ -1,0 +1,16 @@
+const table = 'campaign'
+
+export const up = async (knex) => {
+  await knex.schema.alterTable(table, (t) => {
+    // whether this campaign exposes a quote wall (post-to-wall affordance).
+    // opt-in: defaults to false; 七日書 campaigns are enabled via data backfill
+    // and, going forward, via the OSS campaign editor toggle.
+    t.boolean('enable_quote_wall').notNullable().defaultTo(false)
+  })
+}
+
+export const down = async (knex) => {
+  await knex.schema.alterTable(table, (t) => {
+    t.dropColumn('enable_quote_wall')
+  })
+}

--- a/db/migrations/20260617000100_backfill_enable_quote_wall_seven_day_book.js
+++ b/db/migrations/20260617000100_backfill_enable_quote_wall_seven_day_book.js
@@ -1,0 +1,17 @@
+const table = 'campaign'
+
+// One-time backfill: enable the quote wall for existing 七日書 campaigns.
+// The name match is used here ONCE (at migration time) only; from now on the
+// flag is data-driven (toggled in the OSS campaign editor), so renaming a
+// campaign no longer affects quote-wall eligibility.
+export const up = async (knex) => {
+  await knex(table).where('name', 'like', '%七日書%').update({
+    enable_quote_wall: true,
+  })
+}
+
+export const down = async (knex) => {
+  await knex(table).where('name', 'like', '%七日書%').update({
+    enable_quote_wall: false,
+  })
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -1005,6 +1005,9 @@ input PutWritingChallengeInput {
   managers: [ID!]
   showOther: Boolean
   showAd: Boolean
+
+  """enable the quote wall (post-to-wall) for this campaign"""
+  enableQuoteWall: Boolean
 }
 
 input ApplyCampaignInput {
@@ -1093,6 +1096,9 @@ type WritingChallenge implements Node & Campaign & Channel {
   isManager: Boolean!
   showOther: Boolean!
   showAd: Boolean!
+
+  """whether this campaign exposes a quote wall (post-to-wall affordance)"""
+  enableQuoteWall: Boolean!
   oss: CampaignOSS!
 
   """Quotes on this campaign's quote wall (public)."""
@@ -4478,7 +4484,9 @@ input QuotesInput {
   first: Int
   after: String
 
-  """random sampling for wall display; refetch to shuffle. when true, after is ignored"""
+  """
+  random sampling for wall display; refetch to shuffle. when true, after is ignored
+  """
   random: Boolean
 }
 

--- a/src/connectors/campaignService.ts
+++ b/src/connectors/campaignService.ts
@@ -70,6 +70,7 @@ export class CampaignService {
     exclusive,
     showOther,
     showAd,
+    enableQuoteWall,
   }: {
     name: string
     description?: string
@@ -85,6 +86,7 @@ export class CampaignService {
     exclusive?: boolean
     showOther?: boolean
     showAd?: boolean
+    enableQuoteWall?: boolean
   }) =>
     this.models.create({
       table: 'campaign',
@@ -109,6 +111,7 @@ export class CampaignService {
         exclusive: exclusive ?? false,
         showOther,
         showAd,
+        enableQuoteWall,
       },
     })
 

--- a/src/definitions/campaign.d.ts
+++ b/src/definitions/campaign.d.ts
@@ -25,6 +25,7 @@ export interface Campaign {
   updatedAt: Date
   showOther: boolean
   showAd: boolean
+  enableQuoteWall: boolean
 }
 
 export interface CampaignStage {

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -3522,6 +3522,8 @@ export type GQLPutWritingChallengeInput = {
   channelEnabled?: InputMaybe<Scalars['Boolean']['input']>
   cover?: InputMaybe<Scalars['ID']['input']>
   description?: InputMaybe<Array<GQLTranslationInput>>
+  /** enable the quote wall (post-to-wall) for this campaign */
+  enableQuoteWall?: InputMaybe<Scalars['Boolean']['input']>
   /** exclude articles of this campaign in topic channels and newest */
   exclusive?: InputMaybe<Scalars['Boolean']['input']>
   featuredDescription?: InputMaybe<Array<GQLTranslationInput>>
@@ -5169,6 +5171,8 @@ export type GQLWritingChallenge = GQLCampaign &
     discussion: GQLCommentConnection
     /** Discussion (include replies) count of this campaign. */
     discussionCount: Scalars['Int']['output']
+    /** whether this campaign exposes a quote wall (post-to-wall affordance) */
+    enableQuoteWall: Scalars['Boolean']['output']
     featuredDescription: Scalars['String']['output']
     id: Scalars['ID']['output']
     isManager: Scalars['Boolean']['output']
@@ -12079,6 +12083,11 @@ export type GQLWritingChallengeResolvers<
     RequireFields<GQLWritingChallengeDiscussionArgs, 'input'>
   >
   discussionCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  enableQuoteWall?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
   featuredDescription?: Resolver<
     GQLResolversTypes['String'],
     ParentType,

--- a/src/mutations/campaign/putWritingChallenge.ts
+++ b/src/mutations/campaign/putWritingChallenge.ts
@@ -42,6 +42,7 @@ const resolver: GQLMutationResolvers['putWritingChallenge'] = async (
       managers: managerGlobalIds,
       showOther,
       showAd,
+      enableQuoteWall,
     },
   },
   {
@@ -155,6 +156,7 @@ const resolver: GQLMutationResolvers['putWritingChallenge'] = async (
       exclusive,
       showOther,
       showAd,
+      enableQuoteWall,
     })
 
     // invalidate campaign list cache
@@ -210,6 +212,7 @@ const resolver: GQLMutationResolvers['putWritingChallenge'] = async (
       exclusive,
       showOther,
       showAd,
+      enableQuoteWall,
     }
 
     campaign = await atomService.update({

--- a/src/mutations/quote/putQuote.ts
+++ b/src/mutations/quote/putQuote.ts
@@ -102,6 +102,17 @@ const resolver: GQLMutationResolvers['putQuote'] = async (
   }
   const campaignId = campaignArticle.campaignId
 
+  // the quote wall is opt-in per campaign (e.g. 七日書): the campaign must have
+  // it enabled. this is the authoritative gate — the client also hides the
+  // post-to-wall affordance, but the server is the source of truth.
+  const campaign = await atomService.findUnique({
+    table: 'campaign',
+    where: { id: campaignId },
+  })
+  if (!campaign?.enableQuoteWall) {
+    throw new UserInputError('this campaign does not have a quote wall')
+  }
+
   // dedupe: same user + same article + identical content
   const duplicated = await atomService.findFirst({
     table: 'quote',

--- a/src/queries/campaign/index.ts
+++ b/src/queries/campaign/index.ts
@@ -67,6 +67,7 @@ const schema: GQLResolvers = {
     channelEnabled,
     showOther: ({ showOther }) => showOther,
     showAd: ({ showAd }) => showAd,
+    enableQuoteWall: ({ enableQuoteWall }) => enableQuoteWall,
     organizers,
     oss: (root) => root,
   },

--- a/src/types/__test__/2/quote.test.ts
+++ b/src/types/__test__/2/quote.test.ts
@@ -36,6 +36,8 @@ const campaignData = {
   writingPeriod: [new Date('2024-01-03'), new Date('2024-01-04')] as const,
   creatorId: '1',
   state: CAMPAIGN_STATE.active,
+  // the quote wall is opt-in per campaign; the seed campaign has it enabled
+  enableQuoteWall: true,
 }
 
 let campaign: Campaign
@@ -148,6 +150,37 @@ describe('putQuote', () => {
     expect(row.campaignId).toBe(campaign.id)
     expect(row.userId).toBe(posterUser.id)
     expect(row.state).toBe(QUOTE_STATE.active)
+  })
+
+  test('rejects posting when the campaign has no quote wall', async () => {
+    // temporarily disable the wall on the seed campaign
+    await atomService.update({
+      table: 'campaign',
+      where: { id: campaign.id },
+      data: { enableQuoteWall: false },
+    })
+    try {
+      const server = await testClient({
+        connections,
+        context: { viewer: posterUser },
+        isAuth: true,
+      })
+      const { errors } = await server.executeOperation({
+        query: PUT_QUOTE,
+        variables: {
+          input: { articleId: articleGlobalId, content: 'some html string' },
+        },
+      })
+      expect(errors).toBeDefined()
+      expect(errors?.[0].extensions.code).toBe('BAD_USER_INPUT')
+    } finally {
+      // restore so the rest of the suite is unaffected
+      await atomService.update({
+        table: 'campaign',
+        where: { id: campaign.id },
+        data: { enableQuoteWall: true },
+      })
+    }
   })
 
   test('visitors are blocked by the auth directive', async () => {

--- a/src/types/campaign.ts
+++ b/src/types/campaign.ts
@@ -49,6 +49,8 @@ export default /* GraphQL */ `
     managers: [ID!]
     showOther: Boolean
     showAd: Boolean
+    "enable the quote wall (post-to-wall) for this campaign"
+    enableQuoteWall: Boolean
   }
 
   input ApplyCampaignInput {
@@ -145,6 +147,8 @@ export default /* GraphQL */ `
     isManager: Boolean! @privateCache
     showOther: Boolean!
     showAd: Boolean!
+    "whether this campaign exposes a quote wall (post-to-wall affordance)"
+    enableQuoteWall: Boolean!
 
     oss: CampaignOSS! @auth(mode: "${AUTH_MODE.admin}")
   }


### PR DESCRIPTION
## What
Add a per-campaign `enableQuoteWall` flag so only opted-in campaigns (e.g. 七日書) expose the quote wall / post-to-wall.

## Changes
- migration: add `enable_quote_wall` boolean to `campaign` (default false)
- data backfill: enable it for existing 七日書 campaigns (name match used once at migration time; data-driven thereafter)
- expose `enableQuoteWall` on `WritingChallenge` + `PutWritingChallengeInput`, wired through resolver / campaignService / putWritingChallenge
- `putQuote`: server-side authoritative gate — reject posting to a campaign whose quote wall is not enabled (was: any campaign article)

## Notes
- base = develop → ICU only.
- OSS toggle (matters-oss) and the web post-to-wall gating (matters-web) will follow once this is on ICU.
- Verified locally: tsc 0 errors, eslint clean, codegen regenerated. Migration run + resolver runtime are exercised by CI / ICU.