### PR TITLE
feat(campaign): default the quote wall on for every campaign

### DIFF
--- a/db/migrations/20260617000200_alter_campaign_enable_quote_wall_default_on.js
+++ b/db/migrations/20260617000200_alter_campaign_enable_quote_wall_default_on.js
@@ -1,0 +1,20 @@
+const table = 'campaign'
+
+// Interim decision: open the quote wall for every campaign by default, instead
+// of the original 七日書-only opt-in. The per-campaign `enable_quote_wall` flag
+// is kept (as a future hook for the OSS toggle / 七日書-only restriction); we
+// only flip its default to true and enable it on all existing campaigns.
+export const up = async (knex) => {
+  await knex.schema.alterTable(table, (t) => {
+    t.boolean('enable_quote_wall').notNullable().defaultTo(true).alter()
+  })
+  await knex(table).update({ enable_quote_wall: true })
+}
+
+export const down = async (knex) => {
+  // revert the default; existing per-campaign values are left as-is (the prior
+  // mixed state cannot be reconstructed)
+  await knex.schema.alterTable(table, (t) => {
+    t.boolean('enable_quote_wall').notNullable().defaultTo(false).alter()
+  })
+}


### PR DESCRIPTION
過渡決定:先**取消「只有七日書」限制,讓所有活動都能上金句牆**。

- migration:把 `enable_quote_wall` 預設改 true、現有活動全設 true。
- **不動 OSS**(豆泥正在重寫 OSS);也不動前端(#5976 已在讀這個旗標 → 全 true → 每個活動文章都顯示上牆鈕)。
- per-campaign 旗標**保留**,當作日後掛勾:之後要做七日書專屬,可(a)程式碼判定(名稱/shortHash)或(b)等新 OSS 接這個欄位,皆無需改 schema。

base=develop→ICU。