### PR TITLE
feat(campaign): open the discussion to any logged-in user

### DIFF
--- a/src/mutations/comment/putComment.ts
+++ b/src/mutations/comment/putComment.ts
@@ -77,7 +77,6 @@ const resolver: GQLMutationResolvers['putComment'] = async (
       commentService,
       paymentService,
       articleService,
-      campaignService,
       notificationService,
       userService,
       connections,
@@ -309,22 +308,9 @@ const resolver: GQLMutationResolvers['putComment'] = async (
     }
   }
 
-  // campaign discussion is public to read, but only succeeded participants
-  // (or the campaign organizers/managers) may comment
-  if (campaign) {
-    const isParticipant = await campaignService.isParticipant(
-      campaign.id,
-      viewer.id
-    )
-    const isOrganizer =
-      campaign.creatorId === viewer.id ||
-      (campaign.organizerIds ?? []).includes(viewer.id) ||
-      (campaign.managerIds ?? []).includes(viewer.id)
-
-    if (!isParticipant && !isOrganizer) {
-      throw new ForbiddenError('only campaign participants have the permission')
-    }
-  }
+  // campaign discussion is public to read; any logged-in user may comment.
+  // (relaxed from the previous participant-only restriction — basic user-state
+  // and campaign-state guards are still enforced above.)
 
   // check whether viewer is blocked by target author (skip when no single author,
   // e.g. campaign discussion)

--- a/src/types/__test__/2/campaignComment.test.ts
+++ b/src/types/__test__/2/campaignComment.test.ts
@@ -219,22 +219,33 @@ describe('put campaignDiscussion comment', () => {
     }
   })
 
-  test('non-participant can not comment', async () => {
-    const { errors } = await putCampaignComment(
+  // the discussion is open to every logged-in user (the participant-only
+  // restriction was relaxed), so non-participant / pending / rejected may comment
+  test('non-participant can comment', async () => {
+    const { errors, data } = await putCampaignComment(
       nonParticipantId,
       campaignGlobalId
     )
-    expect(errors?.[0].extensions.code).toBe('FORBIDDEN')
+    expect(errors).toBeUndefined()
+    expect(data.putComment.id).toBeDefined()
   })
 
-  test('pending applicant can not comment', async () => {
-    const { errors } = await putCampaignComment(pendingId, campaignGlobalId)
-    expect(errors?.[0].extensions.code).toBe('FORBIDDEN')
+  test('pending applicant can comment', async () => {
+    const { errors, data } = await putCampaignComment(
+      pendingId,
+      campaignGlobalId
+    )
+    expect(errors).toBeUndefined()
+    expect(data.putComment.id).toBeDefined()
   })
 
-  test('rejected applicant can not comment', async () => {
-    const { errors } = await putCampaignComment(rejectedId, campaignGlobalId)
-    expect(errors?.[0].extensions.code).toBe('FORBIDDEN')
+  test('rejected applicant can comment', async () => {
+    const { errors, data } = await putCampaignComment(
+      rejectedId,
+      campaignGlobalId
+    )
+    expect(errors).toBeUndefined()
+    expect(data.putComment.id).toBeDefined()
   })
 
   test('can not comment on archived campaign', async () => {


### PR DESCRIPTION
放寬活動討論區留言權限:從「只有報名成功者/主辦」改成「任何登入用戶皆可留言」。基本的帳號狀態(banned/frozen)與活動封存 guard 不變。測試已更新(non-participant/pending/rejected 現在都能留言)。base=develop→ICU。

搭配前端會另開一支:canComment 改 viewer.isAuthed、留言點讚 hasUpvote、長留言收回鈕、輸入框框內發布。