### PR TITLE
feat(comment-spam): add OSS deep-link to the 3-tier Telegram alerts

### DIFF
--- a/src/connectors/__test__/commentService.test.ts
+++ b/src/connectors/__test__/commentService.test.ts
@@ -940,6 +940,8 @@ describe('spam telegram alert (notify-only tiering)', () => {
       reason: 'spam_auto',
       dedupeKey: `comment:${comment.id}`,
     })
+    // carries an OSS deep-link for one-click moderation
+    expect(sent[0].ossUrl).toContain('/comments?id=')
   })
 
   test('emits Tier C (spam_review) for high-score benign-looking content', async () => {

--- a/src/connectors/commentService.ts
+++ b/src/connectors/commentService.ts
@@ -23,6 +23,7 @@ import {
   USER_ACTION,
   USER_FEATURE_FLAG_TYPE,
   NOTICE_TYPE,
+  NODE_TYPES,
 } from '#common/enums/index.js'
 import { environment } from '#common/environment.js'
 import {
@@ -32,6 +33,7 @@ import {
   UserInputError,
 } from '#common/errors.js'
 import { enqueueReportAlert } from '#common/notifications/reportAlert.js'
+import { toGlobalId } from '#common/utils/index.js'
 import { v4 } from 'uuid'
 
 import { BaseService } from './baseService.js'
@@ -1037,6 +1039,7 @@ export class CommentService extends BaseService<Comment> {
 
     const author = await this.models.userIdLoader.load(comment.authorId)
     const snippet = stripHtml(content).slice(0, 80)
+    const globalId = toGlobalId({ type: NODE_TYPES.Comment, id })
     await enqueueReportAlert({
       source: 'spam_detection',
       dedupeKey: `comment:${id}`,
@@ -1044,6 +1047,9 @@ export class CommentService extends BaseService<Comment> {
         2
       )}）：${snippet}`,
       reason: TIER_REASON[tier],
+      ossUrl: `${environment.ossSiteDomain}/comments?id=${encodeURIComponent(
+        globalId
+      )}`,
     })
   }
 


### PR DESCRIPTION
Adds a `進 OSS 處理` link to the `spam_detection` (A/B/C) Telegram alerts — previously the only report-alert source without one. Links to `${ossSiteDomain}/comments?id=<commentGlobalId>` (the OSS comments triage page; the id param deep-links where supported, harmless otherwise).

Pairs with the prod/dev `MATTERS_OSS_SITE_DOMAIN` fix (was wrongly `matters.town`, now `oss.matters.town` / `oss.matters.icu`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)