### PR TITLE
fix(channel): keep spam out of topic channel feeds

### DIFF
--- a/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
+++ b/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
@@ -1,8 +1,10 @@
 import type { Connections, Article, TopicChannel } from '#definitions/index.js'
 
+import { FEATURE_FLAG, FEATURE_NAME } from '#common/enums/index.js'
 import { AtomService } from '../../atomService.js'
 import { CampaignService } from '../../campaignService.js'
 import { ChannelService } from '../../channel/channelService.js'
+import { SystemService } from '../../systemService.js'
 import { genConnections, closeConnections, createCampaign } from '../utils.js'
 
 let connections: Connections
@@ -11,12 +13,14 @@ let atomService: AtomService
 let channel: TopicChannel
 let articles: Article[]
 let campaignService: CampaignService
+let systemService: SystemService
 
 beforeAll(async () => {
   connections = await genConnections()
   channelService = new ChannelService(connections)
   atomService = new AtomService(connections)
   campaignService = new CampaignService(connections)
+  systemService = new SystemService(connections)
 }, 30000)
 
 afterAll(async () => {
@@ -40,6 +44,20 @@ beforeEach(async () => {
     take: 6,
   })
   expect(articles).toHaveLength(6)
+  await Promise.all(
+    articles.map((article) =>
+      atomService.update({
+        table: 'article',
+        where: { id: article.id },
+        data: { isSpam: null, spamScore: null },
+      })
+    )
+  )
+  await systemService.setFeatureFlag({
+    name: FEATURE_NAME.spam_detection,
+    flag: FEATURE_FLAG.on,
+    value: 0.5,
+  })
 
   // Add articles to channel
   await channelService.setArticleTopicChannels({
@@ -178,6 +196,33 @@ describe('findTopicChannelArticles', () => {
     for (const id of [articles[0].id, articles[2].id, articles[3].id]) {
       expect(resultIds).toContain(id)
     }
+  })
+
+  test('excludes unpinned articles with spam score above threshold', async () => {
+    await atomService.update({
+      table: 'article',
+      where: { id: articles[0].id },
+      data: { isSpam: null, spamScore: 0.6 },
+    })
+    await atomService.update({
+      table: 'article',
+      where: { id: articles[1].id },
+      data: { isSpam: false, spamScore: 0.9 },
+    })
+    await atomService.update({
+      table: 'article',
+      where: { id: articles[2].id },
+      data: { isSpam: true, spamScore: 0.1 },
+    })
+
+    const { query } = await channelService.findTopicChannelArticles(channel.id)
+    const results = await query
+    const resultIds = results.map((a) => a.id)
+
+    expect(resultIds).not.toContain(articles[0].id)
+    expect(resultIds).toContain(articles[1].id)
+    expect(resultIds).not.toContain(articles[2].id)
+    expect(resultIds).toContain(articles[3].id)
   })
 
   describe('datetimeRange filtering', () => {

--- a/src/connectors/__test__/channelService/topicChannel.test.ts
+++ b/src/connectors/__test__/channelService/topicChannel.test.ts
@@ -186,6 +186,11 @@ describe('setArticleChannels', () => {
   beforeEach(async () => {
     await atomService.deleteMany({ table: 'topic_channel_article' })
     await atomService.deleteMany({ table: 'topic_channel' })
+    await atomService.update({
+      table: 'article',
+      where: { id: articleId },
+      data: { isSpam: null, spamScore: null },
+    })
   })
 
   test('sets article channels', async () => {
@@ -215,8 +220,7 @@ describe('setArticleChannels', () => {
     expect(articleChannels[1].isLabeled).toBe(true)
   })
 
-  test('sets isSpam to false when adding articles to channels', async () => {
-    // First set article as spam
+  test('does not clear isSpam when adding articles to channels', async () => {
     await atomService.update({
       table: 'article',
       where: { id: articleId },
@@ -229,15 +233,14 @@ describe('setArticleChannels', () => {
       channelIds: [channel.id],
     })
 
-    // Verify article is no longer marked as spam
     const article = await atomService.findUnique({
       table: 'article',
       where: { id: articleId },
     })
-    expect(article.isSpam).toBe(false)
+    expect(article.isSpam).toBe(true)
   })
 
-  test('sets isSpam to false when re-adding articles to channels', async () => {
+  test('does not clear isSpam when re-adding articles to channels', async () => {
     const channel = await channelService.createTopicChannel(channelData)
 
     // First add article to channel
@@ -265,12 +268,11 @@ describe('setArticleChannels', () => {
       channelIds: [channel.id],
     })
 
-    // Verify article is no longer marked as spam
     const article = await atomService.findUnique({
       table: 'article',
       where: { id: articleId },
     })
-    expect(article.isSpam).toBe(false)
+    expect(article.isSpam).toBe(true)
   })
 
   test('removes existing channels when setting empty array', async () => {

--- a/src/connectors/channel/channelService.ts
+++ b/src/connectors/channel/channelService.ts
@@ -45,6 +45,7 @@ import { ArticleService } from '../article/articleService.js'
 import { AtomService } from '../atomService.js'
 import { Cache } from '../cache/index.js'
 import { NotificationService } from '../notification/notificationService.js'
+import { SystemService } from '../systemService.js'
 
 import { ChannelClassifier } from './channelClassifier.js'
 
@@ -321,11 +322,6 @@ export class ChannelService {
 
     // Add new channels or re-enable disabled ones
     if (toAdd.length > 0) {
-      await this.models.update({
-        table: 'article',
-        where: { id: articleId },
-        data: { isSpam: false },
-      })
       await this.models.upsertOnConflict({
         table: 'topic_channel_article',
         create: toAdd.map((channelId) =>
@@ -397,6 +393,9 @@ export class ChannelService {
     }
 
     const pinnedArticleIds = channel.pinnedArticles || []
+    const spamThreshold = await new SystemService(
+      this.connections
+    ).getSpamThreshold()
 
     const pinnedQuery = knexRO
       .select(
@@ -426,11 +425,7 @@ export class ChannelService {
         'article.channel_enabled': true,
       })
       .whereIn('topic_channel_article.channel_id', channelIds)
-      .where((qb) => {
-        qb.where('article.is_spam', false).orWhere((b) => {
-          b.whereNull('article.is_spam')
-        })
-      })
+      .modify(excludeSpamModifier, spamThreshold)
       .modify(excludeRestrictedModifier)
       .modify(excludeExclusiveCampaignArticles)
       .where((builder) => {


### PR DESCRIPTION
## Why

Topic channel feeds could surface spam articles because `findTopicChannelArticles` only filtered `article.is_spam`, ignoring high `spam_score` rows where `is_spam` is still null. The channel assignment path also cleared `article.is_spam` to false whenever an article was added or re-enabled in a channel, which could override moderation/model state.

This is especially risky after the article spam model was updated and deployed, because high `spam_score` should now be honored consistently in channel feeds.

## What changed

- Use the shared `excludeSpam` modifier in topic channel article queries, so unpinned channel feeds honor both `is_spam` and `spam_score >= spam_threshold`.
- Stop clearing `article.is_spam` when assigning topic channels.
- Update tests to lock the new behavior and cover the high-score channel exclusion case.

## Production audit SQL

```sql
with spam_threshold as (
  select value::numeric as threshold
  from feature_flag
  where name = 'spam_detection'
    and flag = 'on'
  limit 1
)
select
  tc.name as channel_name,
  count(*) as leaked_count,
  count(*) filter (where a.is_spam = false and a.spam_score >= st.threshold) as manual_false_high_score_count,
  count(*) filter (where a.is_spam is null and a.spam_score >= st.threshold) as null_high_score_count
from topic_channel_article tca
join topic_channel tc on tc.id = tca.channel_id
join article a on a.id = tca.article_id
cross join spam_threshold st
where tca.enabled = true
  and a.state = 'active'
  and a.channel_enabled = true
  and tc.name in ('生活', '書影音', '時事', '還有')
  and a.created_at >= now() - interval '7 days'
  and (
    a.is_spam = true
    or (a.is_spam is null and a.spam_score >= st.threshold)
    or (a.is_spam = false and a.spam_score >= st.threshold)
  )
group by tc.name
order by leaked_count desc;
```

## Verification

- `npm run build`
- `npm run lint`
- `npx prettier --check src/connectors/channel/channelService.ts src/connectors/__test__/channelService/topicChannel.test.ts src/connectors/__test__/channelService/findTopicChannelArticles.test.ts`

Connector Jest was attempted but blocked in this local environment because Postgres is not running, no `MATTERS_PG_*` env vars are set, and Docker is unavailable. The failure occurs during `genConnections()` setup before test assertions run.
