### PR TITLE
chore(release): unblock v5.25.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,31 +13,50 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Get Version
         id: version
-        uses: martinbeentjes/npm-get-version-action@master
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "current-version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Generate CHANGELOG
-        uses: scottbrenner/generate-changelog-action@master
         id: changelog
-        env:
-          REPO: ${{ github.repository }}
+        run: |
+          PREVIOUS_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)
+          {
+            echo 'changelog<<EOF'
+            if [ -n "$PREVIOUS_TAG" ]; then
+              git log --pretty=format:'- %s (%h)' "$PREVIOUS_TAG"..HEAD
+            else
+              git log --pretty=format:'- %s (%h)'
+            fi
+            echo
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create Release
-        uses: actions/create-release@v1.1.4
-        with:
-          tag_name: v${{ steps.version.outputs.current-version}}
-          release_name: v${{ steps.version.outputs.current-version}}
-          body: |
-            ${{ steps.changelog.outputs.changelog }}
-          draft: false
-          prerelease: false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: v${{ steps.version.outputs.current-version }}
+          RELEASE_BODY: ${{ steps.changelog.outputs.changelog }}
+        run: |
+          if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            echo "Release $TAG_NAME already exists; skipping creation."
+            exit 0
+          fi
+
+          gh release create "$TAG_NAME" \
+            --title "$TAG_NAME" \
+            --target "$GITHUB_SHA" \
+            --notes "$RELEASE_BODY"
 
       - name: Slack Notification
         if: always()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matters-server",
-  "version": "5.25.0",
+  "version": "5.25.1",
   "description": "Matters Server",
   "author": "Matters <hi@matters.news>",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump matters-server to v5.25.1 so the #4864 release no longer collides with the existing v5.25.0 tag
- replace deprecated release actions with shell/gh release creation
- make release creation idempotent when a tag already exists

## Validation
- parsed .github/workflows/release.yml with Ruby YAML
- verified package.json reports 5.25.1
- confirmed GitHub release v5.25.1 does not exist yet
- confirmed generated changelog range starts at v5.25.0 and includes #4864