### PR TITLE
fix(spam-ring): findScore 對無 reader-view 列的帳號回 0（修凍結集團 authorScore 報錯）

### DIFF
--- a/src/connectors/__test__/userService.test.ts
+++ b/src/connectors/__test__/userService.test.ts
@@ -966,6 +966,15 @@ describe('recommendAuthors', () => {
   })
 })
 
+describe('findScore', () => {
+  test('returns 0 (not throw) when the user has no user_reader_view row', async () => {
+    // Brand-new/inactive accounts are absent from user_reader_view; findScore
+    // must not crash spam-ring freeze, whose members are mostly throwaway accounts.
+    const score = await userService.findScore('999999')
+    expect(score).toBe(0)
+  })
+})
+
 describe('updateUserExtra', () => {
   const userId = '1'
 

--- a/src/connectors/userService.ts
+++ b/src/connectors/userService.ts
@@ -1155,11 +1155,14 @@ export class UserService extends BaseService<User> {
     })
 
   public findScore = async (userId: string) => {
+    // New/inactive accounts have no user_reader_view row (.first() → undefined);
+    // treat a missing row as zero karma instead of throwing. This unblocks
+    // spam-ring freeze, whose members are mostly brand-new throwaway accounts.
     const author = await this.knexRO('user_reader_view')
       .select()
       .where({ id: userId })
       .first()
-    return author.authorScore || 0
+    return author?.authorScore || 0
   }
 
   /*********************************


### PR DESCRIPTION
## 問題（prod 阻斷）

在 oss.matters.town/next「集團偵測」點「凍結集團」會失敗：
`Cannot read properties of undefined (reading 'authorScore')`。

`freezeSpamRing` 逐成員跑 karma 護欄時呼叫 `userService.findScore(user.id)`：

```ts
const author = await this.knexRO('user_reader_view').where({ id: userId }).first()
return author.authorScore || 0   // author 為 undefined 時丟錯
```

FREEZE 集團的成員幾乎都是**全新拋棄式帳號**（新帳號比 80–100%），這些帳號在
`user_reader_view`（有讀者/作者活動才有列）**沒有列** → `.first()` 回 `undefined`
→ 讀 `.authorScore` 即丟錯，整個 freeze mutation 失敗（碰到第一個新帳號就掛）。

## 修正

`author?.authorScore || 0`：無列＝零 karma（語意正確，新帳號本就無 author score），
不再丟錯；score 0 < 護欄門檻 `SPAM_RING_GUARDRAIL_MAX_SCORE`(5) → 該帳號照常凍結
（正是 spam ring 要的行為）。

補 `findScore` 測試：無 `user_reader_view` 列的帳號回 0、不丟錯。

## 測試

- `npx tsc -p . --noEmit` → 0 errors
- prettier ✓、eslint 0 errors（既有 any warning 與本變更無關）
- 新增整合測試於 `userService.test.ts`；matters-server 全套 jest 需 PG，依慣例由 CI 跑。

## 部署備註

此 bug **已在 production**（spam ring 後端 #4863 在 master）。屬 prod 阻斷，建議
依 hotfix 流程**儘快 cherry-pick 到 master / 發布到 prod**，否則控制台無法凍結 ring。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
