### PR TITLE
Update spam ring freeze policy

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -2655,6 +2655,7 @@ type SpamRingSignals {
   topEntity: String
   sampleCodes: [String!]
   sampleBrands: [String!]
+  sampleTexts: [String!]
   contentModelMax: Float
 }
 
@@ -2736,6 +2737,7 @@ enum SpamRingsSort {
   score
   detectedAt
   nAuthors
+  frozenAt
 }
 
 input OSSSpamRingsInput {
@@ -3970,6 +3972,7 @@ input SpamRingSignalsInput {
   topEntity: String
   sampleCodes: [String!]
   sampleBrands: [String!]
+  sampleTexts: [String!]
   contentModelMax: Float
 }
 

--- a/src/connectors/__test__/spamRingService.test.ts
+++ b/src/connectors/__test__/spamRingService.test.ts
@@ -73,8 +73,14 @@ const makeConnections = ({
 }
 
 const makeUserService = (users: Record<string, any>) => ({
-  banUser: jest.fn(async (id: string) => ({ ...users[id], state: USER_STATE.banned })),
-  unbanUser: jest.fn(async (id: string) => ({ ...users[id], state: USER_STATE.active })),
+  banUser: jest.fn(async (id: string) => ({
+    ...users[id],
+    state: USER_STATE.banned,
+  })),
+  unbanUser: jest.fn(async (id: string) => ({
+    ...users[id],
+    state: USER_STATE.active,
+  })),
   findScore: jest.fn(async (_id: string) => 0),
 })
 
@@ -87,17 +93,29 @@ const makeService = (connections: any, users: Record<string, any>) => {
 }
 
 describe('SpamRingService.freezeRing', () => {
-  test('bans eligible members, skips old / already-banned, freezes ring', async () => {
-    const ring = { id: '1', status: 'pending' }
+  test('bans eligible members, skips old / already-banned for low-confidence ring, freezes ring', async () => {
+    const ring = { id: '1', status: 'pending', signals: { nearDupRingSize: 1 } }
     const members = [
       { id: 'm1', userId: 'u1', status: 'pending', bannedByThisRing: false },
       { id: 'm2', userId: 'u2', status: 'pending', bannedByThisRing: false },
       { id: 'm3', userId: 'u3', status: 'pending', bannedByThisRing: false },
     ]
     const users: Record<string, any> = {
-      u1: { id: 'u1', state: USER_STATE.active, createdAt: new Date(Date.now() - DAY) },
-      u2: { id: 'u2', state: USER_STATE.active, createdAt: new Date(Date.now() - 100 * DAY) },
-      u3: { id: 'u3', state: USER_STATE.banned, createdAt: new Date(Date.now() - DAY) },
+      u1: {
+        id: 'u1',
+        state: USER_STATE.active,
+        createdAt: new Date(Date.now() - DAY),
+      },
+      u2: {
+        id: 'u2',
+        state: USER_STATE.active,
+        createdAt: new Date(Date.now() - 100 * DAY),
+      },
+      u3: {
+        id: 'u3',
+        state: USER_STATE.banned,
+        createdAt: new Date(Date.now() - DAY),
+      },
     }
     const { connections, rec } = makeConnections({ ring, members })
     const service = makeService(connections, users)
@@ -115,11 +133,17 @@ describe('SpamRingService.freezeRing', () => {
       remark: USER_BAN_REMARK.spamRing,
     })
     expect(result.frozen.map((u: any) => u.id)).toEqual(['u1'])
-    expect(result.skipped.map((s: any) => s.user.id).sort()).toEqual(['u2', 'u3'])
+    expect(result.skipped.map((s: any) => s.user.id).sort()).toEqual([
+      'u2',
+      'u3',
+    ])
     const u2skip = result.skipped.find((s: any) => s.user.id === 'u2')
     expect(u2skip?.reason).toMatch(/old account/)
     // ring marked frozen
-    expect(rec.ringUpdates.at(-1)).toMatchObject({ status: 'frozen', frozenBy: '9' })
+    expect(rec.ringUpdates.at(-1)).toMatchObject({
+      status: 'frozen',
+      frozenBy: '9',
+    })
     // events include the member ban + ring frozen + a skip
     const actions = rec.eventInserts.map((e) => e.action)
     expect(actions).toEqual(
@@ -127,11 +151,64 @@ describe('SpamRingService.freezeRing', () => {
     )
   })
 
+  test('bans old and high-karma members for high-confidence repeated ring', async () => {
+    const ring = {
+      id: '1',
+      status: 'pending',
+      signals: { nearDupRingSize: 12, sampleCodes: ['LIDANG'] },
+    }
+    const members = [
+      { id: 'm1', userId: 'u1', status: 'pending', bannedByThisRing: false },
+      { id: 'm2', userId: 'u2', status: 'pending', bannedByThisRing: false },
+    ]
+    const users: Record<string, any> = {
+      u1: {
+        id: 'u1',
+        state: USER_STATE.active,
+        createdAt: new Date(Date.now() - 100 * DAY),
+      },
+      u2: {
+        id: 'u2',
+        state: USER_STATE.active,
+        createdAt: new Date(Date.now() - DAY),
+      },
+    }
+    const { connections, rec } = makeConnections({ ring, members })
+    const service = makeService(connections, users)
+    const userService = makeUserService(users)
+    userService.findScore = jest.fn(async (id: string) =>
+      id === 'u2' ? 10 : 0
+    )
+
+    const result = await service.freezeRing({
+      ringId: '1',
+      actorId: '9',
+      userService: userService as any,
+    })
+
+    expect(userService.banUser).toHaveBeenCalledTimes(2)
+    expect(result.frozen.map((u: any) => u.id).sort()).toEqual(['u1', 'u2'])
+    expect(result.skipped).toEqual([])
+
+    const frozenEvent = rec.eventInserts.find((e) => e.action === 'frozen')
+    expect(JSON.parse(frozenEvent.detail)).toMatchObject({
+      frozen: 2,
+      skipped: 0,
+      guardrailBypassed: true,
+    })
+  })
+
   test('refuses to freeze a dismissed ring', async () => {
-    const { connections } = makeConnections({ ring: { id: '1', status: 'dismissed' } })
+    const { connections } = makeConnections({
+      ring: { id: '1', status: 'dismissed' },
+    })
     const service = makeService(connections, {})
     await expect(
-      service.freezeRing({ ringId: '1', actorId: '9', userService: makeUserService({}) as any })
+      service.freezeRing({
+        ringId: '1',
+        actorId: '9',
+        userService: makeUserService({}) as any,
+      })
     ).rejects.toThrow('dismissed')
   })
 })
@@ -167,20 +244,35 @@ describe('SpamRingService.unfreezeRing', () => {
   })
 
   test('refuses to unfreeze a ring that is not frozen', async () => {
-    const { connections } = makeConnections({ ring: { id: '1', status: 'pending' } })
+    const { connections } = makeConnections({
+      ring: { id: '1', status: 'pending' },
+    })
     const service = makeService(connections, {})
     await expect(
-      service.unfreezeRing({ ringId: '1', actorId: '9', userService: makeUserService({}) as any })
+      service.unfreezeRing({
+        ringId: '1',
+        actorId: '9',
+        userService: makeUserService({}) as any,
+      })
     ).rejects.toThrow('not frozen')
   })
 })
 
 describe('SpamRingService.dismissRing', () => {
   test('marks ring dismissed and writes an event', async () => {
-    const { connections, rec } = makeConnections({ ring: { id: '1', status: 'pending' } })
+    const { connections, rec } = makeConnections({
+      ring: { id: '1', status: 'pending' },
+    })
     const service = makeService(connections, {})
-    await service.dismissRing({ ringId: '1', actorId: '9', note: 'false positive' })
-    expect(rec.ringUpdates.at(-1)).toMatchObject({ status: 'dismissed', note: 'false positive' })
+    await service.dismissRing({
+      ringId: '1',
+      actorId: '9',
+      note: 'false positive',
+    })
+    expect(rec.ringUpdates.at(-1)).toMatchObject({
+      status: 'dismissed',
+      note: 'false positive',
+    })
     expect(rec.eventInserts.map((e) => e.action)).toContain('dismissed')
   })
 })
@@ -221,7 +313,13 @@ const makeImportConnections = ({
   }
 
   const builder = (table: string) => {
-    const ctx: any = { table, where: {}, whereIn: null, offset: undefined, limit: undefined }
+    const ctx: any = {
+      table,
+      where: {},
+      whereIn: null,
+      offset: undefined,
+      limit: undefined,
+    }
     const b: any = {
       where: (w: any) => {
         Object.assign(ctx.where, w)
@@ -294,7 +392,9 @@ const makeImportConnections = ({
       then: (resolve: any) => {
         if (table === 'user' && ctx.whereIn) {
           return resolve(
-            users.filter((u) => ctx.whereIn.values.includes(u[ctx.whereIn.column]))
+            users.filter((u) =>
+              ctx.whereIn.values.includes(u[ctx.whereIn.column])
+            )
           )
         }
         const rows = rowsFor(table, ctx.where)

--- a/src/connectors/spamRingService.ts
+++ b/src/connectors/spamRingService.ts
@@ -22,8 +22,44 @@ import { BaseService } from './baseService.js'
 // 模組級常數，便於與信任安全負責人統一調參。
 export const SPAM_RING_GUARDRAIL_MAX_AGE_DAYS = 30
 export const SPAM_RING_GUARDRAIL_MAX_SCORE = 5
+export const SPAM_RING_GUARDRAIL_BYPASS_MIN_RING_SIZE = 10
 
 const DAY_MS = 86400000
+
+const parseSignals = (
+  signals: SpamRing['signals'] | string | null | undefined
+): SpamRingSignals => {
+  if (!signals) {
+    return {}
+  }
+  if (typeof signals !== 'string') {
+    return signals
+  }
+  try {
+    return JSON.parse(signals) ?? {}
+  } catch {
+    return {}
+  }
+}
+
+const arrayLength = (value?: string[] | null) =>
+  Array.isArray(value) ? value.length : 0
+
+const isHighConfidenceFreezeRing = (ring: SpamRing) => {
+  const signals = parseSignals(ring.signals)
+  const nearDupRingSize = signals.nearDupRingSize ?? 0
+  const entityRingSize = signals.entityRingSize ?? 0
+  const hasExternalEntity =
+    !!signals.topEntity ||
+    arrayLength(signals.sampleCodes) > 0 ||
+    arrayLength(signals.sampleBrands) > 0
+
+  return (
+    nearDupRingSize >= SPAM_RING_GUARDRAIL_BYPASS_MIN_RING_SIZE ||
+    entityRingSize >= SPAM_RING_GUARDRAIL_BYPASS_MIN_RING_SIZE ||
+    hasExternalEntity
+  )
+}
 
 export interface SpamRingCandidate {
   fingerprint: string
@@ -223,6 +259,7 @@ export class SpamRingService extends BaseService<SpamRing> {
     const members = await this.findMembers(ringId)
     const frozen: User[] = []
     const skipped: Array<{ user: User; reason: string }> = []
+    const bypassGuardrail = isHighConfidenceFreezeRing(ring)
 
     for (const member of members) {
       const user = (await this.models.userIdLoader.load(
@@ -247,17 +284,24 @@ export class SpamRingService extends BaseService<SpamRing> {
         continue
       }
       if (user.state === USER_STATE.banned) {
-        await this.skipMember(member.id, user, 'already banned', actorId, ringId)
+        await this.skipMember(
+          member.id,
+          user,
+          'already banned',
+          actorId,
+          ringId
+        )
         skipped.push({ user, reason: 'already banned' })
         continue
       }
 
-      // 老帳號 / 高 karma 豁免（硬性護欄）
+      // 低信心 ring 保留老帳號 / 高 karma 護欄；大量重複或外連邀請 ring 仍處置重複帳號。
       const ageDays = (Date.now() - new Date(user.createdAt).getTime()) / DAY_MS
       const score = await userService.findScore(user.id)
       if (
-        ageDays > SPAM_RING_GUARDRAIL_MAX_AGE_DAYS ||
-        score > SPAM_RING_GUARDRAIL_MAX_SCORE
+        !bypassGuardrail &&
+        (ageDays > SPAM_RING_GUARDRAIL_MAX_AGE_DAYS ||
+          score > SPAM_RING_GUARDRAIL_MAX_SCORE)
       ) {
         const reason =
           ageDays > SPAM_RING_GUARDRAIL_MAX_AGE_DAYS
@@ -305,6 +349,7 @@ export class SpamRingService extends BaseService<SpamRing> {
           remark: remark ?? null,
           frozen: frozen.length,
           skipped: skipped.length,
+          guardrailBypassed: bypassGuardrail,
         },
       },
     ])
@@ -351,7 +396,10 @@ export class SpamRingService extends BaseService<SpamRing> {
       // freeze 後狀態已變（例如被封存）→ 不復活，僅記錄
       if (user.state !== USER_STATE.banned) {
         const reason = `state changed to ${user.state}`
-        await this.updateMember(member.id, { status: 'skipped', skipReason: reason })
+        await this.updateMember(member.id, {
+          status: 'skipped',
+          skipReason: reason,
+        })
         skipped.push({ user, reason })
         continue
       }
@@ -375,7 +423,12 @@ export class SpamRingService extends BaseService<SpamRing> {
       .update({ status: 'restored', updatedAt: now })
       .returning('*')
     await this.insertEvents([
-      { ringId, actorId, action: 'unfrozen', detail: { unbanned: unbanned.length } },
+      {
+        ringId,
+        actorId,
+        action: 'unfrozen',
+        detail: { unbanned: unbanned.length },
+      },
     ])
 
     return { ring: updatedRing, unbanned, skipped }
@@ -474,7 +527,13 @@ export class SpamRingService extends BaseService<SpamRing> {
       preFreezeState: user.state,
     })
     await this.insertEvents([
-      { ringId, memberId, actorId, action: 'member_skipped', detail: { reason } },
+      {
+        ringId,
+        memberId,
+        actorId,
+        action: 'member_skipped',
+        detail: { reason },
+      },
     ])
   }
 

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -4423,6 +4423,7 @@ export type GQLSpamRingSignals = {
   nearDupRingSize?: Maybe<Scalars['Int']['output']>
   sampleBrands?: Maybe<Array<Scalars['String']['output']>>
   sampleCodes?: Maybe<Array<Scalars['String']['output']>>
+  sampleTexts?: Maybe<Array<Scalars['String']['output']>>
   topEntity?: Maybe<Scalars['String']['output']>
 }
 
@@ -4433,6 +4434,7 @@ export type GQLSpamRingSignalsInput = {
   nearDupRingSize?: InputMaybe<Scalars['Int']['input']>
   sampleBrands?: InputMaybe<Array<Scalars['String']['input']>>
   sampleCodes?: InputMaybe<Array<Scalars['String']['input']>>
+  sampleTexts?: InputMaybe<Array<Scalars['String']['input']>>
   topEntity?: InputMaybe<Scalars['String']['input']>
 }
 
@@ -4444,7 +4446,7 @@ export type GQLSpamRingSkip = {
 
 export type GQLSpamRingStatus = 'dismissed' | 'frozen' | 'pending' | 'restored'
 
-export type GQLSpamRingsSort = 'detectedAt' | 'nAuthors' | 'score'
+export type GQLSpamRingsSort = 'detectedAt' | 'frozenAt' | 'nAuthors' | 'score'
 
 export type GQLSpamStatus = {
   __typename?: 'SpamStatus'
@@ -11793,6 +11795,11 @@ export type GQLSpamRingSignalsResolvers<
     ContextType
   >
   sampleCodes?: Resolver<
+    Maybe<Array<GQLResolversTypes['String']>>,
+    ParentType,
+    ContextType
+  >
+  sampleTexts?: Resolver<
     Maybe<Array<GQLResolversTypes['String']>>,
     ParentType,
     ContextType

--- a/src/definitions/spamRing.d.ts
+++ b/src/definitions/spamRing.d.ts
@@ -1,9 +1,5 @@
 export type SpamRingStatus = 'pending' | 'frozen' | 'dismissed' | 'restored'
-export type SpamRingMemberStatus =
-  | 'pending'
-  | 'frozen'
-  | 'skipped'
-  | 'restored'
+export type SpamRingMemberStatus = 'pending' | 'frozen' | 'skipped' | 'restored'
 export type SpamRingSeverity = 'low' | 'medium' | 'high' | 'critical'
 export type SpamRingEventAction =
   | 'detected'
@@ -22,6 +18,7 @@ export interface SpamRingSignals {
   topEntity?: string | null
   sampleCodes?: string[] | null
   sampleBrands?: string[] | null
+  sampleTexts?: string[] | null
   contentModelMax?: number | null
 }
 

--- a/src/queries/system/oss/spamRings.ts
+++ b/src/queries/system/oss/spamRings.ts
@@ -17,6 +17,9 @@ export const spamRings: GQLOssResolvers['spamRings'] = async (
     case 'detectedAt':
       orderBy = { column: 'detectedAt', order: 'desc' }
       break
+    case 'frozenAt':
+      orderBy = { column: 'frozenAt', order: 'desc' }
+      break
     case 'nAuthors':
       orderBy = { column: 'nAuthors', order: 'desc' }
       break

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -326,6 +326,7 @@ export default /* GraphQL */ `
     topEntity: String
     sampleCodes: [String!]
     sampleBrands: [String!]
+    sampleTexts: [String!]
     contentModelMax: Float
   }
 
@@ -405,6 +406,7 @@ export default /* GraphQL */ `
     score
     detectedAt
     nAuthors
+    frozenAt
   }
 
   input OSSSpamRingsInput {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -898,6 +898,7 @@ export default /* GraphQL */ `
     topEntity: String
     sampleCodes: [String!]
     sampleBrands: [String!]
+    sampleTexts: [String!]
     contentModelMax: Float
   }
 


### PR DESCRIPTION
## Summary
- allow high-confidence repeated or external-entity spam rings to freeze old and high-karma repeated accounts
- add sampleTexts to spam ring signals and frozenAt sorting for OSS
- record whether guardrails were bypassed in the frozen event detail

## Tests
- node_modules/.bin/tsc -p .
- MATTERS_ENV=test node --experimental-vm-modules --no-experimental-fetch node_modules/.bin/jest build/connectors/__test__/spamRingService.test.js --runInBand