### PR TITLE
[codex] Add topic channel spam threshold audit support

### DIFF
--- a/db/migrations/20260630000000_add_topic_channel_spam_filter_and_detector_fields.js
+++ b/db/migrations/20260630000000_add_topic_channel_spam_filter_and_detector_fields.js
@@ -1,0 +1,28 @@
+const featureFlagTable = 'feature_flag'
+const featureFlagName = 'topic_channel_spam_filter'
+const articleTable = 'article'
+
+export const up = async (knex) => {
+  await knex(featureFlagTable)
+    .insert({ name: featureFlagName, flag: 'on', value: 0.8 })
+    .onConflict('name')
+    .ignore()
+
+  await knex.schema.table(articleTable, (t) => {
+    t.text('decision').nullable()
+    t.text('reason').nullable()
+    t.float('p_spam').nullable()
+    t.float('p_ham').nullable()
+  })
+}
+
+export const down = async (knex) => {
+  await knex.schema.table(articleTable, (t) => {
+    t.dropColumn('decision')
+    t.dropColumn('reason')
+    t.dropColumn('p_spam')
+    t.dropColumn('p_ham')
+  })
+
+  await knex(featureFlagTable).where({ name: featureFlagName }).del()
+}

--- a/db/seeds/31_feature_flag.js
+++ b/db/seeds/31_feature_flag.js
@@ -37,6 +37,11 @@ export const seed = async (knex) => {
       value: 0.5,
     },
     {
+      name: 'topic_channel_spam_filter',
+      flag: 'on',
+      value: 0.8,
+    },
+    {
       name: 'article_channel',
       flag: 'off',
       value: 0.5,

--- a/db/sql/topic-channel-spam-threshold-audit.sql
+++ b/db/sql/topic-channel-spam-threshold-audit.sql
@@ -1,0 +1,100 @@
+-- Topic channel spam threshold review list.
+--
+-- Buckets:
+-- - pseudo_positive_candidate: hidden from topic channels by the 0.8 channel
+--   threshold, but still below the global spam threshold.
+-- - pseudo_negative_candidate: still allowed into topic channels, but close
+--   enough to 0.8 to sample for missed spam.
+--
+-- This query does not model account freezes, restrictions, reports, bans, or
+-- deletions. Those should continue to use their own OSS moderation criteria.
+
+with thresholds as (
+  select
+    0.8::float as topic_channel_threshold,
+    (
+      select value
+      from feature_flag
+      where name = 'spam_detection'
+        and flag = 'on'
+      limit 1
+    ) as global_spam_threshold
+),
+latest_article_version as (
+  select distinct on (article_id)
+    article_id,
+    title,
+    summary,
+    created_at
+  from article_version
+  order by article_id, created_at desc
+),
+topic_channel_candidates as (
+  select
+    tc.id as channel_id,
+    tc.name as channel_name,
+    tc.short_hash as channel_short_hash,
+    tca.article_id,
+    tca.score as channel_score,
+    tca.is_labeled as channel_is_labeled,
+    tca.created_at as channel_article_created_at,
+    a.short_hash as article_short_hash,
+    a.author_id,
+    a.spam_score,
+    a.is_spam,
+    a.state,
+    a.channel_enabled,
+    lav.title,
+    lav.summary,
+    thresholds.topic_channel_threshold,
+    thresholds.global_spam_threshold
+  from topic_channel_article tca
+  join topic_channel tc on tc.id = tca.channel_id
+  join article a on a.id = tca.article_id
+  left join latest_article_version lav on lav.article_id = a.id
+  cross join thresholds
+  where tca.enabled = true
+    and tc.enabled = true
+    and a.state = 'active'
+    and a.channel_enabled = true
+    and a.is_spam is null
+    and a.spam_score is not null
+)
+select
+  case
+    when spam_score >= topic_channel_threshold
+      and (
+        global_spam_threshold is null
+        or spam_score < global_spam_threshold
+      )
+      then 'pseudo_positive_candidate'
+    when spam_score >= 0.65
+      and spam_score < topic_channel_threshold
+      then 'pseudo_negative_candidate'
+  end as review_bucket,
+  channel_name,
+  channel_short_hash,
+  article_id,
+  article_short_hash,
+  author_id,
+  spam_score,
+  channel_score,
+  channel_is_labeled,
+  topic_channel_threshold,
+  global_spam_threshold,
+  title,
+  summary,
+  channel_article_created_at
+from topic_channel_candidates
+where (
+    spam_score >= topic_channel_threshold
+    and (
+      global_spam_threshold is null
+      or spam_score < global_spam_threshold
+    )
+  )
+  or (
+    spam_score >= 0.65
+    and spam_score < topic_channel_threshold
+  )
+order by review_bucket, spam_score desc, channel_article_created_at desc;

--- a/docs/specs/topic-channel-spam-threshold-and-detector-audit.md
+++ b/docs/specs/topic-channel-spam-threshold-and-detector-audit.md
@@ -1,0 +1,171 @@
+# SPEC: Topic Channel Spam Threshold And Detector Audit
+
+| Field                 | Value                                           |
+| --------------------- | ----------------------------------------------- |
+| Feature / change name | Topic channel spam threshold and detector audit |
+| Owner                 | Mashbean                                        |
+| Drafted by            | Codex                                           |
+| Risk tier             | Full                                            |
+| Date                  | 2026-06-30                                      |
+| Status                | Approved                                        |
+
+## 1. Problem & User
+
+Moderators and readers are seeing a recent surge of spam in `https://matters.town/newest` and topic channels such as `生活事` and `性別／愛`. The current production `spam_detection` threshold is `0.94`, so articles with `spam_score < 0.94` can remain visible or be collected into topic channels even when the content is clearly spam.
+
+The user-visible goal is to reduce spam collected by topic channels with a more aggressive channel-only threshold while keeping account-state and global visibility decisions conservative.
+
+## 2. Goal & Non-Goals
+
+In scope:
+
+- Add a topic-channel-only spam filter threshold fixed at `0.8`.
+- Apply the topic-channel spam threshold to all topic channels.
+- Keep the existing global `spam_detection` threshold separate from topic channel collection.
+- Preserve `spam_detection` behavior for publication, `/newest`, search exclusion, global visibility, comments, account restrictions, freezes, bans, and deletions.
+- Capture detector response metadata for future audit and calibration, including `score`, `decision`, `reason`, `p_spam`, and `p_ham` when the detector returns them.
+- Add durable audit logging for manual spam status changes and article state changes.
+- Provide a review list for pseudo positive and pseudo negative sampling.
+- Add tests proving channel-only filtering can be more aggressive than global spam filtering.
+
+Out of scope:
+
+- No account freezing, banning, restriction, or deletion rule changes.
+- No production mutation as part of implementation.
+- No retraining or redeploying the Lambda spam model.
+- No public dataset release change.
+- No UI change.
+
+## 3. Success Criteria
+
+| #   | Acceptance condition                                                                                                                       | How verified                                                                                                     |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| 1   | Topic channel articles use a channel-only spam threshold and can exclude `spam_score >= 0.8` while global spam threshold remains `0.94`.   | Unit test for `ChannelService.findTopicChannelArticles`; staging GraphQL query against a controlled article set. |
+| 2   | `/newest` continues to use the global `spam_detection` threshold.                                                                          | Unit test for `ArticleService.findNewestArticles` or resolver-level regression test.                             |
+| 3   | Publication spam decision does not use the channel-only threshold.                                                                         | Unit test around `PublicationService._runPostProcessing` or existing publication spam tests.                     |
+| 4   | Detector metadata is preserved when returned by the model and old score-only responses still work.                                         | Unit tests for `SpamDetector.detect` and post-processing persistence/logging.                                    |
+| 5   | Manual `setSpamStatus` and `updateArticleState` produce audit records with actor, target, old value, new value, and reason when available. | Resolver unit tests and audit log query inspection in staging.                                                   |
+| 6   | All topic channels use `0.8` after migration, while non-channel moderation decisions keep their existing criteria.                         | Migration review and topic channel query tests.                                                                  |
+| 7   | Operators can generate a review list for pseudo positive and pseudo negative sampling.                                                     | `db/sql/topic-channel-spam-threshold-audit.sql`.                                                                 |
+
+## 4. Repos & Service Placement
+
+| Work area                        | Repo                                                             | Core / Non-core   | Reason                                                                       |
+| -------------------------------- | ---------------------------------------------------------------- | ----------------- | ---------------------------------------------------------------------------- |
+| Topic channel spam filtering     | `thematters/matters-server`                                      | Core              | Topic channel GraphQL query and domain filtering live in `ChannelService`.   |
+| Detector response handling       | `thematters/matters-server`                                      | Core              | Publication post-processing currently owns article `spam_score` persistence. |
+| Manual moderation audit log      | `thematters/matters-server`                                      | Core              | `setSpamStatus` and `updateArticleState` are core admin mutations.           |
+| Historical dataset investigation | `thematters/matters-spam-dataset`, AWS S3 when session is active | Non-core evidence | Dataset is evidence and calibration input, not runtime behavior.             |
+
+## 5. Data & Schema
+
+New or changed tables and columns:
+
+- Preferred additive migration on `article`:
+  - `decision text nullable`
+  - `reason text nullable`
+  - `p_spam float nullable`
+  - `p_ham float nullable`
+- Add feature flag row:
+  - `topic_channel_spam_filter`, `flag=on`, `value=0.8`
+
+Review list:
+
+- `db/sql/topic-channel-spam-threshold-audit.sql`
+- `pseudo_positive_candidate` lists articles that are blocked by topic-channel `0.8` but remain below global `spam_detection`.
+- `pseudo_negative_candidate` lists articles still allowed by topic-channel `0.8`, but close enough to sample for missed spam.
+- The list is for channel collection review only and must not be used as account enforcement input.
+
+GraphQL:
+
+- No public GraphQL fields by default.
+- OSS-only spam status can later expose detector metadata if needed, but this SPEC does not require it.
+
+Backfill:
+
+- No mandatory backfill. Existing rows keep only `spam_score`.
+- Historical CloudWatch and dataset score evidence can be used for calibration, but implementation must tolerate null metadata.
+
+Dataset finding so far:
+
+- `matters-spam-dataset` public schema does not include detector raw response.
+- Internal v2026.06 files include `current_spam_score`, `current_is_spam`, `label_source`, and correction metadata.
+- The documented source families are separate and must not be mixed as ground truth: public release, correction CSV, and legacy S3 parquet.
+- AWS verification found `matters-spam-sample-worker`, writing comment samples to `s3://matters-spam-training-samples/comment-training-samples/l2-captured`. Those records contain `label`, `text`, `labelSource`, `commentHash`, `occurredAt`, and optional `score` or `authorHash`, but not article detector raw response.
+- S3 also contains article correction and ring-shadow artifacts, but no article detector raw response store was found.
+- `spam-detection-serverless` article handler reads `event.body` as raw text and its README examples use raw POST bodies. Direct production endpoint comparison showed JSON `{ "text": ... }` can score normal text near spam levels, while raw body returns the expected lower score. `matters-server` article detection must use raw body before trusting score or `decision` comparisons.
+
+## 6. Permissions
+
+| Actor                      | May do                                                                        | Must NOT do                                                            | Enforced by                                                               |
+| -------------------------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Anonymous / regular viewer | Read topic channel articles filtered by enabled thresholds.                   | See admin-only detector metadata or audit log internals.               | Existing public GraphQL resolvers.                                        |
+| Admin / OSS user           | Read spam status and moderate content according to existing permission gates. | Change production feature flags without explicit approval.             | Existing `@auth(mode: admin)`, `readSpamStatus`, and `setFeature` policy. |
+| Server post-processing     | Persist detector score and metadata.                                          | Freeze, ban, delete, or restrict accounts from channel-only threshold. | Service-layer separation and tests.                                       |
+
+## 7. Risk Class
+
+| Risk surface                  | Touched? | Boundary                                                                             |
+| ----------------------------- | -------- | ------------------------------------------------------------------------------------ |
+| Payments / payout / wallet    | No       | Not touched.                                                                         |
+| Moderation / spam / blocklist | Yes      | Topic channel spam filtering, detector metadata, manual moderation audit logging.    |
+| Federation / ActivityPub      | No       | No federation export changes.                                                        |
+| Auth / OAuth / session        | No       | No auth changes.                                                                     |
+| File upload                   | No       | Not touched.                                                                         |
+| Public domain routing         | No       | Not touched.                                                                         |
+| Account state / permissions   | Yes      | Audit logging reads actor and target state, but does not change account-state rules. |
+| Email / notifications         | No       | No notification behavior change.                                                     |
+
+Security review is mandatory before production promotion or flag launch.
+
+## 8. Feature-Flag Plan
+
+| Field                   | Value                                                                                                |
+| ----------------------- | ---------------------------------------------------------------------------------------------------- |
+| State while in progress | On for all topic channels                                                                            |
+| Flag name               | `topic_channel_spam_filter`                                                                          |
+| Default state           | `on`, `value=0.8`                                                                                    |
+| Back-end guard          | `SystemService.getTopicChannelSpamThreshold`, used only by `ChannelService.findTopicChannelArticles` |
+| Front-end gating        | None. No UI.                                                                                         |
+| Launch trigger          | Deploy after owner approval and monitor review-list samples.                                         |
+| Kill-switch             | `setFeature(name: topic_channel_spam_filter, flag: off)`                                             |
+
+## 9. Design Surface
+
+| Field                     | Value          |
+| ------------------------- | -------------- |
+| Any UI?                   | No             |
+| Design handoff spec       | Not applicable |
+| Design-system conformance | Not applicable |
+
+## 10. Rollout & Rollback
+
+Rollout:
+
+- Merge additive schema and default-on topic channel feature flag to `develop`.
+- Deploy to staging with `topic_channel_spam_filter=on`, `value=0.8`.
+- Verify topic channel spam reduction without changing `/newest`, publication spam handling, account restrictions, freezes, bans, or deletion.
+- Generate pseudo positive and pseudo negative samples with `db/sql/topic-channel-spam-threshold-audit.sql`.
+- After security review and owner approval, promote to production with the same topic-channel-only threshold.
+
+Rollback:
+
+- Set `topic_channel_spam_filter` to `off`.
+- Existing global `spam_detection` threshold remains independent.
+- Detector metadata columns are additive and can remain unused.
+
+Monitoring:
+
+- Topic channel article volume by channel.
+- Articles excluded by channel spam threshold.
+- False-positive samples, especially `生活事`, `性別／愛`, `書音影`, and `身心靈`.
+- `/newest` spam visibility separately from channel collection.
+- OSS moderation actions, reports, freezes, restrictions, bans, and deletions separately from topic channel collection.
+
+## 11. Open Questions
+
+- No article detector raw response store was found in the checked S3 bucket or local dataset repos. If one exists, it is outside `matters-spam-training-samples` or under a name not discovered in this pass.
+- Detector metadata is stored as individual nullable columns: `decision`, `reason`, `p_spam`, and `p_ham`.
+- The article detector request contract is raw body. `matters-server` should send raw text for article detection while leaving comment and moment detector calls unchanged.
+- Confirm whether `decision=block` should be used for global visibility in a later SPEC after replay validation. It is not part of this channel-only change.
+- Confirm whether audit log should include a free-form moderation reason now or only old/new state.

--- a/schema.graphql
+++ b/schema.graphql
@@ -3010,6 +3010,7 @@ enum FeatureName {
   circle_management
   circle_interact
   spam_detection
+  topic_channel_spam_filter
   article_channel
   hottest_moment_feed
 }

--- a/src/common/enums/cache.ts
+++ b/src/common/enums/cache.ts
@@ -34,6 +34,7 @@ export const CACHE_PREFIX = {
   EMAIL_DOMAIL_WHITELIST: 'cache-email-domain-whitelist',
   TAG_COVERS: 'cache-tag-covers',
   SPAM_THRESHOLD: 'cache-spam-threshold',
+  TOPIC_CHANNEL_SPAM_THRESHOLD: 'cache-topic-channel-spam-threshold',
   ARTICLE_CHANNEL_THRESHOLD: 'cache-article-channel-threshold',
   RECOMMENDATION_TAGS: 'cache-recommendation-tags',
   RECOMMENDATION_AUTHORS: 'cache-recommendation-authors',

--- a/src/common/enums/feature.ts
+++ b/src/common/enums/feature.ts
@@ -8,6 +8,7 @@ export const FEATURE_NAME = {
   circle_management: 'circle_management',
   circle_interact: 'circle_interact',
   spam_detection: 'spam_detection',
+  topic_channel_spam_filter: 'topic_channel_spam_filter',
   article_channel: 'article_channel',
   hottest_moment_feed: 'hottest_moment_feed',
 } as const

--- a/src/common/enums/logging.ts
+++ b/src/common/enums/logging.ts
@@ -55,6 +55,8 @@ export const AUDIT_LOG_ACTION = {
   rejectMomentFeedApplication: 'reject_moment_feed_application',
   revokeMomentFeedApplication: 'revoke_moment_feed_application',
   autoApproveMomentFeedApplication: 'auto_approve_moment_feed_application',
+  setSpamStatus: 'set_spam_status',
+  updateArticleState: 'update_article_state',
 } as const
 
 export const AUDIT_LOG_STATUS = {

--- a/src/connectors/__test__/articleService/articleService.test.ts
+++ b/src/connectors/__test__/articleService/articleService.test.ts
@@ -989,6 +989,38 @@ describe('spam detection', () => {
     })
     expect(article?.spamScore).toBe(score)
   })
+  test('persists detector metadata', async () => {
+    const articleId = '1'
+
+    const mockSpamDetoctor = {
+      detectResult: jest.fn(() => ({
+        score: 0.88,
+        decision: 'block',
+        reason: 'commercial solicitation',
+        pSpam: 0.7,
+        pHam: 0.02,
+      })),
+    }
+    // @ts-ignore
+    await publicationService._detectSpam(
+      { id: articleId, title: 'test', content: 'test' },
+      mockSpamDetoctor as any
+    )
+
+    const article = await atomService.findUnique({
+      table: 'article',
+      where: { id: articleId },
+    })
+    expect(article).toEqual(
+      expect.objectContaining({
+        spamScore: 0.88,
+        decision: 'block',
+        reason: 'commercial solicitation',
+        pSpam: 0.7,
+        pHam: 0.02,
+      })
+    )
+  })
   test('find spam articles', async () => {
     const articles = await articleService.findArticles({
       spam: {

--- a/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
+++ b/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
@@ -1,13 +1,16 @@
 import type { Connections, Article, TopicChannel } from '#definitions/index.js'
 
+import { FEATURE_FLAG, FEATURE_NAME } from '#common/enums/index.js'
 import { AtomService } from '../../atomService.js'
 import { CampaignService } from '../../campaignService.js'
 import { ChannelService } from '../../channel/channelService.js'
+import { SystemService } from '../../systemService.js'
 import { genConnections, closeConnections, createCampaign } from '../utils.js'
 
 let connections: Connections
 let channelService: ChannelService
 let atomService: AtomService
+let systemService: SystemService
 let channel: TopicChannel
 let articles: Article[]
 let campaignService: CampaignService
@@ -16,6 +19,7 @@ beforeAll(async () => {
   connections = await genConnections()
   channelService = new ChannelService(connections)
   atomService = new AtomService(connections)
+  systemService = new SystemService(connections)
   campaignService = new CampaignService(connections)
 }, 30000)
 
@@ -24,6 +28,14 @@ afterAll(async () => {
 })
 
 beforeEach(async () => {
+  await systemService.setFeatureFlag({
+    name: FEATURE_NAME.topic_channel_spam_filter,
+    flag: FEATURE_FLAG.off,
+  })
+  await systemService.setFeatureFlag({
+    name: FEATURE_NAME.spam_detection,
+    flag: FEATURE_FLAG.off,
+  })
   await atomService.deleteMany({ table: 'topic_channel_article' })
   await atomService.deleteMany({ table: 'topic_channel' })
 
@@ -40,6 +52,15 @@ beforeEach(async () => {
     take: 6,
   })
   expect(articles).toHaveLength(6)
+  await Promise.all(
+    articles.map(({ id }) =>
+      atomService.update({
+        table: 'article',
+        where: { id },
+        data: { isSpam: null, spamScore: null },
+      })
+    )
+  )
 
   // Add articles to channel
   await channelService.setArticleTopicChannels({
@@ -178,6 +199,37 @@ describe('findTopicChannelArticles', () => {
     for (const id of [articles[0].id, articles[2].id, articles[3].id]) {
       expect(resultIds).toContain(id)
     }
+  })
+
+  test('uses topic channel spam threshold separately from global threshold', async () => {
+    await systemService.setFeatureFlag({
+      name: FEATURE_NAME.spam_detection,
+      flag: FEATURE_FLAG.on,
+      value: 0.94,
+    })
+    await systemService.setFeatureFlag({
+      name: FEATURE_NAME.topic_channel_spam_filter,
+      flag: FEATURE_FLAG.on,
+      value: 0.8,
+    })
+
+    await atomService.update({
+      table: 'article',
+      where: { id: articles[0].id },
+      data: { isSpam: null, spamScore: 0.85 },
+    })
+    await atomService.update({
+      table: 'article',
+      where: { id: articles[1].id },
+      data: { isSpam: null, spamScore: 0.75 },
+    })
+
+    const { query } = await channelService.findTopicChannelArticles(channel.id)
+    const results = await query
+    const resultIds = results.map((article) => article.id)
+
+    expect(resultIds).not.toContain(articles[0].id)
+    expect(resultIds).toContain(articles[1].id)
   })
 
   describe('datetimeRange filtering', () => {

--- a/src/connectors/__test__/spamDetection.test.ts
+++ b/src/connectors/__test__/spamDetection.test.ts
@@ -1,5 +1,61 @@
-import { SpamDetector } from '../spamDetector.js'
+import {
+  createSpamDetectorConfig,
+  normalizeSpamDetectionResponse,
+  SpamDetector,
+} from '../spamDetector.js'
 import { environment } from '#common/environment.js'
+
+describe('spam detector response handling', () => {
+  test('normalizes score and detector metadata', () => {
+    expect(
+      normalizeSpamDetectionResponse({
+        score: 0.88,
+        decision: 'block',
+        reason: 'commercial solicitation',
+        p_spam: 0.7,
+        p_ham: 0.02,
+      })
+    ).toEqual({
+      score: 0.88,
+      decision: 'block',
+      reason: 'commercial solicitation',
+      pSpam: 0.7,
+      pHam: 0.02,
+    })
+  })
+
+  test('normalizes lambda proxy body responses', () => {
+    expect(
+      normalizeSpamDetectionResponse({
+        body: JSON.stringify({ score: 0.12, decision: 'review' }),
+      })
+    ).toEqual({
+      score: 0.12,
+      decision: 'review',
+      reason: null,
+      pSpam: null,
+      pHam: null,
+    })
+  })
+
+  test('builds raw and json request payloads', () => {
+    const rawConfig = createSpamDetectorConfig({
+      apiUrl: 'https://example.test',
+      text: 'test text',
+      requestFormat: 'raw',
+    })
+    expect(rawConfig.data).toBe('test text')
+    expect(rawConfig.headers).toEqual({ 'Content-Type': 'text/plain' })
+
+    expect(
+      createSpamDetectorConfig({
+        apiUrl: 'https://example.test',
+        text: 'test text',
+        requestFormat: 'json',
+      }).data
+    ).toEqual({ text: 'test text' })
+  })
+})
 
 test.skip('detect', async () => {
   const spamDetection = new SpamDetector(environment.spamDetectionApiUrl)

--- a/src/connectors/__test__/systemService.test.ts
+++ b/src/connectors/__test__/systemService.test.ts
@@ -369,6 +369,17 @@ test('get spam threshold', async () => {
   expect(threshold).toBe(0.5)
 })
 
+test('get topic channel spam threshold', async () => {
+  await systemService.setFeatureFlag({
+    name: FEATURE_NAME.topic_channel_spam_filter,
+    flag: FEATURE_FLAG.on,
+    value: 0.8,
+  })
+
+  const threshold = await systemService.getTopicChannelSpamThreshold()
+  expect(threshold).toBe(0.8)
+})
+
 describe('announcement', () => {
   beforeEach(async () => {
     await atomService.deleteMany({ table: 'channel_announcement' })

--- a/src/connectors/article/publicationService.ts
+++ b/src/connectors/article/publicationService.ts
@@ -49,7 +49,7 @@ import { DraftService } from '../draftService.js'
 import { LanguageDetector } from '../languageDetector.js'
 import { NotificationService } from '../notification/notificationService.js'
 import { SearchService } from '../searchService.js'
-import { SpamDetector } from '../spamDetector.js'
+import { type SpamDetectionResult, SpamDetector } from '../spamDetector.js'
 import { SystemService } from '../systemService.js'
 import { TagService } from '../tagService.js'
 import { UserService } from '../userService.js'
@@ -61,6 +61,13 @@ const require = createRequire(import.meta.url)
 const { html2md } = require('@matters/matters-editor/transformers')
 const logger = getLogger('service-article')
 const { difference, isEqual, uniq } = _
+
+type SpamDetectorLike = {
+  detect: (text: string) => Promise<number | null> | number | null
+  detectResult?: (
+    text: string
+  ) => Promise<SpamDetectionResult | null> | SpamDetectionResult | null
+}
 
 export class PublicationService extends BaseService<Article> {
   private systemService: SystemService
@@ -520,9 +527,12 @@ export class PublicationService extends BaseService<Article> {
    *                               *
    *********************************/
 
-  public detectSpam = async (id: string, spamDetector?: SpamDetector) => {
+  public detectSpam = async (id: string, spamDetector?: SpamDetectorLike) => {
     const detector =
-      spamDetector ?? new SpamDetector(environment.spamDetectionApiUrl)
+      spamDetector ??
+      new SpamDetector(environment.spamDetectionApiUrl, {
+        requestFormat: 'raw',
+      })
     const { title, summary, summaryCustomized } =
       await this.articleService.loadLatestArticleVersion(id)
     const content = await this.articleService.loadLatestArticleContent(id)
@@ -539,21 +549,34 @@ export class PublicationService extends BaseService<Article> {
       content,
       summary,
     }: { id: string; title: string; content: string; summary?: string },
-    spamDetector?: SpamDetector
+    spamDetector?: SpamDetectorLike
   ) => {
     const detector =
-      spamDetector ?? new SpamDetector(environment.spamDetectionApiUrl)
+      spamDetector ??
+      new SpamDetector(environment.spamDetectionApiUrl, {
+        requestFormat: 'raw',
+      })
     const text = summary
       ? title + '\n' + summary + '\n' + content
       : title + '\n' + content
-    const score = await detector.detect(text)
+    const result =
+      detector.detectResult !== undefined
+        ? await detector.detectResult(text)
+        : { score: await detector.detect(text) }
+    const score = result?.score ?? null
     logger.info(`Spam detection for article ${id}: ${score}`)
 
-    if (score) {
+    if (score !== null) {
       await this.models.update({
         table: 'article',
         where: { id },
-        data: { spamScore: score },
+        data: {
+          spamScore: score,
+          decision: result && 'decision' in result ? result.decision : null,
+          reason: result && 'reason' in result ? result.reason : null,
+          pSpam: result && 'pSpam' in result ? result.pSpam : null,
+          pHam: result && 'pHam' in result ? result.pHam : null,
+        },
       })
     }
     return score

--- a/src/connectors/channel/channelService.ts
+++ b/src/connectors/channel/channelService.ts
@@ -45,6 +45,7 @@ import { ArticleService } from '../article/articleService.js'
 import { AtomService } from '../atomService.js'
 import { Cache } from '../cache/index.js'
 import { NotificationService } from '../notification/notificationService.js'
+import { SystemService } from '../systemService.js'
 
 import { ChannelClassifier } from './channelClassifier.js'
 
@@ -397,6 +398,12 @@ export class ChannelService {
     }
 
     const pinnedArticleIds = channel.pinnedArticles || []
+    const systemService = new SystemService(this.connections)
+    const [globalSpamThreshold, topicChannelSpamThreshold] = await Promise.all([
+      systemService.getSpamThreshold(),
+      systemService.getTopicChannelSpamThreshold(),
+    ])
+    const spamThreshold = topicChannelSpamThreshold ?? globalSpamThreshold
 
     const pinnedQuery = knexRO
       .select(
@@ -426,10 +433,16 @@ export class ChannelService {
         'article.channel_enabled': true,
       })
       .whereIn('topic_channel_article.channel_id', channelIds)
-      .where((qb) => {
-        qb.where('article.is_spam', false).orWhere((b) => {
-          b.whereNull('article.is_spam')
-        })
+      .modify((builder) => {
+        if (spamThreshold) {
+          builder.modify(excludeSpamModifier, spamThreshold)
+        } else {
+          builder.where((qb) => {
+            qb.where('article.is_spam', false).orWhere((b) => {
+              b.whereNull('article.is_spam')
+            })
+          })
+        }
       })
       .modify(excludeRestrictedModifier)
       .modify(excludeExclusiveCampaignArticles)

--- a/src/connectors/spamDetector.ts
+++ b/src/connectors/spamDetector.ts
@@ -5,31 +5,118 @@ import axios, { type AxiosRequestConfig } from 'axios'
 
 const logger = getLogger('spam-detector')
 
+export type SpamDetectorRequestFormat = 'json' | 'raw'
+
+export interface SpamDetectionResult {
+  score: number
+  decision?: string | null
+  reason?: string | null
+  pSpam?: number | null
+  pHam?: number | null
+}
+
+const toNullableString = (value: unknown) =>
+  typeof value === 'string' && value.length > 0 ? value : null
+
+const toNullableNumber = (value: unknown) => {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : null
+}
+
+const parsePayload = (data: unknown): Record<string, unknown> | null => {
+  if (typeof data === 'string') {
+    try {
+      return parsePayload(JSON.parse(data))
+    } catch {
+      return null
+    }
+  }
+
+  if (data && typeof data === 'object') {
+    const payload = data as Record<string, unknown>
+    if ('body' in payload) {
+      return parsePayload(payload.body)
+    }
+    return payload
+  }
+
+  return null
+}
+
+export const normalizeSpamDetectionResponse = (
+  data: unknown
+): SpamDetectionResult | null => {
+  const payload = parsePayload(data)
+  if (!payload) {
+    return null
+  }
+
+  const score = Number(payload.score)
+  if (!Number.isFinite(score)) {
+    return null
+  }
+
+  return {
+    score,
+    decision: toNullableString(payload.decision),
+    reason: toNullableString(payload.reason),
+    pSpam: toNullableNumber(payload.p_spam ?? payload.pSpam),
+    pHam: toNullableNumber(payload.p_ham ?? payload.pHam),
+  }
+}
+
+export const createSpamDetectorConfig = ({
+  apiUrl,
+  text,
+  requestFormat,
+}: {
+  apiUrl: string
+  text: string
+  requestFormat: SpamDetectorRequestFormat
+}): AxiosRequestConfig => ({
+  method: 'post',
+  url: apiUrl,
+  data: requestFormat === 'raw' ? text : { text },
+  headers: requestFormat === 'raw' ? { 'Content-Type': 'text/plain' } : {},
+})
+
 export class SpamDetector {
   private apiUrl: string
+  private requestFormat: SpamDetectorRequestFormat
 
-  public constructor(apiUrl: string) {
+  public constructor(
+    apiUrl: string,
+    {
+      requestFormat = 'json',
+    }: { requestFormat?: SpamDetectorRequestFormat } = {}
+  ) {
     this.apiUrl = apiUrl
+    this.requestFormat = requestFormat
   }
 
   public detect = async (text: string): Promise<number | null> => {
+    const result = await this.detectResult(text)
+    return result?.score ?? null
+  }
+
+  public detectResult = async (
+    text: string
+  ): Promise<SpamDetectionResult | null> => {
     if (isTest) {
       return null
     }
 
-    const config: AxiosRequestConfig = {
-      method: 'post',
-      url: this.apiUrl,
-      data: {
-        text,
-      },
-    }
+    const config = createSpamDetectorConfig({
+      apiUrl: this.apiUrl,
+      text,
+      requestFormat: this.requestFormat,
+    })
 
     let retries = 0
     while (retries < 3) {
       try {
         const response = await axios(config)
-        return response.data.score
+        return normalizeSpamDetectionResponse(response.data)
       } catch (error) {
         retries++
         if (retries >= 3) {

--- a/src/connectors/systemService.ts
+++ b/src/connectors/systemService.ts
@@ -168,6 +168,35 @@ export class SystemService extends BaseService<BaseDBSchema> {
   }
 
   /**
+   * Get the topic-channel-only spam threshold from `feature_flag` table.
+   */
+  public getTopicChannelSpamThreshold = async (): Promise<number | null> => {
+    const cache = new Cache(
+      CACHE_PREFIX.TOPIC_CHANNEL_SPAM_THRESHOLD,
+      this.connections.objectCacheRedis
+    )
+    const value = (await cache.getObject({
+      keys: { id: 'topic_channel_spam_threshold' },
+      getter: this._getTopicChannelSpamThreshold,
+      expire: isTest ? CACHE_TTL.INSTANT : CACHE_TTL.SHORT,
+    })) as number | null
+    return value
+  }
+  private _getTopicChannelSpamThreshold = async (): Promise<number | null> => {
+    const threshold = await this.models.findFirst({
+      table: 'feature_flag',
+      where: {
+        name: FEATURE_NAME.topic_channel_spam_filter,
+        flag: FEATURE_FLAG.on,
+      },
+    })
+    if (!threshold || !threshold.value) {
+      return null
+    }
+    return threshold.value
+  }
+
+  /**
    * Get the article channel threshold from `feature_flag` table
    * Use to determine whether a article is in a channel by its score
    */

--- a/src/definitions/article.d.ts
+++ b/src/definitions/article.d.ts
@@ -20,6 +20,10 @@ export interface Article {
   shortHash: string
   spamScore: number | null
   isSpam: boolean | null
+  decision: string | null
+  reason: string | null
+  pSpam: number | null
+  pHam: number | null
   isAd: boolean | null
   channelEnabled: boolean
 }

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -1898,6 +1898,7 @@ export type GQLFeatureName =
   | 'payout'
   | 'spam_detection'
   | 'tag_adoption'
+  | 'topic_channel_spam_filter'
   | 'verify_appreciate'
 
 export type GQLFeaturedCommentsInput = {

--- a/src/mutations/article/updateArticleState.ts
+++ b/src/mutations/article/updateArticleState.ts
@@ -2,16 +2,25 @@ import type { GQLMutationResolvers } from '#definitions/index.js'
 
 import {
   ARTICLE_STATE,
+  AUDIT_LOG_ACTION,
+  AUDIT_LOG_STATUS,
   OFFICIAL_NOTICE_EXTEND_TYPE,
 } from '#common/enums/index.js'
+import { auditLog } from '#common/logger.js'
 import { fromGlobalId } from '#common/utils/index.js'
 
 const resolver: GQLMutationResolvers['updateArticleState'] = async (
   _,
   { input: { id, state } },
-  { dataSources: { atomService, notificationService } }
+  { dataSources: { atomService, notificationService }, viewer }
 ) => {
   const { id: dbId } = fromGlobalId(id)
+  const actorId = viewer && 'id' in viewer ? viewer.id : null
+
+  const before = await atomService.findUnique({
+    table: 'article',
+    where: { id: dbId },
+  })
 
   const article = await atomService.update({
     table: 'article',
@@ -19,6 +28,15 @@ const resolver: GQLMutationResolvers['updateArticleState'] = async (
     data: {
       state,
     },
+  })
+  auditLog({
+    actorId,
+    action: AUDIT_LOG_ACTION.updateArticleState,
+    status: AUDIT_LOG_STATUS.succeeded,
+    entity: 'article',
+    entityId: dbId,
+    oldValue: JSON.stringify({ state: before?.state ?? null }),
+    newValue: JSON.stringify({ state }),
   })
 
   // trigger notification

--- a/src/mutations/system/setSpamStatus.ts
+++ b/src/mutations/system/setSpamStatus.ts
@@ -1,15 +1,21 @@
 import type { GQLMutationResolvers } from '#definitions/index.js'
 
-import { NODE_TYPES } from '#common/enums/index.js'
+import {
+  AUDIT_LOG_ACTION,
+  AUDIT_LOG_STATUS,
+  NODE_TYPES,
+} from '#common/enums/index.js'
 import { UserInputError } from '#common/errors.js'
+import { auditLog } from '#common/logger.js'
 import { fromGlobalId } from '#common/utils/index.js'
 
 const resolver: GQLMutationResolvers['setSpamStatus'] = async (
   _,
   { input: { id: globalId, isSpam } },
-  { dataSources: { atomService, publicationService } }
+  { dataSources: { atomService, publicationService }, viewer }
 ) => {
   const { type, id } = fromGlobalId(globalId)
+  const actorId = viewer && 'id' in viewer ? viewer.id : null
 
   if (!id) {
     throw new UserInputError('id is invalid')
@@ -17,10 +23,23 @@ const resolver: GQLMutationResolvers['setSpamStatus'] = async (
 
   switch (type) {
     case NODE_TYPES.Article: {
+      const before = await atomService.findUnique({
+        table: 'article',
+        where: { id },
+      })
       const article = await atomService.update({
         table: 'article',
         where: { id },
         data: { isSpam },
+      })
+      auditLog({
+        actorId,
+        action: AUDIT_LOG_ACTION.setSpamStatus,
+        status: AUDIT_LOG_STATUS.succeeded,
+        entity: 'article',
+        entityId: id,
+        oldValue: JSON.stringify({ isSpam: before?.isSpam ?? null }),
+        newValue: JSON.stringify({ isSpam }),
       })
 
       if (!isSpam) {
@@ -31,20 +50,46 @@ const resolver: GQLMutationResolvers['setSpamStatus'] = async (
     }
 
     case NODE_TYPES.Comment: {
+      const before = await atomService.findUnique({
+        table: 'comment',
+        where: { id },
+      })
       const comment = await atomService.update({
         table: 'comment',
         where: { id },
         data: { isSpam },
+      })
+      auditLog({
+        actorId,
+        action: AUDIT_LOG_ACTION.setSpamStatus,
+        status: AUDIT_LOG_STATUS.succeeded,
+        entity: 'comment',
+        entityId: id,
+        oldValue: JSON.stringify({ isSpam: before?.isSpam ?? null }),
+        newValue: JSON.stringify({ isSpam }),
       })
 
       return { ...comment, __type: NODE_TYPES.Comment } as any
     }
 
     case NODE_TYPES.Moment: {
+      const before = await atomService.findUnique({
+        table: 'moment',
+        where: { id },
+      })
       const moment = await atomService.update({
         table: 'moment',
         where: { id },
         data: { isSpam },
+      })
+      auditLog({
+        actorId,
+        action: AUDIT_LOG_ACTION.setSpamStatus,
+        status: AUDIT_LOG_STATUS.succeeded,
+        entity: 'moment',
+        entityId: id,
+        oldValue: JSON.stringify({ isSpam: before?.isSpam ?? null }),
+        newValue: JSON.stringify({ isSpam }),
       })
 
       return { ...moment, __type: NODE_TYPES.Moment } as any

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -682,6 +682,7 @@ export default /* GraphQL */ `
     circle_management
     circle_interact
     spam_detection
+    topic_channel_spam_filter
     article_channel
     hottest_moment_feed
   }


### PR DESCRIPTION
## Summary

- Add a topic-channel-only spam threshold feature flag, default on with value 0.8 for all topic channels.
- Keep global `spam_detection` unchanged and use it only as fallback if the channel flag is explicitly disabled.
- Fix article spam detector transport to raw text body while leaving comment and moment detector calls on the existing JSON path.
- Persist article detector metadata in nullable `decision`, `reason`, `p_spam`, and `p_ham` columns.
- Add audit logs for manual spam status and article state changes.
- Add `db/sql/topic-channel-spam-threshold-audit.sql` to list pseudo positive and pseudo negative candidates for review.
- Add an approved SPEC with AWS/S3 sample-worker findings and the separation between channel collection and OSS moderation decisions.

## Why

Recent topic-channel spam was passing because the channel collection path relied on the same conservative global spam threshold. The article detector endpoint also expects raw request bodies, but the server was sending JSON, which can inflate scores for normal text. This change forces all topic channels to collect with the 0.8 channel threshold while keeping `/newest`, publication spam handling, reports, restrictions, freezes, bans, and deletion decisions on their existing OSS moderation criteria.

## Review list

`db/sql/topic-channel-spam-threshold-audit.sql` produces two buckets:

- `pseudo_positive_candidate`: blocked by topic-channel 0.8, but still below global `spam_detection`.
- `pseudo_negative_candidate`: still allowed by topic-channel 0.8, but close enough to sample for missed spam.

The list is for channel collection calibration only, not account enforcement.

## Validation

- `npm run build`
- `MATTERS_ENV=test node --experimental-vm-modules --no-experimental-fetch node_modules/.bin/jest build/connectors/__test__/spamDetection.test.js --runInBand --forceExit`
- `MATTERS_ENV=test MATTERS_PG_HOST=localhost MATTERS_PG_PORT=55432 MATTERS_PG_USER=$(whoami) MATTERS_PG_PASSWORD= MATTERS_PG_DATABASE=postgres node --experimental-vm-modules --no-experimental-fetch node_modules/.bin/jest build/connectors/__test__/channelService/findTopicChannelArticles.test.js --runInBand --forceExit`
- `MATTERS_ENV=test MATTERS_PG_HOST=localhost MATTERS_PG_PORT=55432 MATTERS_PG_USER=$(whoami) MATTERS_PG_PASSWORD= MATTERS_PG_DATABASE=postgres node --experimental-vm-modules --no-experimental-fetch node_modules/.bin/jest build/connectors/__test__/articleService/articleService.test.js --runInBand --forceExit`
- `MATTERS_ENV=test MATTERS_PG_HOST=localhost MATTERS_PG_PORT=55432 MATTERS_PG_USER=$(whoami) MATTERS_PG_PASSWORD= MATTERS_PG_DATABASE=postgres node --experimental-vm-modules --no-experimental-fetch node_modules/.bin/jest build/connectors/__test__/systemService.test.js --runInBand --forceExit`
