### PR TITLE
fix(auth): close unauthenticated OSS admin-console read via field-alias bypass [SECURITY]

### DIFF
--- a/src/types/directives/__test__/auth.test.ts
+++ b/src/types/directives/__test__/auth.test.ts
@@ -1,0 +1,62 @@
+import { makeExecutableSchema } from '@graphql-tools/schema'
+import { graphql } from 'graphql'
+
+import { AUTH_MODE } from '#common/enums/index.js'
+
+import { authDirective } from '../auth.js'
+
+const { typeDef, transformer } = authDirective('auth')
+
+const makeSchema = () =>
+  transformer(
+    makeExecutableSchema({
+      typeDefs: [
+        typeDef,
+        `type OSS { secret: String }
+         type Query {
+           oss: OSS @auth(mode: "${AUTH_MODE.admin}")
+           publicField: String @auth(mode: "${AUTH_MODE.visitor}")
+         }`,
+      ],
+      resolvers: {
+        Query: { oss: () => ({}), publicField: () => 'public' },
+        OSS: { secret: () => 'TOP-SECRET' },
+      },
+    })
+  )
+
+// anonymous visitor: no `id`, only the visitor auth mode
+const anonymousViewer = {
+  authMode: AUTH_MODE.visitor,
+  hasAuthMode: (req: string) => req === AUTH_MODE.visitor,
+}
+
+const run = (source: string) =>
+  graphql({
+    schema: makeSchema(),
+    source,
+    contextValue: { viewer: anonymousViewer },
+  })
+
+describe('auth directive — anonymous access to admin-gated fields', () => {
+  test('rejects an anonymous query of an admin field (oss)', async () => {
+    const res = await run('{ oss { secret } }')
+    expect(res.data?.oss ?? null).toBeNull()
+    expect(res.errors?.[0]?.message).toMatch(/isn't authorized/)
+  })
+
+  // Regression for the field-alias bypass: aliasing `oss` must NOT skip the admin gate.
+  test('rejects an anonymous query of an ALIASED admin field', async () => {
+    const res = await run('{ x: oss { secret } }')
+    expect(
+      (res.data as { x?: unknown } | null | undefined)?.x ?? null
+    ).toBeNull()
+    expect(res.errors?.[0]?.message).toMatch(/isn't authorized/)
+  })
+
+  test('still allows an anonymous query of a visitor field', async () => {
+    const res = await run('{ publicField }')
+    expect(res.errors).toBeUndefined()
+    expect(res.data?.publicField).toBe('public')
+  })
+})

--- a/src/types/directives/auth.ts
+++ b/src/types/directives/auth.ts
@@ -28,8 +28,13 @@ export const authDirective = (directiveName = 'auth') => ({
              * Query
              */
             if (isQuery) {
-              // "visitor" can only access anonymous' fields
-              if (!viewer.id && isSelf && !nodes.includes('oss')) {
+              // "visitor" can only access anonymous' fields.
+              // Gate on the field's own required mode, NOT on a substring of the
+              // response path: `nodes` is alias-derived, so `!nodes.includes('oss')`
+              // was bypassable by aliasing `oss` (e.g. `x: oss`), which let an
+              // anonymous viewer skip the admin check below and read the whole OSS
+              // admin subtree. Admin-gated fields must never take this fast path.
+              if (!viewer.id && isSelf && requireMode !== AUTH_MODE.admin) {
                 return await resolve(root, args, context, info)
               }
 


### PR DESCRIPTION
## 🔒 Security hotfix — unauthenticated read of the OSS admin console (field-alias bypass)

**Severity: HIGH (borderline CRITICAL) · pre-auth · production.** Found by a security audit (matters-agent-sop `security-audit` skill) of the spam-ring feature; the flaw is in the shared `@auth` directive, so it exposes the **entire** `oss` admin tree, not just spam rings.

### The bug
The `@auth` directive's anonymous query fast-path excluded the admin OSS tree with `!nodes.includes('oss')`, where `nodes = responsePathAsArray(info.path)` is built from the **response alias**, not the schema field name. So aliasing `oss` defeats the substring check:
```
{ oss { ... } }      -> FORBIDDEN
{ x: oss { ... } }   -> returns data (admin gate skipped)   ← unauthenticated
```
With no `rootValue` configured, `isSelf` (`root?.id === viewer?.id`) is `undefined === undefined` → true; an anonymous viewer has no `id`; and no global auth middleware fronts `/graphql`. All three conditions hold, so the fast-path `return await resolve(...)` runs **before** the `hasAuthMode('admin')` check, and the OSS child fields carry no `@auth` of their own. Net: any anonymous client can read `oss.users / articles / reports / oauthClients / restrictedUsers / spamRings { members { user { id userName displayName } } signals events frozenBy } …` — moderation targets, detection heuristics, and user PII. Read-only (the mutation branch has no anonymous fast-path).

Reproduced end-to-end against the built schema with `graphql@16.8.1`.

### The fix
Gate the anonymous fast-path on the field's **own required mode**, not on an alias-derived path substring:
```diff
- if (!viewer.id && isSelf && !nodes.includes('oss')) {
+ if (!viewer.id && isSelf && requireMode !== AUTH_MODE.admin) {
```
This is alias-proof and **minimal**: it only stops anonymous viewers from short-circuiting `@auth(mode: admin)` fields (exactly the hole — `oss` and any other admin field); anonymous access to `visitor`/`user`/`oauth` fields is unchanged.

### Test
New standalone unit test (`src/types/directives/__test__/auth.test.ts`, no DB) — asserts an anonymous query of `oss` is rejected **plain and aliased** (the regression guard), while a `visitor` field still resolves. `tsc` 0 errors; 3/3 pass locally.

### Rollout
Hotfix on **master** (the flaw is in long-standing code, live in prod). Please **cherry-pick to develop**. Suggest also adding an integration-level assertion in the OSS query tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
