### PR TITLE
feat(spam-ring): re-land #4879 (集團凍結改設 state='frozen'; stranded by merge race)

### DIFF
--- a/src/connectors/__test__/spamRingService.test.ts
+++ b/src/connectors/__test__/spamRingService.test.ts
@@ -81,6 +81,14 @@ const makeUserService = (users: Record<string, any>) => ({
     ...users[id],
     state: USER_STATE.active,
   })),
+  freezeUser: jest.fn(async (id: string) => ({
+    ...users[id],
+    state: USER_STATE.frozen,
+  })),
+  unfreezeUser: jest.fn(async (id: string, state: string) => ({
+    ...users[id],
+    state,
+  })),
   findScore: jest.fn(async (_id: string) => 0),
 })
 
@@ -127,11 +135,12 @@ describe('SpamRingService.freezeRing', () => {
       userService: userService as any,
     })
 
-    // only u1 banned (u2 old account, u3 already banned)
-    expect(userService.banUser).toHaveBeenCalledTimes(1)
-    expect(userService.banUser).toHaveBeenCalledWith('u1', {
+    // only u1 frozen (u2 old account, u3 already banned)
+    expect(userService.freezeUser).toHaveBeenCalledTimes(1)
+    expect(userService.freezeUser).toHaveBeenCalledWith('u1', {
       remark: USER_BAN_REMARK.spamRing,
     })
+    expect(userService.banUser).not.toHaveBeenCalled()
     expect(result.frozen.map((u: any) => u.id)).toEqual(['u1'])
     expect(result.skipped.map((s: any) => s.user.id).sort()).toEqual([
       'u2',
@@ -147,7 +156,7 @@ describe('SpamRingService.freezeRing', () => {
     // events include the member ban + ring frozen + a skip
     const actions = rec.eventInserts.map((e) => e.action)
     expect(actions).toEqual(
-      expect.arrayContaining(['member_banned', 'member_skipped', 'frozen'])
+      expect.arrayContaining(['member_frozen', 'member_skipped', 'frozen'])
     )
   })
 
@@ -186,7 +195,7 @@ describe('SpamRingService.freezeRing', () => {
       userService: userService as any,
     })
 
-    expect(userService.banUser).toHaveBeenCalledTimes(2)
+    expect(userService.freezeUser).toHaveBeenCalledTimes(2)
     expect(result.frozen.map((u: any) => u.id).sort()).toEqual(['u1', 'u2'])
     expect(result.skipped).toEqual([])
 
@@ -196,6 +205,33 @@ describe('SpamRingService.freezeRing', () => {
       skipped: 0,
       guardrailBypassed: true,
     })
+  })
+
+  test('skips a member already frozen by something else (no re-claim)', async () => {
+    const ring = { id: '1', status: 'pending', signals: { nearDupRingSize: 1 } }
+    const members = [
+      { id: 'm1', userId: 'u1', status: 'pending', bannedByThisRing: false },
+    ]
+    const users: Record<string, any> = {
+      u1: {
+        id: 'u1',
+        state: USER_STATE.frozen,
+        createdAt: new Date(Date.now() - DAY),
+      },
+    }
+    const { connections } = makeConnections({ ring, members })
+    const service = makeService(connections, users)
+    const userService = makeUserService(users)
+
+    const result = await service.freezeRing({
+      ringId: '1',
+      actorId: '9',
+      userService: userService as any,
+    })
+
+    expect(userService.freezeUser).not.toHaveBeenCalled()
+    expect(result.frozen).toEqual([])
+    expect(result.skipped.map((s: any) => s.reason)).toEqual(['already frozen'])
   })
 
   test('refuses to freeze a dismissed ring', async () => {
@@ -214,16 +250,28 @@ describe('SpamRingService.freezeRing', () => {
 })
 
 describe('SpamRingService.unfreezeRing', () => {
-  test('unbans only members this ring banned; leaves others; restores ring', async () => {
+  test('unfreezes only members this ring froze; restores preFreezeState; leaves others', async () => {
     const ring = { id: '1', status: 'frozen' }
     const members = [
-      { id: 'm1', userId: 'u1', status: 'frozen', bannedByThisRing: true },
+      {
+        id: 'm1',
+        userId: 'u1',
+        status: 'frozen',
+        bannedByThisRing: true,
+        preFreezeState: USER_STATE.active,
+      },
       { id: 'm2', userId: 'u2', status: 'skipped', bannedByThisRing: false },
-      { id: 'm3', userId: 'u3', status: 'frozen', bannedByThisRing: true },
+      {
+        id: 'm3',
+        userId: 'u3',
+        status: 'frozen',
+        bannedByThisRing: true,
+        preFreezeState: USER_STATE.active,
+      },
     ]
     const users: Record<string, any> = {
-      u1: { id: 'u1', state: USER_STATE.banned },
-      u2: { id: 'u2', state: USER_STATE.banned }, // banned by something else
+      u1: { id: 'u1', state: USER_STATE.frozen },
+      u2: { id: 'u2', state: USER_STATE.frozen }, // frozen by something else
       u3: { id: 'u3', state: USER_STATE.archived }, // state changed since freeze
     }
     const { connections } = makeConnections({ ring, members })
@@ -236,9 +284,12 @@ describe('SpamRingService.unfreezeRing', () => {
       userService: userService as any,
     })
 
-    // only u1 unbanned (u2 not banned-by-this-ring → untouched; u3 archived → skipped)
-    expect(userService.unbanUser).toHaveBeenCalledTimes(1)
-    expect(userService.unbanUser).toHaveBeenCalledWith('u1', USER_STATE.active)
+    // only u1 unfrozen (u2 not frozen-by-this-ring → untouched; u3 archived → skipped)
+    expect(userService.unfreezeUser).toHaveBeenCalledTimes(1)
+    expect(userService.unfreezeUser).toHaveBeenCalledWith(
+      'u1',
+      USER_STATE.active
+    )
     expect(result.unbanned.map((u: any) => u.id)).toEqual(['u1'])
     expect(result.skipped.map((s: any) => s.user.id)).toEqual(['u3'])
   })

--- a/src/connectors/spamRingService.ts
+++ b/src/connectors/spamRingService.ts
@@ -294,6 +294,19 @@ export class SpamRingService extends BaseService<SpamRing> {
         skipped.push({ user, reason: 'already banned' })
         continue
       }
+      if (user.state === USER_STATE.frozen) {
+        // already frozen (by admin or another ring) → don't re-claim it,
+        // otherwise unfreeze would lift a freeze this ring didn't cause.
+        await this.skipMember(
+          member.id,
+          user,
+          'already frozen',
+          actorId,
+          ringId
+        )
+        skipped.push({ user, reason: 'already frozen' })
+        continue
+      }
 
       // 低信心 ring 保留老帳號 / 高 karma 護欄；大量重複或外連邀請 ring 仍處置重複帳號。
       const ageDays = (Date.now() - new Date(user.createdAt).getTime()) / DAY_MS
@@ -314,8 +327,9 @@ export class SpamRingService extends BaseService<SpamRing> {
         continue
       }
 
-      // 永久但可逆封禁：省略 banDays → 不寫 punish_record、無到期；仍發 user_banned 申訴通知
-      const banned = (await userService.banUser(user.id, {
+      // 永久但可逆的凍結：設 state='frozen'（與一般凍結同狀態，不寫 punish_record、
+      // 無到期）；freezeUser 會發 user_frozen 申訴通知，維持可申訴。
+      const frozenUser = (await userService.freezeUser(user.id, {
         remark: USER_BAN_REMARK.spamRing,
       })) as User
       await this.updateMember(member.id, {
@@ -325,9 +339,9 @@ export class SpamRingService extends BaseService<SpamRing> {
         skipReason: null,
       })
       await this.insertEvents([
-        { ringId, memberId: member.id, actorId, action: 'member_banned' },
+        { ringId, memberId: member.id, actorId, action: 'member_frozen' },
       ])
-      frozen.push(banned)
+      frozen.push(frozenUser)
     }
 
     const now = new Date()
@@ -393,8 +407,8 @@ export class SpamRingService extends BaseService<SpamRing> {
       if (!user) {
         continue
       }
-      // freeze 後狀態已變（例如被封存）→ 不復活，僅記錄
-      if (user.state !== USER_STATE.banned) {
+      // freeze 後狀態又被改動（例如被封存/封禁）→ 不復活，僅記錄
+      if (user.state !== USER_STATE.frozen) {
         const reason = `state changed to ${user.state}`
         await this.updateMember(member.id, {
           status: 'skipped',
@@ -403,9 +417,10 @@ export class SpamRingService extends BaseService<SpamRing> {
         skipped.push({ user, reason })
         continue
       }
-      const restored = (await userService.unbanUser(
+      // 還原成凍結前的狀態（preFreezeState，通常為 active）
+      const restored = (await userService.unfreezeUser(
         user.id,
-        USER_STATE.active
+        member.preFreezeState ?? USER_STATE.active
       )) as User
       await this.updateMember(member.id, {
         status: 'restored',

--- a/src/connectors/userService.ts
+++ b/src/connectors/userService.ts
@@ -1990,6 +1990,34 @@ export class UserService extends BaseService<User> {
     return await this.baseUpdate(userId, { state })
   }
 
+  // Freeze: reversible restriction state (`frozen`, not `banned`). Sends the
+  // user_frozen notice so the action stays appealable, mirroring banUser.
+  // Used by spam-ring freeze so ring-frozen accounts land in the same `frozen`
+  // state as an admin freeze (no punish_record, no expiry).
+  public freezeUser = async (
+    userId: string,
+    { remark }: { remark?: ValueOf<typeof USER_BAN_REMARK> } = {}
+  ) => {
+    const notificationService = new NotificationService(this.connections)
+    notificationService.trigger({
+      event: OFFICIAL_NOTICE_EXTEND_TYPE.user_frozen,
+      recipientId: userId,
+    })
+
+    const data = {
+      state: USER_STATE.frozen,
+      updatedAt: new Date(),
+    }
+
+    return await this.baseUpdate(userId, remark ? { ...data, remark } : data)
+  }
+
+  // Reverse a freeze by restoring an explicit prior state (e.g. preFreezeState).
+  public unfreezeUser = async (
+    userId: string,
+    state: ValueOf<typeof USER_STATE>
+  ) => await this.baseUpdate(userId, { state })
+
   public verifyWalletSignature = async ({
     ethAddress,
     nonce,

--- a/src/definitions/spamRing.d.ts
+++ b/src/definitions/spamRing.d.ts
@@ -7,6 +7,7 @@ export type SpamRingEventAction =
   | 'unfrozen'
   | 'dismissed'
   | 'member_banned'
+  | 'member_frozen'
   | 'member_skipped'
   | 'member_restored'
 


### PR DESCRIPTION
## Re-land #4879 — "集團凍結改設 state='frozen'" (stranded by a merge race)

**#4879 shows MERGED but its changes are NOT in `develop`.** It merged into its base branch `codex/spam-ring-policy-ux-support` at 07:39:28, **7 seconds after** #4877 (codex → develop) merged at 07:39:21 — so develop's snapshot of codex predated #4879. Net effect: develop has #4877 (high-confidence guardrail bypass) but **not** #4879, so `freezeRing` still calls `banUser` → `user.state='banned'` instead of `freezeUser` → `'frozen'`. The matters-web zh-Hant/zh-Hans "凍結" labels merged in #5989 therefore have no matching backend state (ring-frozen users are `banned`, so they don't get the `isFrozen` indicator).

This PR re-lands **only** #4879's commit (`812f6179e`) by cherry-pick onto current develop. Re-basing on the codex branch is **not** viable — codex is now stale vs develop on ~25 unrelated files (setSpamStatus, updateArticleState, ...), so a codex→develop merge would revert other work; cherry-picking the single commit avoids that.

### What it does (unchanged from the approved #4879)
- `userService.freezeUser` (state='frozen' + `user_frozen` appeal notice) / `unfreezeUser`.
- `freezeRing` uses `freezeUser` (not `banUser`); adds an "already frozen → skip" guard; event `member_frozen`.
- `unfreezeRing` restores `member.preFreezeState` and gates on `state==='frozen'`.
- `SpamRingEventAction` += `'member_frozen'`.

### Verification
Cherry-pick applied cleanly onto develop (no conflicts, same #4877 base). `tsc -p .` 0 errors; `spamRingService.test.ts` 10/10 pass.

> A follow-up PR adds transaction/locking hardening to freezeRing/unfreezeRing (security-audit findings F3/F4/F2) on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
