### PR TITLE
release: promote develop to production

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,8 +75,7 @@ jobs:
       - name: Lint
         id: lint
         run: |
-          npm run lint \
-          && npm run format:check
+          npm run lint
 
       - name: Test
         id: test

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,0 +1,46 @@
+name: Format Check
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+      - develop
+
+jobs:
+  format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Cache NPM dependencies
+        uses: actions/cache@v4
+        id: node_modules_cache
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-v18-npm-v3-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Dependencies
+        if: steps.node_modules_cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Format Check
+        run: |
+          files=$(git diff --name-only --diff-filter=ACMR \
+            "origin/${{ github.base_ref }}...HEAD" \
+            | grep -E '\.(js|jsx|ts|tsx|json)$' \
+            | grep -vE '^(build|coverage|node_modules)/' || true)
+          if [ -z "$files" ]; then
+            echo "No prettier-managed files changed; skipping."
+            exit 0
+          fi
+          echo "$files"
+          echo "$files" | xargs npx prettier --check

--- a/db/migrations/20260619090000_create_moderation_case_table.js
+++ b/db/migrations/20260619090000_create_moderation_case_table.js
@@ -1,0 +1,149 @@
+const caseTable = 'moderation_case'
+const reporterTable = 'moderation_case_reporter'
+const eventTable = 'moderation_event'
+
+export const up = async (knex) => {
+  await knex('entity_type').insert([
+    { table: caseTable },
+    { table: reporterTable },
+    { table: eventTable },
+  ])
+
+  await knex.schema.createTable(caseTable, (t) => {
+    t.bigIncrements('id').primary()
+    t.enu('source', [
+      'direct_report',
+      'community_watch',
+      'admin',
+      'system',
+      'model_assisted',
+      'automated',
+    ]).notNullable()
+    t.enu('target_type', [
+      'article',
+      'comment',
+      'moment',
+      'user',
+      'tag',
+      'other',
+    ]).notNullable()
+    t.bigInteger('target_id').unsigned().notNullable()
+    t.bigInteger('primary_reporter_id').unsigned()
+    t.string('reason').notNullable()
+    t.text('public_reason')
+    t.enu('status', [
+      'received',
+      'reviewing',
+      'action_taken',
+      'rejected',
+      'appealed',
+      'resolved',
+      'closed',
+    ])
+      .notNullable()
+      .defaultTo('received')
+    t.enu('outcome', [
+      'no_action',
+      'content_collapsed',
+      'content_hidden',
+      'content_removed',
+      'account_limited',
+      'restored',
+      'partially_restored',
+      'upheld',
+    ])
+    t.enu('automation_role', [
+      'none',
+      'suggested',
+      'assisted',
+      'automated',
+    ])
+      .notNullable()
+      .defaultTo('none')
+    t.string('model_name')
+    t.string('model_version')
+    t.enu('notice_state', [
+      'not_required',
+      'pending',
+      'sent',
+      'delayed',
+      'prohibited',
+      'failed',
+    ])
+      .notNullable()
+      .defaultTo('not_required')
+    t.timestamp('resolved_at')
+    t.timestamp('closed_at')
+    t.timestamp('created_at').defaultTo(knex.fn.now())
+    t.timestamp('updated_at').defaultTo(knex.fn.now())
+
+    t.foreign('primary_reporter_id').references('id').inTable('user')
+    t.index(['source', 'created_at'])
+    t.index(['target_type', 'target_id'])
+    t.index(['status', 'created_at'])
+    t.index(['outcome', 'created_at'])
+    t.index(['automation_role', 'created_at'])
+    t.unique(['source', 'target_type', 'target_id', 'reason'])
+  })
+
+  await knex.schema.createTable(reporterTable, (t) => {
+    t.bigIncrements('id').primary()
+    t.bigInteger('case_id').unsigned().notNullable()
+    t.bigInteger('reporter_id').unsigned().notNullable()
+    t.bigInteger('report_id').unsigned()
+    t.timestamp('reported_at').defaultTo(knex.fn.now())
+
+    t.foreign('case_id').references('id').inTable(caseTable).onDelete('CASCADE')
+    t.foreign('reporter_id').references('id').inTable('user')
+    t.foreign('report_id').references('id').inTable('report').onDelete('SET NULL')
+    t.unique(['case_id', 'reporter_id'])
+    t.index(['reporter_id', 'reported_at'])
+    t.index(['report_id'])
+  })
+
+  await knex.schema.createTable(eventTable, (t) => {
+    t.bigIncrements('id').primary()
+    t.bigInteger('case_id').unsigned().notNullable()
+    t.enu('event_type', [
+      'created',
+      'notified',
+      'reviewed',
+      'actioned',
+      'appealed',
+      'restored',
+      'closed',
+      'exported',
+    ]).notNullable()
+    t.enu('actor_type', [
+      'user',
+      'community_watcher',
+      'admin',
+      'system',
+      'model',
+    ]).notNullable()
+    t.bigInteger('actor_id').unsigned()
+    t.text('public_reason')
+    t.text('internal_note')
+    t.string('from_status')
+    t.string('to_status')
+    t.string('from_outcome')
+    t.string('to_outcome')
+    t.jsonb('metadata')
+    t.timestamp('created_at').defaultTo(knex.fn.now())
+
+    t.foreign('case_id').references('id').inTable(caseTable).onDelete('CASCADE')
+    t.foreign('actor_id').references('id').inTable('user')
+    t.index(['case_id', 'created_at'])
+    t.index(['event_type', 'created_at'])
+    t.index(['actor_type', 'created_at'])
+  })
+}
+
+export const down = async (knex) => {
+  await knex.schema.dropTable(eventTable)
+  await knex.schema.dropTable(reporterTable)
+  await knex.schema.dropTable(caseTable)
+  await knex('entity_type')
+    .whereIn('table', [caseTable, reporterTable, eventTable])
+    .del()
+}

--- a/db/migrations/20260630000000_add_topic_channel_spam_filter_and_detector_fields.js
+++ b/db/migrations/20260630000000_add_topic_channel_spam_filter_and_detector_fields.js
@@ -1,0 +1,28 @@
+const featureFlagTable = 'feature_flag'
+const featureFlagName = 'topic_channel_spam_filter'
+const articleTable = 'article'
+
+export const up = async (knex) => {
+  await knex(featureFlagTable)
+    .insert({ name: featureFlagName, flag: 'on', value: 0.8 })
+    .onConflict('name')
+    .ignore()
+
+  await knex.schema.table(articleTable, (t) => {
+    t.text('decision').nullable()
+    t.text('reason').nullable()
+    t.float('p_spam').nullable()
+    t.float('p_ham').nullable()
+  })
+}
+
+export const down = async (knex) => {
+  await knex.schema.table(articleTable, (t) => {
+    t.dropColumn('decision')
+    t.dropColumn('reason')
+    t.dropColumn('p_spam')
+    t.dropColumn('p_ham')
+  })
+
+  await knex(featureFlagTable).where({ name: featureFlagName }).del()
+}

--- a/db/seeds/31_feature_flag.js
+++ b/db/seeds/31_feature_flag.js
@@ -37,6 +37,11 @@ export const seed = async (knex) => {
       value: 0.5,
     },
     {
+      name: 'topic_channel_spam_filter',
+      flag: 'on',
+      value: 0.8,
+    },
+    {
       name: 'article_channel',
       flag: 'off',
       value: 0.5,

--- a/db/sql/topic-channel-spam-threshold-audit.sql
+++ b/db/sql/topic-channel-spam-threshold-audit.sql
@@ -1,0 +1,100 @@
+-- Topic channel spam threshold review list.
+--
+-- Buckets:
+-- - pseudo_positive_candidate: hidden from topic channels by the 0.8 channel
+--   threshold, but still below the global spam threshold.
+-- - pseudo_negative_candidate: still allowed into topic channels, but close
+--   enough to 0.8 to sample for missed spam.
+--
+-- This query does not model account freezes, restrictions, reports, bans, or
+-- deletions. Those should continue to use their own OSS moderation criteria.
+
+with thresholds as (
+  select
+    0.8::float as topic_channel_threshold,
+    (
+      select value
+      from feature_flag
+      where name = 'spam_detection'
+        and flag = 'on'
+      limit 1
+    ) as global_spam_threshold
+),
+latest_article_version as (
+  select distinct on (article_id)
+    article_id,
+    title,
+    summary,
+    created_at
+  from article_version
+  order by article_id, created_at desc
+),
+topic_channel_candidates as (
+  select
+    tc.id as channel_id,
+    tc.name as channel_name,
+    tc.short_hash as channel_short_hash,
+    tca.article_id,
+    tca.score as channel_score,
+    tca.is_labeled as channel_is_labeled,
+    tca.created_at as channel_article_created_at,
+    a.short_hash as article_short_hash,
+    a.author_id,
+    a.spam_score,
+    a.is_spam,
+    a.state,
+    a.channel_enabled,
+    lav.title,
+    lav.summary,
+    thresholds.topic_channel_threshold,
+    thresholds.global_spam_threshold
+  from topic_channel_article tca
+  join topic_channel tc on tc.id = tca.channel_id
+  join article a on a.id = tca.article_id
+  left join latest_article_version lav on lav.article_id = a.id
+  cross join thresholds
+  where tca.enabled = true
+    and tc.enabled = true
+    and a.state = 'active'
+    and a.channel_enabled = true
+    and a.is_spam is null
+    and a.spam_score is not null
+)
+select
+  case
+    when spam_score >= topic_channel_threshold
+      and (
+        global_spam_threshold is null
+        or spam_score < global_spam_threshold
+      )
+      then 'pseudo_positive_candidate'
+    when spam_score >= 0.65
+      and spam_score < topic_channel_threshold
+      then 'pseudo_negative_candidate'
+  end as review_bucket,
+  channel_name,
+  channel_short_hash,
+  article_id,
+  article_short_hash,
+  author_id,
+  spam_score,
+  channel_score,
+  channel_is_labeled,
+  topic_channel_threshold,
+  global_spam_threshold,
+  title,
+  summary,
+  channel_article_created_at
+from topic_channel_candidates
+where (
+    spam_score >= topic_channel_threshold
+    and (
+      global_spam_threshold is null
+      or spam_score < global_spam_threshold
+    )
+  )
+  or (
+    spam_score >= 0.65
+    and spam_score < topic_channel_threshold
+  )
+order by review_bucket, spam_score desc, channel_article_created_at desc;

--- a/docs/NCCTransparencyExternalMetrics.example.json
+++ b/docs/NCCTransparencyExternalMetrics.example.json
@@ -1,0 +1,51 @@
+{
+  "government_requests": {
+    "total": 2,
+    "by_jurisdiction": {
+      "TW": 2
+    },
+    "by_agency_type": {
+      "court": 1,
+      "law_enforcement": 1
+    },
+    "by_request_type": {
+      "data_request": 1,
+      "content_restriction": 1
+    },
+    "by_data_type": {
+      "account_information": 1,
+      "content": 1
+    },
+    "by_result": {
+      "rejected": 1,
+      "partially_complied": 1
+    },
+    "by_user_notice": {
+      "notified": 1,
+      "prohibited": 1
+    }
+  },
+  "privacy_requests": {
+    "total": 3,
+    "access": 1,
+    "correction": 0,
+    "deletion": 2,
+    "restriction": 0
+  },
+  "policy_changes": [
+    {
+      "date": "2026-03-01",
+      "category": "content_rules",
+      "summary": "Updated public content handling rules for spam reports.",
+      "public_url": "/transparency/automation"
+    }
+  ],
+  "model_changes": [
+    {
+      "date": "2026-04-15",
+      "category": "spam_detection",
+      "summary": "Moved comment spam classifier to review-only monitoring."
+    }
+  ],
+  "recommendation_changes": []
+}

--- a/docs/NCCTransparencyMetrics.md
+++ b/docs/NCCTransparencyMetrics.md
@@ -1,0 +1,95 @@
+# NCC Transparency Metrics Export
+
+This export produces aggregated moderation and Community Watch metrics for a
+fixed reporting period. It is intended for transparency report drafting and
+review, not for public case-level disclosure.
+
+## Usage
+
+Build the server first, then run the export command with an inclusive date
+range.
+
+Make sure the usual `MATTERS_PG_*` database environment variables point to the
+database snapshot intended for the report before running the command.
+
+```bash
+npm run build
+npm run transparency:export -- \
+  --start=2026-01-01 \
+  --end=2026-06-30 \
+  --timezone=Asia/Taipei \
+  --slug=2026-H1 \
+  --out-dir=./tmp/transparency-metrics
+```
+
+The command writes both files below.
+
+```text
+transparency-metrics-2026-H1.json
+transparency-metrics-2026-H1.csv
+```
+
+## Optional External Structured Metrics
+
+Government, legal, and privacy request logs may live outside the application
+database. Policy, model, and recommendation change logs may also come from
+reviewed public documentation instead of database tables. When those sources
+have been reviewed and reduced to safe structured fields, pass a local JSON
+file with `--external-metrics`.
+
+```bash
+npm run build
+npm run transparency:export -- \
+  --start=2026-01-01 \
+  --end=2026-06-30 \
+  --timezone=Asia/Taipei \
+  --slug=2026-H1 \
+  --out-dir=./tmp/transparency-metrics \
+  --external-metrics=/path/to/private/aggregate-transparency-metrics.json
+```
+
+Request metrics in the external file must contain aggregate counts only.
+Change logs may contain public-safe date, category, summary, and public URL
+fields. The file must not include case records, requester names, email
+addresses, IP addresses, original content, internal notes, reviewer notes,
+legal document text, attachments, or private case identifiers.
+
+See `docs/NCCTransparencyExternalMetrics.example.json` for the supported
+schema. Unknown fields are rejected so accidental case-level data does not
+enter the export.
+
+## Included Metrics
+
+- Moderation case totals and distributions by target type, source, reason,
+  status, outcome, automation role, and notice state.
+- Appeal counts from moderation events and Community Watch review events.
+- Handling-time aggregates for moderation cases with `resolved_at`.
+- Community Watch action counts, reason distribution, appeals, restores, and
+  staff review counts.
+- Explicit `not_recorded` fields for government requests, privacy requests,
+  policy changes, model changes, and recommendation changes until their
+  structured sources are wired in.
+- Optional government request, privacy request, policy change, model change,
+  and recommendation change metrics when a reviewed external metrics JSON file
+  is provided.
+
+## Privacy Boundary
+
+The export only includes aggregate bucket counts. It must not include user ids,
+email addresses, IP addresses, original content, internal notes, reviewer notes,
+report ids, legal document content, or case-level records.
+
+The focused test at
+`src/connectors/__test__/transparencyService.test.ts` asserts this boundary by
+seeding sensitive source fields and checking that the generated JSON omits them.
+
+## Data Status
+
+The first version marks the overall dataset as `partial` because legacy reports
+do not yet have complete structured sources. Government request, privacy
+request, policy change, model change, and recommendation change metrics are
+marked `not_recorded` unless a reviewed external metrics file is passed with
+`--external-metrics`.
+
+Do not convert `not_recorded` or `unknown` fields into `0` in the public report.
+Zero means a fully recorded source had no matching events in the period.

--- a/docs/specs/topic-channel-spam-threshold-and-detector-audit.md
+++ b/docs/specs/topic-channel-spam-threshold-and-detector-audit.md
@@ -1,0 +1,171 @@
+# SPEC: Topic Channel Spam Threshold And Detector Audit
+
+| Field                 | Value                                           |
+| --------------------- | ----------------------------------------------- |
+| Feature / change name | Topic channel spam threshold and detector audit |
+| Owner                 | Mashbean                                        |
+| Drafted by            | Codex                                           |
+| Risk tier             | Full                                            |
+| Date                  | 2026-06-30                                      |
+| Status                | Approved                                        |
+
+## 1. Problem & User
+
+Moderators and readers are seeing a recent surge of spam in `https://matters.town/newest` and topic channels such as `生活事` and `性別／愛`. The current production `spam_detection` threshold is `0.94`, so articles with `spam_score < 0.94` can remain visible or be collected into topic channels even when the content is clearly spam.
+
+The user-visible goal is to reduce spam collected by topic channels with a more aggressive channel-only threshold while keeping account-state and global visibility decisions conservative.
+
+## 2. Goal & Non-Goals
+
+In scope:
+
+- Add a topic-channel-only spam filter threshold fixed at `0.8`.
+- Apply the topic-channel spam threshold to all topic channels.
+- Keep the existing global `spam_detection` threshold separate from topic channel collection.
+- Preserve `spam_detection` behavior for publication, `/newest`, search exclusion, global visibility, comments, account restrictions, freezes, bans, and deletions.
+- Capture detector response metadata for future audit and calibration, including `score`, `decision`, `reason`, `p_spam`, and `p_ham` when the detector returns them.
+- Add durable audit logging for manual spam status changes and article state changes.
+- Provide a review list for pseudo positive and pseudo negative sampling.
+- Add tests proving channel-only filtering can be more aggressive than global spam filtering.
+
+Out of scope:
+
+- No account freezing, banning, restriction, or deletion rule changes.
+- No production mutation as part of implementation.
+- No retraining or redeploying the Lambda spam model.
+- No public dataset release change.
+- No UI change.
+
+## 3. Success Criteria
+
+| #   | Acceptance condition                                                                                                                       | How verified                                                                                                     |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| 1   | Topic channel articles use a channel-only spam threshold and can exclude `spam_score >= 0.8` while global spam threshold remains `0.94`.   | Unit test for `ChannelService.findTopicChannelArticles`; staging GraphQL query against a controlled article set. |
+| 2   | `/newest` continues to use the global `spam_detection` threshold.                                                                          | Unit test for `ArticleService.findNewestArticles` or resolver-level regression test.                             |
+| 3   | Publication spam decision does not use the channel-only threshold.                                                                         | Unit test around `PublicationService._runPostProcessing` or existing publication spam tests.                     |
+| 4   | Detector metadata is preserved when returned by the model and old score-only responses still work.                                         | Unit tests for `SpamDetector.detect` and post-processing persistence/logging.                                    |
+| 5   | Manual `setSpamStatus` and `updateArticleState` produce audit records with actor, target, old value, new value, and reason when available. | Resolver unit tests and audit log query inspection in staging.                                                   |
+| 6   | All topic channels use `0.8` after migration, while non-channel moderation decisions keep their existing criteria.                         | Migration review and topic channel query tests.                                                                  |
+| 7   | Operators can generate a review list for pseudo positive and pseudo negative sampling.                                                     | `db/sql/topic-channel-spam-threshold-audit.sql`.                                                                 |
+
+## 4. Repos & Service Placement
+
+| Work area                        | Repo                                                             | Core / Non-core   | Reason                                                                       |
+| -------------------------------- | ---------------------------------------------------------------- | ----------------- | ---------------------------------------------------------------------------- |
+| Topic channel spam filtering     | `thematters/matters-server`                                      | Core              | Topic channel GraphQL query and domain filtering live in `ChannelService`.   |
+| Detector response handling       | `thematters/matters-server`                                      | Core              | Publication post-processing currently owns article `spam_score` persistence. |
+| Manual moderation audit log      | `thematters/matters-server`                                      | Core              | `setSpamStatus` and `updateArticleState` are core admin mutations.           |
+| Historical dataset investigation | `thematters/matters-spam-dataset`, AWS S3 when session is active | Non-core evidence | Dataset is evidence and calibration input, not runtime behavior.             |
+
+## 5. Data & Schema
+
+New or changed tables and columns:
+
+- Preferred additive migration on `article`:
+  - `decision text nullable`
+  - `reason text nullable`
+  - `p_spam float nullable`
+  - `p_ham float nullable`
+- Add feature flag row:
+  - `topic_channel_spam_filter`, `flag=on`, `value=0.8`
+
+Review list:
+
+- `db/sql/topic-channel-spam-threshold-audit.sql`
+- `pseudo_positive_candidate` lists articles that are blocked by topic-channel `0.8` but remain below global `spam_detection`.
+- `pseudo_negative_candidate` lists articles still allowed by topic-channel `0.8`, but close enough to sample for missed spam.
+- The list is for channel collection review only and must not be used as account enforcement input.
+
+GraphQL:
+
+- No public GraphQL fields by default.
+- OSS-only spam status can later expose detector metadata if needed, but this SPEC does not require it.
+
+Backfill:
+
+- No mandatory backfill. Existing rows keep only `spam_score`.
+- Historical CloudWatch and dataset score evidence can be used for calibration, but implementation must tolerate null metadata.
+
+Dataset finding so far:
+
+- `matters-spam-dataset` public schema does not include detector raw response.
+- Internal v2026.06 files include `current_spam_score`, `current_is_spam`, `label_source`, and correction metadata.
+- The documented source families are separate and must not be mixed as ground truth: public release, correction CSV, and legacy S3 parquet.
+- AWS verification found `matters-spam-sample-worker`, writing comment samples to `s3://matters-spam-training-samples/comment-training-samples/l2-captured`. Those records contain `label`, `text`, `labelSource`, `commentHash`, `occurredAt`, and optional `score` or `authorHash`, but not article detector raw response.
+- S3 also contains article correction and ring-shadow artifacts, but no article detector raw response store was found.
+- `spam-detection-serverless` article handler reads `event.body` as raw text and its README examples use raw POST bodies. Direct production endpoint comparison showed JSON `{ "text": ... }` can score normal text near spam levels, while raw body returns the expected lower score. `matters-server` article detection must use raw body before trusting score or `decision` comparisons.
+
+## 6. Permissions
+
+| Actor                      | May do                                                                        | Must NOT do                                                            | Enforced by                                                               |
+| -------------------------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Anonymous / regular viewer | Read topic channel articles filtered by enabled thresholds.                   | See admin-only detector metadata or audit log internals.               | Existing public GraphQL resolvers.                                        |
+| Admin / OSS user           | Read spam status and moderate content according to existing permission gates. | Change production feature flags without explicit approval.             | Existing `@auth(mode: admin)`, `readSpamStatus`, and `setFeature` policy. |
+| Server post-processing     | Persist detector score and metadata.                                          | Freeze, ban, delete, or restrict accounts from channel-only threshold. | Service-layer separation and tests.                                       |
+
+## 7. Risk Class
+
+| Risk surface                  | Touched? | Boundary                                                                             |
+| ----------------------------- | -------- | ------------------------------------------------------------------------------------ |
+| Payments / payout / wallet    | No       | Not touched.                                                                         |
+| Moderation / spam / blocklist | Yes      | Topic channel spam filtering, detector metadata, manual moderation audit logging.    |
+| Federation / ActivityPub      | No       | No federation export changes.                                                        |
+| Auth / OAuth / session        | No       | No auth changes.                                                                     |
+| File upload                   | No       | Not touched.                                                                         |
+| Public domain routing         | No       | Not touched.                                                                         |
+| Account state / permissions   | Yes      | Audit logging reads actor and target state, but does not change account-state rules. |
+| Email / notifications         | No       | No notification behavior change.                                                     |
+
+Security review is mandatory before production promotion or flag launch.
+
+## 8. Feature-Flag Plan
+
+| Field                   | Value                                                                                                |
+| ----------------------- | ---------------------------------------------------------------------------------------------------- |
+| State while in progress | On for all topic channels                                                                            |
+| Flag name               | `topic_channel_spam_filter`                                                                          |
+| Default state           | `on`, `value=0.8`                                                                                    |
+| Back-end guard          | `SystemService.getTopicChannelSpamThreshold`, used only by `ChannelService.findTopicChannelArticles` |
+| Front-end gating        | None. No UI.                                                                                         |
+| Launch trigger          | Deploy after owner approval and monitor review-list samples.                                         |
+| Kill-switch             | `setFeature(name: topic_channel_spam_filter, flag: off)`                                             |
+
+## 9. Design Surface
+
+| Field                     | Value          |
+| ------------------------- | -------------- |
+| Any UI?                   | No             |
+| Design handoff spec       | Not applicable |
+| Design-system conformance | Not applicable |
+
+## 10. Rollout & Rollback
+
+Rollout:
+
+- Merge additive schema and default-on topic channel feature flag to `develop`.
+- Deploy to staging with `topic_channel_spam_filter=on`, `value=0.8`.
+- Verify topic channel spam reduction without changing `/newest`, publication spam handling, account restrictions, freezes, bans, or deletion.
+- Generate pseudo positive and pseudo negative samples with `db/sql/topic-channel-spam-threshold-audit.sql`.
+- After security review and owner approval, promote to production with the same topic-channel-only threshold.
+
+Rollback:
+
+- Set `topic_channel_spam_filter` to `off`.
+- Existing global `spam_detection` threshold remains independent.
+- Detector metadata columns are additive and can remain unused.
+
+Monitoring:
+
+- Topic channel article volume by channel.
+- Articles excluded by channel spam threshold.
+- False-positive samples, especially `生活事`, `性別／愛`, `書音影`, and `身心靈`.
+- `/newest` spam visibility separately from channel collection.
+- OSS moderation actions, reports, freezes, restrictions, bans, and deletions separately from topic channel collection.
+
+## 11. Open Questions
+
+- No article detector raw response store was found in the checked S3 bucket or local dataset repos. If one exists, it is outside `matters-spam-training-samples` or under a name not discovered in this pass.
+- Detector metadata is stored as individual nullable columns: `decision`, `reason`, `p_spam`, and `p_ham`.
+- The article detector request contract is raw body. `matters-server` should send raw text for article detection while leaving comment and moment detector calls unchanged.
+- Confirm whether `decision=block` should be used for global visibility in a later SPEC after replay validation. It is not part of this channel-only change.
+- Confirm whether audit log should include a free-form moderation reason now or only old/new state.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "format": "prettier --write \"{,!(node_modules|build|coverage)/**/}*.{js,jsx,ts,tsx,json}\"",
     "format:check": "npm run format -- --list-different",
+    "transparency:export": "node build/handlers/bin/exportTransparencyMetrics.js",
     "gen:schema": "tsc -p . && node build/common/utils/exportSchema.js",
     "gen:types": "graphql-codegen-esm --config codegen.json # detail docs see https://the-guild.dev/graphql/codegen/plugins/typescript/typescript",
     "gen": "npm run gen:schema && npm run gen:types",

--- a/schema.graphql
+++ b/schema.graphql
@@ -174,6 +174,7 @@ type Mutation {
   putUserFederationSetting(input: PutUserFederationSettingInput!): UserFederationSetting!
   putArticleFederationSetting(input: PutArticleFederationSettingInput!): ArticleFederationSetting!
   putIcymiTopic(input: PutIcymiTopicInput!): IcymiTopic
+  updateModerationCase(input: UpdateModerationCaseInput!): ModerationCase!
   setSpamStatus(input: SetSpamStatusInput!): Writing!
   setAdStatus(input: SetAdStatusInput!): Article!
   setWritingAdStatus(input: SetAdStatusInput!): Writing!
@@ -2572,7 +2573,27 @@ type Report implements Node {
   The audit record when this report originates from a community watch action.
   """
   communityWatchAction: CommunityWatchAction
+
+  """
+  Structured moderation case summary for OSS review and transparency reporting.
+  """
+  moderationCase: ModerationCase
   createdAt: DateTime!
+}
+
+type ModerationCase {
+  id: ID!
+  source: ModerationCaseSource!
+  targetType: ModerationTargetType!
+  reason: String!
+  publicReason: String
+  status: ModerationCaseStatus!
+  outcome: ModerationCaseOutcome
+  automationRole: ModerationAutomationRole!
+  noticeState: ModerationNoticeState!
+  createdAt: DateTime!
+  resolvedAt: DateTime
+  closedAt: DateTime
 }
 
 type ReportConnection implements Connection {
@@ -2726,6 +2747,15 @@ input OSSSpamRingsInput {
 
 input OSSSpamRingsFilter {
   status: SpamRingStatus
+}
+
+input UpdateModerationCaseInput {
+  id: ID!
+  status: ModerationCaseStatus
+  outcome: ModerationCaseOutcome
+  noticeState: ModerationNoticeState
+  publicReason: String
+  internalNote: String
 }
 
 input NodeInput {
@@ -3070,6 +3100,61 @@ enum ReportSource {
 
   """Created automatically when a community watch member removes a comment."""
   community_watch
+}
+
+enum ModerationCaseSource {
+  direct_report
+  community_watch
+  admin
+  system
+  model_assisted
+  automated
+}
+
+enum ModerationTargetType {
+  article
+  comment
+  moment
+  user
+  tag
+  other
+}
+
+enum ModerationCaseStatus {
+  received
+  reviewing
+  action_taken
+  rejected
+  appealed
+  resolved
+  closed
+}
+
+enum ModerationCaseOutcome {
+  no_action
+  content_collapsed
+  content_hidden
+  content_removed
+  account_limited
+  restored
+  partially_restored
+  upheld
+}
+
+enum ModerationAutomationRole {
+  none
+  suggested
+  assisted
+  automated
+}
+
+enum ModerationNoticeState {
+  not_required
+  pending
+  sent
+  delayed
+  prohibited
+  failed
 }
 
 type IcymiTopic implements Node {

--- a/schema.graphql
+++ b/schema.graphql
@@ -3010,6 +3010,7 @@ enum FeatureName {
   circle_management
   circle_interact
   spam_detection
+  topic_channel_spam_filter
   article_channel
   hottest_moment_feed
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -2655,6 +2655,7 @@ type SpamRingSignals {
   topEntity: String
   sampleCodes: [String!]
   sampleBrands: [String!]
+  sampleTexts: [String!]
   contentModelMax: Float
 }
 
@@ -2736,6 +2737,7 @@ enum SpamRingsSort {
   score
   detectedAt
   nAuthors
+  frozenAt
 }
 
 input OSSSpamRingsInput {
@@ -3970,6 +3972,7 @@ input SpamRingSignalsInput {
   topEntity: String
   sampleCodes: [String!]
   sampleBrands: [String!]
+  sampleTexts: [String!]
   contentModelMax: Float
 }
 

--- a/src/common/enums/cache.ts
+++ b/src/common/enums/cache.ts
@@ -34,6 +34,7 @@ export const CACHE_PREFIX = {
   EMAIL_DOMAIL_WHITELIST: 'cache-email-domain-whitelist',
   TAG_COVERS: 'cache-tag-covers',
   SPAM_THRESHOLD: 'cache-spam-threshold',
+  TOPIC_CHANNEL_SPAM_THRESHOLD: 'cache-topic-channel-spam-threshold',
   ARTICLE_CHANNEL_THRESHOLD: 'cache-article-channel-threshold',
   RECOMMENDATION_TAGS: 'cache-recommendation-tags',
   RECOMMENDATION_AUTHORS: 'cache-recommendation-authors',

--- a/src/common/enums/feature.ts
+++ b/src/common/enums/feature.ts
@@ -8,6 +8,7 @@ export const FEATURE_NAME = {
   circle_management: 'circle_management',
   circle_interact: 'circle_interact',
   spam_detection: 'spam_detection',
+  topic_channel_spam_filter: 'topic_channel_spam_filter',
   article_channel: 'article_channel',
   hottest_moment_feed: 'hottest_moment_feed',
 } as const

--- a/src/common/enums/logging.ts
+++ b/src/common/enums/logging.ts
@@ -55,6 +55,8 @@ export const AUDIT_LOG_ACTION = {
   rejectMomentFeedApplication: 'reject_moment_feed_application',
   revokeMomentFeedApplication: 'revoke_moment_feed_application',
   autoApproveMomentFeedApplication: 'auto_approve_moment_feed_application',
+  setSpamStatus: 'set_spam_status',
+  updateArticleState: 'update_article_state',
 } as const
 
 export const AUDIT_LOG_STATUS = {

--- a/src/common/enums/quote.ts
+++ b/src/common/enums/quote.ts
@@ -6,7 +6,3 @@ export const QUOTE_STATE = {
 
 // a quote is a "one-glance" excerpt; longer text is a paragraph, not a quote
 export const MAX_QUOTE_LENGTH = 80
-
-// anti-abuse caps (product-decided defaults, tunable)
-export const QUOTE_DAILY_LIMIT = 5
-export const QUOTE_PER_ARTICLE_LIMIT = 2

--- a/src/common/utils/__test__/communityWatchRemoveComment.test.ts
+++ b/src/common/utils/__test__/communityWatchRemoveComment.test.ts
@@ -131,6 +131,12 @@ const createContext = ({
       userService: {
         findFeatureFlags: async () => featureFlags,
       },
+      commentService: {
+        findActiveCommunityWatchAction: async () =>
+          insertedActions[0] ? { id: '501', ...insertedActions[0] } : null,
+        syncCommunityWatchModerationCaseCreated: jest.fn(),
+        syncCommunityWatchModerationCaseNoticeSent: jest.fn(),
+      },
       notificationService: {
         trigger: jest.fn(),
       },

--- a/src/common/utils/__test__/communityWatchStaffReview.test.ts
+++ b/src/common/utils/__test__/communityWatchStaffReview.test.ts
@@ -149,7 +149,10 @@ const createMutationContext = ({
       hasRole: (role: string) => isAdmin && role === 'admin',
     },
     dataSources: {
-      commentService,
+      commentService: {
+        syncCommunityWatchModerationCaseNoticeSent: jest.fn<any>(),
+        ...commentService,
+      },
       notificationService,
       connections: { redis: { smembers: async () => [] } },
     },
@@ -433,6 +436,9 @@ describe('community watch staff review mutations', () => {
       ],
       data: {
         link: `https://community-watch.matters.town/records/${baseAction.uuid}/`,
+        moderationSource: 'community_watch',
+        publicReason: baseAction.reason,
+        appealLink: 'https://matters.town/appeals',
       },
     })
     expect(notificationTrigger).toHaveBeenCalledWith({
@@ -447,6 +453,9 @@ describe('community watch staff review mutations', () => {
       ],
       data: {
         link: `https://community-watch.matters.town/records/${baseAction.uuid}/`,
+        moderationSource: 'community_watch',
+        publicReason: baseAction.reason,
+        appealLink: 'https://matters.town/appeals',
       },
     })
   })

--- a/src/connectors/__test__/articleService/articleService.test.ts
+++ b/src/connectors/__test__/articleService/articleService.test.ts
@@ -989,6 +989,38 @@ describe('spam detection', () => {
     })
     expect(article?.spamScore).toBe(score)
   })
+  test('persists detector metadata', async () => {
+    const articleId = '1'
+
+    const mockSpamDetoctor = {
+      detectResult: jest.fn(() => ({
+        score: 0.88,
+        decision: 'block',
+        reason: 'commercial solicitation',
+        pSpam: 0.7,
+        pHam: 0.02,
+      })),
+    }
+    // @ts-ignore
+    await publicationService._detectSpam(
+      { id: articleId, title: 'test', content: 'test' },
+      mockSpamDetoctor as any
+    )
+
+    const article = await atomService.findUnique({
+      table: 'article',
+      where: { id: articleId },
+    })
+    expect(article).toEqual(
+      expect.objectContaining({
+        spamScore: 0.88,
+        decision: 'block',
+        reason: 'commercial solicitation',
+        pSpam: 0.7,
+        pHam: 0.02,
+      })
+    )
+  })
   test('find spam articles', async () => {
     const articles = await articleService.findArticles({
       spam: {

--- a/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
+++ b/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
@@ -1,13 +1,16 @@
 import type { Connections, Article, TopicChannel } from '#definitions/index.js'
 
+import { FEATURE_FLAG, FEATURE_NAME } from '#common/enums/index.js'
 import { AtomService } from '../../atomService.js'
 import { CampaignService } from '../../campaignService.js'
 import { ChannelService } from '../../channel/channelService.js'
+import { SystemService } from '../../systemService.js'
 import { genConnections, closeConnections, createCampaign } from '../utils.js'
 
 let connections: Connections
 let channelService: ChannelService
 let atomService: AtomService
+let systemService: SystemService
 let channel: TopicChannel
 let articles: Article[]
 let campaignService: CampaignService
@@ -16,6 +19,7 @@ beforeAll(async () => {
   connections = await genConnections()
   channelService = new ChannelService(connections)
   atomService = new AtomService(connections)
+  systemService = new SystemService(connections)
   campaignService = new CampaignService(connections)
 }, 30000)
 
@@ -24,6 +28,14 @@ afterAll(async () => {
 })
 
 beforeEach(async () => {
+  await systemService.setFeatureFlag({
+    name: FEATURE_NAME.topic_channel_spam_filter,
+    flag: FEATURE_FLAG.off,
+  })
+  await systemService.setFeatureFlag({
+    name: FEATURE_NAME.spam_detection,
+    flag: FEATURE_FLAG.off,
+  })
   await atomService.deleteMany({ table: 'topic_channel_article' })
   await atomService.deleteMany({ table: 'topic_channel' })
 
@@ -40,6 +52,15 @@ beforeEach(async () => {
     take: 6,
   })
   expect(articles).toHaveLength(6)
+  await Promise.all(
+    articles.map(({ id }) =>
+      atomService.update({
+        table: 'article',
+        where: { id },
+        data: { isSpam: null, spamScore: null },
+      })
+    )
+  )
 
   // Add articles to channel
   await channelService.setArticleTopicChannels({
@@ -178,6 +199,37 @@ describe('findTopicChannelArticles', () => {
     for (const id of [articles[0].id, articles[2].id, articles[3].id]) {
       expect(resultIds).toContain(id)
     }
+  })
+
+  test('uses topic channel spam threshold separately from global threshold', async () => {
+    await systemService.setFeatureFlag({
+      name: FEATURE_NAME.spam_detection,
+      flag: FEATURE_FLAG.on,
+      value: 0.94,
+    })
+    await systemService.setFeatureFlag({
+      name: FEATURE_NAME.topic_channel_spam_filter,
+      flag: FEATURE_FLAG.on,
+      value: 0.8,
+    })
+
+    await atomService.update({
+      table: 'article',
+      where: { id: articles[0].id },
+      data: { isSpam: null, spamScore: 0.85 },
+    })
+    await atomService.update({
+      table: 'article',
+      where: { id: articles[1].id },
+      data: { isSpam: null, spamScore: 0.75 },
+    })
+
+    const { query } = await channelService.findTopicChannelArticles(channel.id)
+    const results = await query
+    const resultIds = results.map((article) => article.id)
+
+    expect(resultIds).not.toContain(articles[0].id)
+    expect(resultIds).toContain(articles[1].id)
   })
 
   describe('datetimeRange filtering', () => {

--- a/src/connectors/__test__/spamDetection.test.ts
+++ b/src/connectors/__test__/spamDetection.test.ts
@@ -1,5 +1,61 @@
-import { SpamDetector } from '../spamDetector.js'
+import {
+  createSpamDetectorConfig,
+  normalizeSpamDetectionResponse,
+  SpamDetector,
+} from '../spamDetector.js'
 import { environment } from '#common/environment.js'
+
+describe('spam detector response handling', () => {
+  test('normalizes score and detector metadata', () => {
+    expect(
+      normalizeSpamDetectionResponse({
+        score: 0.88,
+        decision: 'block',
+        reason: 'commercial solicitation',
+        p_spam: 0.7,
+        p_ham: 0.02,
+      })
+    ).toEqual({
+      score: 0.88,
+      decision: 'block',
+      reason: 'commercial solicitation',
+      pSpam: 0.7,
+      pHam: 0.02,
+    })
+  })
+
+  test('normalizes lambda proxy body responses', () => {
+    expect(
+      normalizeSpamDetectionResponse({
+        body: JSON.stringify({ score: 0.12, decision: 'review' }),
+      })
+    ).toEqual({
+      score: 0.12,
+      decision: 'review',
+      reason: null,
+      pSpam: null,
+      pHam: null,
+    })
+  })
+
+  test('builds raw and json request payloads', () => {
+    const rawConfig = createSpamDetectorConfig({
+      apiUrl: 'https://example.test',
+      text: 'test text',
+      requestFormat: 'raw',
+    })
+    expect(rawConfig.data).toBe('test text')
+    expect(rawConfig.headers).toEqual({ 'Content-Type': 'text/plain' })
+
+    expect(
+      createSpamDetectorConfig({
+        apiUrl: 'https://example.test',
+        text: 'test text',
+        requestFormat: 'json',
+      }).data
+    ).toEqual({ text: 'test text' })
+  })
+})
 
 test.skip('detect', async () => {
   const spamDetection = new SpamDetector(environment.spamDetectionApiUrl)

--- a/src/connectors/__test__/spamRingService.test.ts
+++ b/src/connectors/__test__/spamRingService.test.ts
@@ -73,8 +73,14 @@ const makeConnections = ({
 }
 
 const makeUserService = (users: Record<string, any>) => ({
-  banUser: jest.fn(async (id: string) => ({ ...users[id], state: USER_STATE.banned })),
-  unbanUser: jest.fn(async (id: string) => ({ ...users[id], state: USER_STATE.active })),
+  banUser: jest.fn(async (id: string) => ({
+    ...users[id],
+    state: USER_STATE.banned,
+  })),
+  unbanUser: jest.fn(async (id: string) => ({
+    ...users[id],
+    state: USER_STATE.active,
+  })),
   findScore: jest.fn(async (_id: string) => 0),
 })
 
@@ -87,17 +93,29 @@ const makeService = (connections: any, users: Record<string, any>) => {
 }
 
 describe('SpamRingService.freezeRing', () => {
-  test('bans eligible members, skips old / already-banned, freezes ring', async () => {
-    const ring = { id: '1', status: 'pending' }
+  test('bans eligible members, skips old / already-banned for low-confidence ring, freezes ring', async () => {
+    const ring = { id: '1', status: 'pending', signals: { nearDupRingSize: 1 } }
     const members = [
       { id: 'm1', userId: 'u1', status: 'pending', bannedByThisRing: false },
       { id: 'm2', userId: 'u2', status: 'pending', bannedByThisRing: false },
       { id: 'm3', userId: 'u3', status: 'pending', bannedByThisRing: false },
     ]
     const users: Record<string, any> = {
-      u1: { id: 'u1', state: USER_STATE.active, createdAt: new Date(Date.now() - DAY) },
-      u2: { id: 'u2', state: USER_STATE.active, createdAt: new Date(Date.now() - 100 * DAY) },
-      u3: { id: 'u3', state: USER_STATE.banned, createdAt: new Date(Date.now() - DAY) },
+      u1: {
+        id: 'u1',
+        state: USER_STATE.active,
+        createdAt: new Date(Date.now() - DAY),
+      },
+      u2: {
+        id: 'u2',
+        state: USER_STATE.active,
+        createdAt: new Date(Date.now() - 100 * DAY),
+      },
+      u3: {
+        id: 'u3',
+        state: USER_STATE.banned,
+        createdAt: new Date(Date.now() - DAY),
+      },
     }
     const { connections, rec } = makeConnections({ ring, members })
     const service = makeService(connections, users)
@@ -115,11 +133,17 @@ describe('SpamRingService.freezeRing', () => {
       remark: USER_BAN_REMARK.spamRing,
     })
     expect(result.frozen.map((u: any) => u.id)).toEqual(['u1'])
-    expect(result.skipped.map((s: any) => s.user.id).sort()).toEqual(['u2', 'u3'])
+    expect(result.skipped.map((s: any) => s.user.id).sort()).toEqual([
+      'u2',
+      'u3',
+    ])
     const u2skip = result.skipped.find((s: any) => s.user.id === 'u2')
     expect(u2skip?.reason).toMatch(/old account/)
     // ring marked frozen
-    expect(rec.ringUpdates.at(-1)).toMatchObject({ status: 'frozen', frozenBy: '9' })
+    expect(rec.ringUpdates.at(-1)).toMatchObject({
+      status: 'frozen',
+      frozenBy: '9',
+    })
     // events include the member ban + ring frozen + a skip
     const actions = rec.eventInserts.map((e) => e.action)
     expect(actions).toEqual(
@@ -127,11 +151,64 @@ describe('SpamRingService.freezeRing', () => {
     )
   })
 
+  test('bans old and high-karma members for high-confidence repeated ring', async () => {
+    const ring = {
+      id: '1',
+      status: 'pending',
+      signals: { nearDupRingSize: 12, sampleCodes: ['LIDANG'] },
+    }
+    const members = [
+      { id: 'm1', userId: 'u1', status: 'pending', bannedByThisRing: false },
+      { id: 'm2', userId: 'u2', status: 'pending', bannedByThisRing: false },
+    ]
+    const users: Record<string, any> = {
+      u1: {
+        id: 'u1',
+        state: USER_STATE.active,
+        createdAt: new Date(Date.now() - 100 * DAY),
+      },
+      u2: {
+        id: 'u2',
+        state: USER_STATE.active,
+        createdAt: new Date(Date.now() - DAY),
+      },
+    }
+    const { connections, rec } = makeConnections({ ring, members })
+    const service = makeService(connections, users)
+    const userService = makeUserService(users)
+    userService.findScore = jest.fn(async (id: string) =>
+      id === 'u2' ? 10 : 0
+    )
+
+    const result = await service.freezeRing({
+      ringId: '1',
+      actorId: '9',
+      userService: userService as any,
+    })
+
+    expect(userService.banUser).toHaveBeenCalledTimes(2)
+    expect(result.frozen.map((u: any) => u.id).sort()).toEqual(['u1', 'u2'])
+    expect(result.skipped).toEqual([])
+
+    const frozenEvent = rec.eventInserts.find((e) => e.action === 'frozen')
+    expect(JSON.parse(frozenEvent.detail)).toMatchObject({
+      frozen: 2,
+      skipped: 0,
+      guardrailBypassed: true,
+    })
+  })
+
   test('refuses to freeze a dismissed ring', async () => {
-    const { connections } = makeConnections({ ring: { id: '1', status: 'dismissed' } })
+    const { connections } = makeConnections({
+      ring: { id: '1', status: 'dismissed' },
+    })
     const service = makeService(connections, {})
     await expect(
-      service.freezeRing({ ringId: '1', actorId: '9', userService: makeUserService({}) as any })
+      service.freezeRing({
+        ringId: '1',
+        actorId: '9',
+        userService: makeUserService({}) as any,
+      })
     ).rejects.toThrow('dismissed')
   })
 })
@@ -167,20 +244,35 @@ describe('SpamRingService.unfreezeRing', () => {
   })
 
   test('refuses to unfreeze a ring that is not frozen', async () => {
-    const { connections } = makeConnections({ ring: { id: '1', status: 'pending' } })
+    const { connections } = makeConnections({
+      ring: { id: '1', status: 'pending' },
+    })
     const service = makeService(connections, {})
     await expect(
-      service.unfreezeRing({ ringId: '1', actorId: '9', userService: makeUserService({}) as any })
+      service.unfreezeRing({
+        ringId: '1',
+        actorId: '9',
+        userService: makeUserService({}) as any,
+      })
     ).rejects.toThrow('not frozen')
   })
 })
 
 describe('SpamRingService.dismissRing', () => {
   test('marks ring dismissed and writes an event', async () => {
-    const { connections, rec } = makeConnections({ ring: { id: '1', status: 'pending' } })
+    const { connections, rec } = makeConnections({
+      ring: { id: '1', status: 'pending' },
+    })
     const service = makeService(connections, {})
-    await service.dismissRing({ ringId: '1', actorId: '9', note: 'false positive' })
-    expect(rec.ringUpdates.at(-1)).toMatchObject({ status: 'dismissed', note: 'false positive' })
+    await service.dismissRing({
+      ringId: '1',
+      actorId: '9',
+      note: 'false positive',
+    })
+    expect(rec.ringUpdates.at(-1)).toMatchObject({
+      status: 'dismissed',
+      note: 'false positive',
+    })
     expect(rec.eventInserts.map((e) => e.action)).toContain('dismissed')
   })
 })
@@ -221,7 +313,13 @@ const makeImportConnections = ({
   }
 
   const builder = (table: string) => {
-    const ctx: any = { table, where: {}, whereIn: null, offset: undefined, limit: undefined }
+    const ctx: any = {
+      table,
+      where: {},
+      whereIn: null,
+      offset: undefined,
+      limit: undefined,
+    }
     const b: any = {
       where: (w: any) => {
         Object.assign(ctx.where, w)
@@ -294,7 +392,9 @@ const makeImportConnections = ({
       then: (resolve: any) => {
         if (table === 'user' && ctx.whereIn) {
           return resolve(
-            users.filter((u) => ctx.whereIn.values.includes(u[ctx.whereIn.column]))
+            users.filter((u) =>
+              ctx.whereIn.values.includes(u[ctx.whereIn.column])
+            )
           )
         }
         const rows = rowsFor(table, ctx.where)

--- a/src/connectors/__test__/systemService.test.ts
+++ b/src/connectors/__test__/systemService.test.ts
@@ -369,6 +369,17 @@ test('get spam threshold', async () => {
   expect(threshold).toBe(0.5)
 })
 
+test('get topic channel spam threshold', async () => {
+  await systemService.setFeatureFlag({
+    name: FEATURE_NAME.topic_channel_spam_filter,
+    flag: FEATURE_FLAG.on,
+    value: 0.8,
+  })
+
+  const threshold = await systemService.getTopicChannelSpamThreshold()
+  expect(threshold).toBe(0.8)
+})
+
 describe('announcement', () => {
   beforeEach(async () => {
     await atomService.deleteMany({ table: 'channel_announcement' })

--- a/src/connectors/__test__/systemService.test.ts
+++ b/src/connectors/__test__/systemService.test.ts
@@ -102,6 +102,31 @@ test('copy asset map', async () => {
 })
 
 describe('report', () => {
+  beforeEach(async () => {
+    await connections.knex('moderation_event').del()
+    await connections.knex('moderation_case_reporter').del()
+    await connections.knex('moderation_case').del()
+  })
+
+  const findModerationCase = ({
+    targetType,
+    targetId,
+    reason = 'other',
+  }: {
+    targetType: 'article' | 'comment' | 'moment'
+    targetId: string
+    reason?: string
+  }) =>
+    connections
+      .knex('moderation_case')
+      .where({
+        source: 'direct_report',
+        targetType,
+        targetId,
+        reason,
+      })
+      .first()
+
   test('submit report', async () => {
     const report = await systemService.submitReport({
       targetType: NODE_TYPES.Article,
@@ -112,7 +137,57 @@ describe('report', () => {
     expect(report.id).toBeDefined()
     expect(report.articleId).not.toBeNull()
     expect(report.commentId).toBeNull()
+
+    const moderationCase = await findModerationCase({
+      targetType: 'article',
+      targetId: '1',
+    })
+    expect(moderationCase).toEqual(
+      expect.objectContaining({
+        source: 'direct_report',
+        targetType: 'article',
+        targetId: '1',
+        primaryReporterId: '1',
+        reason: 'other',
+        status: 'received',
+        outcome: null,
+        automationRole: 'none',
+        noticeState: 'not_required',
+      })
+    )
+
+    const reporter = await connections
+      .knex('moderation_case_reporter')
+      .where({
+        caseId: moderationCase.id,
+        reporterId: '1',
+      })
+      .first()
+    expect(reporter.reportId).toBe(report.id)
+
+    const events = await connections
+      .knex('moderation_event')
+      .where({ caseId: moderationCase.id })
+      .orderBy('id')
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        eventType: 'created',
+        actorType: 'user',
+        actorId: '1',
+        fromStatus: null,
+        toStatus: 'received',
+      })
+    )
+    expect(events[0].metadata).toEqual(
+      expect.objectContaining({
+        reportId: report.id,
+        targetType: 'article',
+      })
+    )
   })
+
   test('submit report on moments', async () => {
     const momentService = new MomentService(connections)
     const moment = await momentService.create(
@@ -129,7 +204,15 @@ describe('report', () => {
     expect(report.momentId).not.toBeNull()
     expect(report.commentId).toBeNull()
     expect(report.articleId).toBeNull()
+
+    const moderationCase = await findModerationCase({
+      targetType: 'moment',
+      targetId: moment.id,
+    })
+    expect(moderationCase.status).toBe('received')
+    expect(moderationCase.outcome).toBeNull()
   })
+
   test('collapse comment if more than 3 different users report it', async () => {
     const commentId = '1'
     const comment = await atomService.findUnique({
@@ -189,6 +272,40 @@ describe('report', () => {
       where: { id: commentId },
     })
     expect(commentAfter4Reports.state).toBe(COMMENT_STATE.collapsed)
+
+    const moderationCase = await findModerationCase({
+      targetType: 'comment',
+      targetId: commentId,
+    })
+    expect(moderationCase).toEqual(
+      expect.objectContaining({
+        status: 'action_taken',
+        outcome: 'content_collapsed',
+      })
+    )
+
+    const reporters = await connections
+      .knex('moderation_case_reporter')
+      .where({ caseId: moderationCase.id })
+      .orderBy('reporterId')
+    expect(reporters.map((r) => r.reporterId)).toEqual(['2', '3', '4'])
+
+    const events = await connections
+      .knex('moderation_event')
+      .where({ caseId: moderationCase.id })
+      .orderBy('id')
+
+    expect(events.map((e) => e.eventType)).toEqual(['created', 'actioned'])
+    expect(events[1]).toEqual(
+      expect.objectContaining({
+        eventType: 'actioned',
+        actorType: 'system',
+        fromStatus: 'received',
+        toStatus: 'action_taken',
+        fromOutcome: null,
+        toOutcome: 'content_collapsed',
+      })
+    )
   })
 
   test('collapse comment if article author report it', async () => {
@@ -218,6 +335,13 @@ describe('report', () => {
     })
 
     expect(commentAfterReport.state).toBe(COMMENT_STATE.collapsed)
+
+    const moderationCase = await findModerationCase({
+      targetType: 'comment',
+      targetId: commentId,
+    })
+    expect(moderationCase.status).toBe('action_taken')
+    expect(moderationCase.outcome).toBe('content_collapsed')
   })
 })
 

--- a/src/connectors/__test__/transparencyService.test.ts
+++ b/src/connectors/__test__/transparencyService.test.ts
@@ -1,0 +1,422 @@
+import type { Connections } from '#definitions/index.js'
+
+import { v4 } from 'uuid'
+
+import { TransparencyService } from '../transparencyService.js'
+
+import { closeConnections, genConnections } from './utils.js'
+
+let connections: Connections
+let service: TransparencyService
+
+beforeAll(async () => {
+  connections = await genConnections()
+  service = new TransparencyService(connections)
+}, 30000)
+
+afterAll(async () => {
+  await closeConnections(connections)
+})
+
+beforeEach(async () => {
+  await connections.knex('moderation_event').del()
+  await connections.knex('moderation_case_reporter').del()
+  await connections.knex('moderation_case').del()
+  await connections.knex('community_watch_review_event').del()
+  await connections.knex('community_watch_action').del()
+})
+
+test('exports aggregated transparency metrics without sensitive fields', async () => {
+  const [collapsedCase, hiddenCase, receivedCase] = await connections
+    .knex('moderation_case')
+    .insert([
+      {
+        source: 'direct_report',
+        targetType: 'comment',
+        targetId: '1',
+        primaryReporterId: '1',
+        reason: 'other',
+        publicReason: 'public reason',
+        status: 'action_taken',
+        outcome: 'content_collapsed',
+        automationRole: 'none',
+        noticeState: 'sent',
+        resolvedAt: new Date('2026-01-10T12:00:00.000+08:00'),
+        createdAt: new Date('2026-01-10T00:00:00.000+08:00'),
+        updatedAt: new Date('2026-01-10T12:00:00.000+08:00'),
+      },
+      {
+        source: 'automated',
+        targetType: 'article',
+        targetId: '1',
+        primaryReporterId: null,
+        reason: 'spam',
+        status: 'action_taken',
+        outcome: 'content_hidden',
+        automationRole: 'automated',
+        noticeState: 'not_required',
+        resolvedAt: new Date('2026-02-01T12:00:00.000+08:00'),
+        createdAt: new Date('2026-02-01T00:00:00.000+08:00'),
+        updatedAt: new Date('2026-02-01T12:00:00.000+08:00'),
+      },
+      {
+        source: 'direct_report',
+        targetType: 'moment',
+        targetId: '1',
+        primaryReporterId: '2',
+        reason: 'other',
+        status: 'received',
+        outcome: null,
+        automationRole: 'none',
+        noticeState: 'not_required',
+        createdAt: new Date('2026-03-01T00:00:00.000+08:00'),
+        updatedAt: new Date('2026-03-01T00:00:00.000+08:00'),
+      },
+    ])
+    .returning('*')
+
+  await connections.knex('moderation_event').insert([
+    {
+      caseId: collapsedCase.id,
+      eventType: 'created',
+      actorType: 'user',
+      actorId: '1',
+      toStatus: 'received',
+      internalNote: 'private moderation note',
+      metadata: { userId: '1', reportId: '1' },
+      createdAt: new Date('2026-01-10T00:00:00.000+08:00'),
+    },
+    {
+      caseId: collapsedCase.id,
+      eventType: 'appealed',
+      actorType: 'user',
+      actorId: '1',
+      fromStatus: 'action_taken',
+      toStatus: 'appealed',
+      internalNote: 'appeal private note',
+      createdAt: new Date('2026-01-11T00:00:00.000+08:00'),
+    },
+    {
+      caseId: hiddenCase.id,
+      eventType: 'actioned',
+      actorType: 'model',
+      fromStatus: 'reviewing',
+      toStatus: 'action_taken',
+      toOutcome: 'content_hidden',
+      createdAt: new Date('2026-02-01T12:00:00.000+08:00'),
+    },
+  ])
+
+  const [communityWatchAction] = await connections
+    .knex('community_watch_action')
+    .insert({
+      uuid: v4(),
+      commentId: '1',
+      commentType: 'article',
+      targetType: 'article',
+      targetId: '1',
+      targetTitle: 'Sensitive title should not export',
+      targetShortHash: 'abc123',
+      reason: 'spam_ad',
+      actorId: '1',
+      commentAuthorId: '2',
+      originalContent: 'original comment content should not export',
+      originalState: 'active',
+      actionState: 'restored',
+      appealState: 'received',
+      reviewState: 'reversed',
+      reviewerId: '1',
+      reviewNote: 'community review note',
+      reviewedAt: new Date('2026-01-12T00:00:00.000+08:00'),
+      contentExpiresAt: new Date('2026-04-12T00:00:00.000+08:00'),
+      createdAt: new Date('2026-01-10T00:00:00.000+08:00'),
+      updatedAt: new Date('2026-01-12T00:00:00.000+08:00'),
+    })
+    .returning('*')
+
+  await connections.knex('community_watch_review_event').insert([
+    {
+      uuid: v4(),
+      actionId: communityWatchAction.id,
+      eventType: 'appeal_received',
+      actorId: '2',
+      note: 'community appeal note',
+      createdAt: new Date('2026-01-11T00:00:00.000+08:00'),
+    },
+    {
+      uuid: v4(),
+      actionId: communityWatchAction.id,
+      eventType: 'comment_restored',
+      actorId: '1',
+      note: 'community restore note',
+      createdAt: new Date('2026-01-12T00:00:00.000+08:00'),
+    },
+  ])
+
+  const metrics = await service.exportMetrics({
+    start: '2026-01-01',
+    end: '2026-06-30',
+    timezone: 'Asia/Taipei',
+    generatedAt: new Date('2026-07-01T00:00:00.000+08:00'),
+  })
+
+  expect(metrics.moderation_cases.total).toBe(3)
+  expect(metrics.moderation_cases.by_target_type).toEqual({
+    article: 1,
+    comment: 1,
+    moment: 1,
+  })
+  expect(metrics.moderation_cases.by_source).toEqual({
+    automated: 1,
+    direct_report: 2,
+  })
+  expect(metrics.moderation_cases.by_outcome).toEqual({
+    content_collapsed: 1,
+    content_hidden: 1,
+    unknown: 1,
+  })
+  expect(metrics.moderation_cases.by_automation_role).toEqual({
+    automated: 1,
+    none: 2,
+  })
+  expect(metrics.appeals).toEqual({
+    total: 2,
+    upheld: 0,
+    reversed: 1,
+    partially_reversed: 0,
+    pending: 1,
+    restored_content: 1,
+  })
+  expect(metrics.handling_time).toEqual({
+    average_hours: 12,
+    median_hours: 12,
+    p90_hours: 12,
+    not_recorded: false,
+  })
+  expect(metrics.community_watch).toEqual({
+    total_actions: 1,
+    by_reason: { spam_ad: 1 },
+    appeals: 1,
+    restored: 1,
+    reviewed_by_staff: 1,
+  })
+  expect(metrics.government_requests.total).toBeNull()
+  expect(metrics.privacy_requests.not_recorded).toBe(true)
+
+  const exported = JSON.stringify(metrics)
+  expect(exported).not.toContain('private moderation note')
+  expect(exported).not.toContain('original comment content')
+  expect(exported).not.toContain('community review note')
+  expect(exported).not.toContain('community appeal note')
+  expect(exported).not.toContain('actorId')
+  expect(exported).not.toContain('primaryReporterId')
+  expect(exported).not.toContain('reportId')
+  expect(exported).not.toContain('userId')
+  expect(exported).not.toContain('Sensitive title')
+  expect(receivedCase.id).toBeDefined()
+})
+
+test('serializes stable CSV rows with not recorded gaps', async () => {
+  const metrics = await service.exportMetrics({
+    start: '2026-01-01',
+    end: '2026-06-30',
+    timezone: 'Asia/Taipei',
+    generatedAt: new Date('2026-07-01T00:00:00.000+08:00'),
+  })
+  const csv = service.toCsv(metrics)
+
+  expect(csv.split('\n')[0]).toBe(
+    'schema_version,period_start,period_end,metric_group,metric_name,bucket,count,data_status,note'
+  )
+  expect(csv).toContain(
+    '2026-06-20.1,2026-01-01,2026-06-30,moderation_cases,total,all,0,partial,'
+  )
+  expect(csv).toContain(
+    '2026-06-20.1,2026-01-01,2026-06-30,government_requests,total,all,,not_recorded,source log not configured'
+  )
+  expect(csv).toContain(
+    '2026-06-20.1,2026-01-01,2026-06-30,handling_time,average_hours,all,,not_recorded,no resolved cases in period'
+  )
+  expect(csv).toContain(
+    '2026-06-20.1,2026-01-01,2026-06-30,policy_changes,total,all,,not_recorded,structured source not configured'
+  )
+})
+
+test('loads optional external aggregate and structured change metrics', async () => {
+  const metrics = await service.exportMetrics({
+    start: '2026-01-01',
+    end: '2026-06-30',
+    timezone: 'Asia/Taipei',
+    generatedAt: new Date('2026-07-01T00:00:00.000+08:00'),
+    externalMetrics: {
+      government_requests: {
+        total: 2,
+        by_jurisdiction: { TW: 2 },
+        by_agency_type: { court: 1, law_enforcement: 1 },
+        by_request_type: { data_request: 1, content_restriction: 1 },
+        by_data_type: { account_information: 1, content: 1 },
+        by_result: { rejected: 1, partially_complied: 1 },
+        by_user_notice: { notified: 1, prohibited: 1 },
+      },
+      privacy_requests: {
+        total: 3,
+        access: 1,
+        deletion: 2,
+      },
+      policy_changes: [
+        {
+          date: '2026-03-01',
+          category: 'content_rules',
+          summary: 'Updated public content handling rules for spam reports.',
+          public_url: '/transparency/automation',
+        },
+      ],
+      model_changes: [
+        {
+          date: '2026-04-15',
+          category: 'spam_detection',
+          summary: 'Moved comment spam classifier to review-only monitoring.',
+        },
+      ],
+      recommendation_changes: [],
+    },
+  })
+
+  expect(metrics.government_requests).toEqual({
+    total: 2,
+    by_jurisdiction: { TW: 2 },
+    by_agency_type: { court: 1, law_enforcement: 1 },
+    by_request_type: { data_request: 1, content_restriction: 1 },
+    by_data_type: { account_information: 1, content: 1 },
+    by_result: { rejected: 1, partially_complied: 1 },
+    by_user_notice: { notified: 1, prohibited: 1 },
+    not_recorded: false,
+  })
+  expect(metrics.privacy_requests).toEqual({
+    total: 3,
+    access: 1,
+    correction: 0,
+    deletion: 2,
+    restriction: 0,
+    not_recorded: false,
+  })
+  expect(metrics.data_status.not_recorded_fields).not.toContain(
+    'government_request_log_source_not_configured'
+  )
+  expect(metrics.data_status.not_recorded_fields).not.toContain(
+    'privacy_request_source_not_structured'
+  )
+  expect(metrics.data_status.not_recorded_fields).not.toContain(
+    'policy_change_source_not_structured'
+  )
+  expect(metrics.data_status.not_recorded_fields).not.toContain(
+    'model_change_source_not_structured'
+  )
+  expect(metrics.data_status.not_recorded_fields).not.toContain(
+    'recommendation_change_source_not_structured'
+  )
+  expect(metrics.policy_changes).toEqual([
+    {
+      date: '2026-03-01',
+      category: 'content_rules',
+      summary: 'Updated public content handling rules for spam reports.',
+      public_url: '/transparency/automation',
+    },
+  ])
+  expect(metrics.model_changes).toEqual([
+    {
+      date: '2026-04-15',
+      category: 'spam_detection',
+      summary: 'Moved comment spam classifier to review-only monitoring.',
+    },
+  ])
+  expect(metrics.recommendation_changes).toEqual([])
+
+  const csv = service.toCsv(metrics)
+  expect(csv).toContain(
+    '2026-06-20.1,2026-01-01,2026-06-30,government_requests,total,all,2,partial,'
+  )
+  expect(csv).toContain(
+    '2026-06-20.1,2026-01-01,2026-06-30,government_requests,by_result,rejected,1,partial,'
+  )
+  expect(csv).toContain(
+    '2026-06-20.1,2026-01-01,2026-06-30,privacy_requests,deletion,all,2,partial,'
+  )
+  expect(csv).toContain(
+    '2026-06-20.1,2026-01-01,2026-06-30,policy_changes,total,all,1,partial,'
+  )
+  expect(csv).toContain(
+    '2026-06-20.1,2026-01-01,2026-06-30,model_changes,by_category,spam_detection,1,partial,'
+  )
+  expect(csv).toContain(
+    '2026-06-20.1,2026-01-01,2026-06-30,recommendation_changes,total,all,0,partial,'
+  )
+})
+
+test('rejects external metrics with unknown or unsafe fields', async () => {
+  await expect(
+    service.exportMetrics({
+      start: '2026-01-01',
+      end: '2026-06-30',
+      externalMetrics: {
+        government_requests: {
+          total: 1,
+          records: [{ email: 'private@example.com' }],
+        },
+      } as any,
+    })
+  ).rejects.toThrow(
+    'externalMetrics.government_requests.records is not supported'
+  )
+
+  await expect(
+    service.exportMetrics({
+      start: '2026-01-01',
+      end: '2026-06-30',
+      externalMetrics: {
+        privacy_requests: {
+          total: -1,
+        },
+      },
+    })
+  ).rejects.toThrow(
+    'externalMetrics.privacy_requests.total must be a non-negative integer'
+  )
+
+  await expect(
+    service.exportMetrics({
+      start: '2026-01-01',
+      end: '2026-06-30',
+      externalMetrics: {
+        policy_changes: [
+          {
+            date: '2026-1-1',
+            category: 'content_rules',
+            summary: 'Invalid date format.',
+          },
+        ],
+      },
+    })
+  ).rejects.toThrow(
+    'externalMetrics.policy_changes[0].date must use YYYY-MM-DD format'
+  )
+
+  await expect(
+    service.exportMetrics({
+      start: '2026-01-01',
+      end: '2026-06-30',
+      externalMetrics: {
+        model_changes: [
+          {
+            date: '2026-01-01',
+            category: 'spam_detection',
+            summary: 'Unsafe URL.',
+            public_url: 'javascript:alert(1)',
+          },
+        ],
+      },
+    })
+  ).rejects.toThrow(
+    'externalMetrics.model_changes[0].public_url must be a public http(s) URL or site-relative path'
+  )
+})

--- a/src/connectors/__test__/userService.test.ts
+++ b/src/connectors/__test__/userService.test.ts
@@ -966,6 +966,15 @@ describe('recommendAuthors', () => {
   })
 })
 
+describe('findScore', () => {
+  test('returns 0 (not throw) when the user has no user_reader_view row', async () => {
+    // Brand-new/inactive accounts are absent from user_reader_view; findScore
+    // must not crash spam-ring freeze, whose members are mostly throwaway accounts.
+    const score = await userService.findScore('999999')
+    expect(score).toBe(0)
+  })
+})
+
 describe('updateUserExtra', () => {
   const userId = '1'
 

--- a/src/connectors/article/publicationService.ts
+++ b/src/connectors/article/publicationService.ts
@@ -49,7 +49,7 @@ import { DraftService } from '../draftService.js'
 import { LanguageDetector } from '../languageDetector.js'
 import { NotificationService } from '../notification/notificationService.js'
 import { SearchService } from '../searchService.js'
-import { SpamDetector } from '../spamDetector.js'
+import { type SpamDetectionResult, SpamDetector } from '../spamDetector.js'
 import { SystemService } from '../systemService.js'
 import { TagService } from '../tagService.js'
 import { UserService } from '../userService.js'
@@ -61,6 +61,13 @@ const require = createRequire(import.meta.url)
 const { html2md } = require('@matters/matters-editor/transformers')
 const logger = getLogger('service-article')
 const { difference, isEqual, uniq } = _
+
+type SpamDetectorLike = {
+  detect: (text: string) => Promise<number | null> | number | null
+  detectResult?: (
+    text: string
+  ) => Promise<SpamDetectionResult | null> | SpamDetectionResult | null
+}
 
 export class PublicationService extends BaseService<Article> {
   private systemService: SystemService
@@ -520,9 +527,12 @@ export class PublicationService extends BaseService<Article> {
    *                               *
    *********************************/
 
-  public detectSpam = async (id: string, spamDetector?: SpamDetector) => {
+  public detectSpam = async (id: string, spamDetector?: SpamDetectorLike) => {
     const detector =
-      spamDetector ?? new SpamDetector(environment.spamDetectionApiUrl)
+      spamDetector ??
+      new SpamDetector(environment.spamDetectionApiUrl, {
+        requestFormat: 'raw',
+      })
     const { title, summary, summaryCustomized } =
       await this.articleService.loadLatestArticleVersion(id)
     const content = await this.articleService.loadLatestArticleContent(id)
@@ -539,21 +549,34 @@ export class PublicationService extends BaseService<Article> {
       content,
       summary,
     }: { id: string; title: string; content: string; summary?: string },
-    spamDetector?: SpamDetector
+    spamDetector?: SpamDetectorLike
   ) => {
     const detector =
-      spamDetector ?? new SpamDetector(environment.spamDetectionApiUrl)
+      spamDetector ??
+      new SpamDetector(environment.spamDetectionApiUrl, {
+        requestFormat: 'raw',
+      })
     const text = summary
       ? title + '\n' + summary + '\n' + content
       : title + '\n' + content
-    const score = await detector.detect(text)
+    const result =
+      detector.detectResult !== undefined
+        ? await detector.detectResult(text)
+        : { score: await detector.detect(text) }
+    const score = result?.score ?? null
     logger.info(`Spam detection for article ${id}: ${score}`)
 
-    if (score) {
+    if (score !== null) {
       await this.models.update({
         table: 'article',
         where: { id },
-        data: { spamScore: score },
+        data: {
+          spamScore: score,
+          decision: result && 'decision' in result ? result.decision : null,
+          reason: result && 'reason' in result ? result.reason : null,
+          pSpam: result && 'pSpam' in result ? result.pSpam : null,
+          pHam: result && 'pHam' in result ? result.pHam : null,
+        },
       })
     }
     return score

--- a/src/connectors/channel/channelService.ts
+++ b/src/connectors/channel/channelService.ts
@@ -45,6 +45,7 @@ import { ArticleService } from '../article/articleService.js'
 import { AtomService } from '../atomService.js'
 import { Cache } from '../cache/index.js'
 import { NotificationService } from '../notification/notificationService.js'
+import { SystemService } from '../systemService.js'
 
 import { ChannelClassifier } from './channelClassifier.js'
 
@@ -397,6 +398,12 @@ export class ChannelService {
     }
 
     const pinnedArticleIds = channel.pinnedArticles || []
+    const systemService = new SystemService(this.connections)
+    const [globalSpamThreshold, topicChannelSpamThreshold] = await Promise.all([
+      systemService.getSpamThreshold(),
+      systemService.getTopicChannelSpamThreshold(),
+    ])
+    const spamThreshold = topicChannelSpamThreshold ?? globalSpamThreshold
 
     const pinnedQuery = knexRO
       .select(
@@ -426,10 +433,16 @@ export class ChannelService {
         'article.channel_enabled': true,
       })
       .whereIn('topic_channel_article.channel_id', channelIds)
-      .where((qb) => {
-        qb.where('article.is_spam', false).orWhere((b) => {
-          b.whereNull('article.is_spam')
-        })
+      .modify((builder) => {
+        if (spamThreshold) {
+          builder.modify(excludeSpamModifier, spamThreshold)
+        } else {
+          builder.where((qb) => {
+            qb.where('article.is_spam', false).orWhere((b) => {
+              b.whereNull('article.is_spam')
+            })
+          })
+        }
       })
       .modify(excludeRestrictedModifier)
       .modify(excludeExclusiveCampaignArticles)

--- a/src/connectors/commentService.ts
+++ b/src/connectors/commentService.ts
@@ -9,6 +9,11 @@ import type {
   Connections,
   GQLCommentCommentsInput,
   GQLCommentsInput,
+  ModerationActorType,
+  ModerationCase,
+  ModerationCaseOutcome,
+  ModerationCaseStatus,
+  ModerationEventType,
   CommunityWatchReviewState,
   User,
   ValueOf,
@@ -32,6 +37,7 @@ import {
   ForbiddenError,
   UserInputError,
 } from '#common/errors.js'
+import { getLogger } from '#common/logger.js'
 import { enqueueReportAlert } from '#common/notifications/reportAlert.js'
 import { toGlobalId } from '#common/utils/index.js'
 import { v4 } from 'uuid'
@@ -52,6 +58,8 @@ import { PaymentService } from './paymentService.js'
 import { SpamDetector } from './spamDetector.js'
 import { SystemService } from './systemService.js'
 import { UserService } from './userService.js'
+
+const logger = getLogger('comment-service')
 
 export interface CommentFilter {
   type: ValueOf<typeof COMMENT_TYPE>
@@ -181,7 +189,21 @@ export class CommentService extends BaseService<Comment> {
       )
     }
 
-    return this.knex.transaction(async (trx) => {
+    let moderationSync:
+      | {
+          previousAction: CommunityWatchAction
+          action: CommunityWatchAction
+          actorId: string
+          note?: string | null
+          events: Array<{
+            eventType: CommunityWatchReviewEventType
+            oldValue: string | null
+            newValue: string | null
+          }>
+        }
+      | undefined
+
+    const updatedAction = await this.knex.transaction(async (trx) => {
       const action = await trx<CommunityWatchAction>('community_watch_action')
         .select()
         .where({ uuid })
@@ -248,7 +270,7 @@ export class CommentService extends BaseService<Comment> {
         })
       }
 
-      const [updatedAction] = await trx<CommunityWatchAction>(
+      const [updatedCommunityWatchAction] = await trx<CommunityWatchAction>(
         'community_watch_action'
       )
         .where({ id: action.id })
@@ -262,8 +284,22 @@ export class CommentService extends BaseService<Comment> {
         events,
       })
 
-      return updatedAction
+      moderationSync = {
+        previousAction: action,
+        action: updatedCommunityWatchAction,
+        actorId,
+        note,
+        events,
+      }
+
+      return updatedCommunityWatchAction
     })
+
+    if (moderationSync) {
+      await this.syncCommunityWatchModerationCaseTransition(moderationSync)
+    }
+
+    return updatedAction
   }
 
   public restoreCommunityWatchComment = async ({
@@ -274,8 +310,17 @@ export class CommentService extends BaseService<Comment> {
     uuid: string
     actorId: string
     note?: string | null
-  }): Promise<{ action: CommunityWatchAction; comment: Comment }> =>
-    this.knex.transaction(async (trx) => {
+  }): Promise<{ action: CommunityWatchAction; comment: Comment }> => {
+    let moderationSync:
+      | {
+          previousAction: CommunityWatchAction
+          action: CommunityWatchAction
+          actorId: string
+          note?: string | null
+        }
+      | undefined
+
+    const result = await this.knex.transaction(async (trx) => {
       const action = await trx<CommunityWatchAction>('community_watch_action')
         .select()
         .where({ uuid })
@@ -358,8 +403,22 @@ export class CommentService extends BaseService<Comment> {
         events,
       })
 
+      moderationSync = {
+        previousAction: action,
+        action: updatedAction,
+        actorId,
+        note,
+      }
+
       return { action: updatedAction, comment: updatedComment }
     })
+
+    if (moderationSync) {
+      await this.syncCommunityWatchModerationCaseRestored(moderationSync)
+    }
+
+    return result
+  }
 
   public clearCommunityWatchOriginalContent = async ({
     uuid,
@@ -442,6 +501,380 @@ export class CommentService extends BaseService<Comment> {
       }))
     )
   }
+
+  public syncCommunityWatchModerationCaseCreated = async ({
+    action,
+  }: {
+    action: CommunityWatchAction
+  }) => {
+    try {
+      await this.knex.transaction(async (trx) => {
+        const { moderationCase, created } =
+          await this.findOrCreateCommunityWatchModerationCase(trx, action)
+
+        if (created) {
+          await this.createCommunityWatchModerationEvent(trx, {
+            moderationCase,
+            eventType: 'created',
+            actorType: 'community_watcher',
+            actorId: action.actorId,
+            toStatus: 'received',
+            publicReason: action.reason,
+            metadata: this.toCommunityWatchModerationMetadata(action),
+          })
+        }
+
+        if (
+          moderationCase.status !== 'action_taken' ||
+          moderationCase.outcome !== 'content_hidden'
+        ) {
+          await trx('moderation_case').where({ id: moderationCase.id }).update({
+            status: 'action_taken',
+            outcome: 'content_hidden',
+            noticeState: 'pending',
+            updatedAt: trx.fn.now(),
+          })
+
+          await this.createCommunityWatchModerationEvent(trx, {
+            moderationCase,
+            eventType: 'actioned',
+            actorType: 'community_watcher',
+            actorId: action.actorId,
+            fromStatus: moderationCase.status,
+            toStatus: 'action_taken',
+            fromOutcome: moderationCase.outcome,
+            toOutcome: 'content_hidden',
+            publicReason: action.reason,
+            metadata: this.toCommunityWatchModerationMetadata(action),
+          })
+        }
+      })
+    } catch (error) {
+      logger.error(error)
+    }
+  }
+
+  private syncCommunityWatchModerationCaseTransition = async ({
+    previousAction,
+    action,
+    actorId,
+    note,
+    events,
+  }: {
+    previousAction: CommunityWatchAction
+    action: CommunityWatchAction
+    actorId: string
+    note?: string | null
+    events: Array<{
+      eventType: CommunityWatchReviewEventType
+      oldValue: string | null
+      newValue: string | null
+    }>
+  }) => {
+    const relevantEvents = events.filter(({ eventType }) =>
+      [
+        'appeal_received',
+        'appeal_resolved',
+        'review_upheld',
+        'reason_changed',
+      ].includes(eventType)
+    )
+    if (relevantEvents.length <= 0) {
+      return
+    }
+
+    try {
+      await this.knex.transaction(async (trx) => {
+        let moderationCase =
+          await this.resolveCommunityWatchModerationCaseForAction(trx, {
+            previousAction,
+            action,
+          })
+
+        for (const event of relevantEvents) {
+          if (event.eventType === 'reason_changed') {
+            await this.createCommunityWatchModerationEvent(trx, {
+              moderationCase,
+              eventType: 'reviewed',
+              actorType: 'admin',
+              actorId,
+              publicReason: action.reason,
+              internalNote: note,
+              metadata: {
+                ...this.toCommunityWatchModerationMetadata(action),
+                communityWatchEvent: event.eventType,
+                oldReason: event.oldValue,
+                newReason: event.newValue,
+              },
+            })
+            continue
+          }
+
+          const next =
+            event.eventType === 'appeal_received'
+              ? { status: 'appealed' as const }
+              : event.eventType === 'appeal_resolved'
+              ? { status: 'resolved' as const, resolvedAt: trx.fn.now() }
+              : {
+                  status: 'resolved' as const,
+                  outcome: 'upheld' as const,
+                  resolvedAt: trx.fn.now(),
+                }
+
+          const [updatedCase] = await trx<ModerationCase>('moderation_case')
+            .where({ id: moderationCase.id })
+            .update({
+              ...next,
+              updatedAt: trx.fn.now(),
+            })
+            .returning('*')
+
+          await this.createCommunityWatchModerationEvent(trx, {
+            moderationCase,
+            eventType:
+              event.eventType === 'appeal_received' ? 'appealed' : 'reviewed',
+            actorType: 'admin',
+            actorId,
+            fromStatus: moderationCase.status,
+            toStatus: next.status,
+            fromOutcome: moderationCase.outcome,
+            toOutcome:
+              'outcome' in next
+                ? (next.outcome as ModerationCaseOutcome)
+                : moderationCase.outcome,
+            publicReason: action.reason,
+            internalNote: note,
+            metadata: {
+              ...this.toCommunityWatchModerationMetadata(action),
+              communityWatchEvent: event.eventType,
+              oldValue: event.oldValue,
+              newValue: event.newValue,
+            },
+          })
+
+          moderationCase = updatedCase
+        }
+      })
+    } catch (error) {
+      logger.error(error)
+    }
+  }
+
+  private syncCommunityWatchModerationCaseRestored = async ({
+    previousAction,
+    action,
+    actorId,
+    note,
+  }: {
+    previousAction: CommunityWatchAction
+    action: CommunityWatchAction
+    actorId: string
+    note?: string | null
+  }) => {
+    try {
+      await this.knex.transaction(async (trx) => {
+        const moderationCase =
+          await this.resolveCommunityWatchModerationCaseForAction(trx, {
+            previousAction,
+            action,
+          })
+
+        await trx('moderation_case').where({ id: moderationCase.id }).update({
+          status: 'resolved',
+          outcome: 'restored',
+          resolvedAt: trx.fn.now(),
+          updatedAt: trx.fn.now(),
+        })
+
+        await this.createCommunityWatchModerationEvent(trx, {
+          moderationCase,
+          eventType: 'restored',
+          actorType: 'admin',
+          actorId,
+          fromStatus: moderationCase.status,
+          toStatus: 'resolved',
+          fromOutcome: moderationCase.outcome,
+          toOutcome: 'restored',
+          publicReason: action.reason,
+          internalNote: note,
+          metadata: this.toCommunityWatchModerationMetadata(action),
+        })
+      })
+    } catch (error) {
+      logger.error(error)
+    }
+  }
+
+  public syncCommunityWatchModerationCaseNoticeSent = async ({
+    action,
+  }: {
+    action: CommunityWatchAction
+  }) => {
+    try {
+      await this.knex.transaction(async (trx) => {
+        const moderationCase =
+          await this.resolveCommunityWatchModerationCaseForAction(trx, {
+            previousAction: action,
+            action,
+          })
+
+        await trx('moderation_case').where({ id: moderationCase.id }).update({
+          noticeState: 'sent',
+          updatedAt: trx.fn.now(),
+        })
+
+        await this.createCommunityWatchModerationEvent(trx, {
+          moderationCase,
+          eventType: 'notified',
+          actorType: 'system',
+          publicReason: action.reason,
+          metadata: this.toCommunityWatchModerationMetadata(action),
+        })
+      })
+    } catch (error) {
+      logger.error(error)
+    }
+  }
+
+  private resolveCommunityWatchModerationCaseForAction = async (
+    trx: Knex.Transaction,
+    {
+      previousAction,
+      action,
+    }: {
+      previousAction: CommunityWatchAction
+      action: CommunityWatchAction
+    }
+  ): Promise<ModerationCase> => {
+    const previousBase =
+      this.toCommunityWatchModerationCaseBase(previousAction)
+    const currentBase = this.toCommunityWatchModerationCaseBase(action)
+
+    const previousCase = await trx<ModerationCase>('moderation_case')
+      .where(previousBase)
+      .first()
+
+    if (previousCase && previousAction.reason !== action.reason) {
+      const existingCurrentCase = await trx<ModerationCase>('moderation_case')
+        .where(currentBase)
+        .first()
+
+      if (existingCurrentCase) {
+        return existingCurrentCase
+      }
+
+      const [updatedCase] = await trx<ModerationCase>('moderation_case')
+        .where({ id: previousCase.id })
+        .update({
+          reason: action.reason,
+          publicReason: action.reason,
+          updatedAt: trx.fn.now(),
+        })
+        .returning('*')
+      return updatedCase
+    }
+
+    if (previousCase) {
+      return previousCase
+    }
+
+    const { moderationCase } =
+      await this.findOrCreateCommunityWatchModerationCase(trx, action)
+    return moderationCase
+  }
+
+  private findOrCreateCommunityWatchModerationCase = async (
+    trx: Knex.Transaction,
+    action: CommunityWatchAction
+  ): Promise<{ moderationCase: ModerationCase; created: boolean }> => {
+    const base = this.toCommunityWatchModerationCaseBase(action)
+    const [inserted] = await trx<ModerationCase>('moderation_case')
+      .insert({
+        ...base,
+        primaryReporterId: action.actorId,
+        publicReason: action.reason,
+        status: 'received',
+        automationRole: 'none',
+        noticeState: 'pending',
+      })
+      .onConflict(['source', 'targetType', 'targetId', 'reason'])
+      .ignore()
+      .returning('*')
+
+    if (inserted) {
+      return { moderationCase: inserted, created: true }
+    }
+
+    const moderationCase = await trx<ModerationCase>('moderation_case')
+      .where(base)
+      .first()
+    if (!moderationCase) {
+      throw new Error('failed to create or load Community Watch moderation case')
+    }
+
+    return { moderationCase, created: false }
+  }
+
+  private toCommunityWatchModerationCaseBase = (
+    action: CommunityWatchAction
+  ) => ({
+    source: 'community_watch' as const,
+    targetType: 'comment' as const,
+    targetId: action.commentId,
+    reason: action.reason,
+  })
+
+  private toCommunityWatchModerationMetadata = (
+    action: CommunityWatchAction
+  ) => ({
+    communityWatchActionId: action.id,
+    communityWatchActionUuid: action.uuid,
+    actionState: action.actionState,
+    appealState: action.appealState,
+    reviewState: action.reviewState,
+  })
+
+  private createCommunityWatchModerationEvent = async (
+    trx: Knex.Transaction,
+    {
+      moderationCase,
+      eventType,
+      actorType,
+      actorId,
+      publicReason,
+      internalNote,
+      fromStatus,
+      toStatus,
+      fromOutcome,
+      toOutcome,
+      metadata,
+    }: {
+      moderationCase: ModerationCase
+      eventType: ModerationEventType
+      actorType: ModerationActorType
+      actorId?: string | null
+      publicReason?: string | null
+      internalNote?: string | null
+      fromStatus?: ModerationCaseStatus | null
+      toStatus?: ModerationCaseStatus | null
+      fromOutcome?: ModerationCaseOutcome | null
+      toOutcome?: ModerationCaseOutcome | null
+      metadata?: Record<string, unknown> | null
+    }
+  ) =>
+    trx('moderation_event').insert({
+      caseId: moderationCase.id,
+      eventType,
+      actorType,
+      actorId,
+      publicReason,
+      internalNote,
+      fromStatus,
+      toStatus,
+      fromOutcome,
+      toOutcome,
+      metadata,
+    })
 
   /**
    * Count comments by a given id and comment type.

--- a/src/connectors/notification/notificationService.ts
+++ b/src/connectors/notification/notificationService.ts
@@ -879,6 +879,7 @@ export class NotificationService {
             }),
           ],
           entities: params.entities,
+          data: params.data,
         }
       case OFFICIAL_NOTICE_EXTEND_TYPE.community_watch_comment_restored:
         return {

--- a/src/connectors/spamDetector.ts
+++ b/src/connectors/spamDetector.ts
@@ -5,31 +5,118 @@ import axios, { type AxiosRequestConfig } from 'axios'
 
 const logger = getLogger('spam-detector')
 
+export type SpamDetectorRequestFormat = 'json' | 'raw'
+
+export interface SpamDetectionResult {
+  score: number
+  decision?: string | null
+  reason?: string | null
+  pSpam?: number | null
+  pHam?: number | null
+}
+
+const toNullableString = (value: unknown) =>
+  typeof value === 'string' && value.length > 0 ? value : null
+
+const toNullableNumber = (value: unknown) => {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : null
+}
+
+const parsePayload = (data: unknown): Record<string, unknown> | null => {
+  if (typeof data === 'string') {
+    try {
+      return parsePayload(JSON.parse(data))
+    } catch {
+      return null
+    }
+  }
+
+  if (data && typeof data === 'object') {
+    const payload = data as Record<string, unknown>
+    if ('body' in payload) {
+      return parsePayload(payload.body)
+    }
+    return payload
+  }
+
+  return null
+}
+
+export const normalizeSpamDetectionResponse = (
+  data: unknown
+): SpamDetectionResult | null => {
+  const payload = parsePayload(data)
+  if (!payload) {
+    return null
+  }
+
+  const score = Number(payload.score)
+  if (!Number.isFinite(score)) {
+    return null
+  }
+
+  return {
+    score,
+    decision: toNullableString(payload.decision),
+    reason: toNullableString(payload.reason),
+    pSpam: toNullableNumber(payload.p_spam ?? payload.pSpam),
+    pHam: toNullableNumber(payload.p_ham ?? payload.pHam),
+  }
+}
+
+export const createSpamDetectorConfig = ({
+  apiUrl,
+  text,
+  requestFormat,
+}: {
+  apiUrl: string
+  text: string
+  requestFormat: SpamDetectorRequestFormat
+}): AxiosRequestConfig => ({
+  method: 'post',
+  url: apiUrl,
+  data: requestFormat === 'raw' ? text : { text },
+  headers: requestFormat === 'raw' ? { 'Content-Type': 'text/plain' } : {},
+})
+
 export class SpamDetector {
   private apiUrl: string
+  private requestFormat: SpamDetectorRequestFormat
 
-  public constructor(apiUrl: string) {
+  public constructor(
+    apiUrl: string,
+    {
+      requestFormat = 'json',
+    }: { requestFormat?: SpamDetectorRequestFormat } = {}
+  ) {
     this.apiUrl = apiUrl
+    this.requestFormat = requestFormat
   }
 
   public detect = async (text: string): Promise<number | null> => {
+    const result = await this.detectResult(text)
+    return result?.score ?? null
+  }
+
+  public detectResult = async (
+    text: string
+  ): Promise<SpamDetectionResult | null> => {
     if (isTest) {
       return null
     }
 
-    const config: AxiosRequestConfig = {
-      method: 'post',
-      url: this.apiUrl,
-      data: {
-        text,
-      },
-    }
+    const config = createSpamDetectorConfig({
+      apiUrl: this.apiUrl,
+      text,
+      requestFormat: this.requestFormat,
+    })
 
     let retries = 0
     while (retries < 3) {
       try {
         const response = await axios(config)
-        return response.data.score
+        return normalizeSpamDetectionResponse(response.data)
       } catch (error) {
         retries++
         if (retries >= 3) {

--- a/src/connectors/spamRingService.ts
+++ b/src/connectors/spamRingService.ts
@@ -22,8 +22,44 @@ import { BaseService } from './baseService.js'
 // 模組級常數，便於與信任安全負責人統一調參。
 export const SPAM_RING_GUARDRAIL_MAX_AGE_DAYS = 30
 export const SPAM_RING_GUARDRAIL_MAX_SCORE = 5
+export const SPAM_RING_GUARDRAIL_BYPASS_MIN_RING_SIZE = 10
 
 const DAY_MS = 86400000
+
+const parseSignals = (
+  signals: SpamRing['signals'] | string | null | undefined
+): SpamRingSignals => {
+  if (!signals) {
+    return {}
+  }
+  if (typeof signals !== 'string') {
+    return signals
+  }
+  try {
+    return JSON.parse(signals) ?? {}
+  } catch {
+    return {}
+  }
+}
+
+const arrayLength = (value?: string[] | null) =>
+  Array.isArray(value) ? value.length : 0
+
+const isHighConfidenceFreezeRing = (ring: SpamRing) => {
+  const signals = parseSignals(ring.signals)
+  const nearDupRingSize = signals.nearDupRingSize ?? 0
+  const entityRingSize = signals.entityRingSize ?? 0
+  const hasExternalEntity =
+    !!signals.topEntity ||
+    arrayLength(signals.sampleCodes) > 0 ||
+    arrayLength(signals.sampleBrands) > 0
+
+  return (
+    nearDupRingSize >= SPAM_RING_GUARDRAIL_BYPASS_MIN_RING_SIZE ||
+    entityRingSize >= SPAM_RING_GUARDRAIL_BYPASS_MIN_RING_SIZE ||
+    hasExternalEntity
+  )
+}
 
 export interface SpamRingCandidate {
   fingerprint: string
@@ -223,6 +259,7 @@ export class SpamRingService extends BaseService<SpamRing> {
     const members = await this.findMembers(ringId)
     const frozen: User[] = []
     const skipped: Array<{ user: User; reason: string }> = []
+    const bypassGuardrail = isHighConfidenceFreezeRing(ring)
 
     for (const member of members) {
       const user = (await this.models.userIdLoader.load(
@@ -247,17 +284,24 @@ export class SpamRingService extends BaseService<SpamRing> {
         continue
       }
       if (user.state === USER_STATE.banned) {
-        await this.skipMember(member.id, user, 'already banned', actorId, ringId)
+        await this.skipMember(
+          member.id,
+          user,
+          'already banned',
+          actorId,
+          ringId
+        )
         skipped.push({ user, reason: 'already banned' })
         continue
       }
 
-      // 老帳號 / 高 karma 豁免（硬性護欄）
+      // 低信心 ring 保留老帳號 / 高 karma 護欄；大量重複或外連邀請 ring 仍處置重複帳號。
       const ageDays = (Date.now() - new Date(user.createdAt).getTime()) / DAY_MS
       const score = await userService.findScore(user.id)
       if (
-        ageDays > SPAM_RING_GUARDRAIL_MAX_AGE_DAYS ||
-        score > SPAM_RING_GUARDRAIL_MAX_SCORE
+        !bypassGuardrail &&
+        (ageDays > SPAM_RING_GUARDRAIL_MAX_AGE_DAYS ||
+          score > SPAM_RING_GUARDRAIL_MAX_SCORE)
       ) {
         const reason =
           ageDays > SPAM_RING_GUARDRAIL_MAX_AGE_DAYS
@@ -305,6 +349,7 @@ export class SpamRingService extends BaseService<SpamRing> {
           remark: remark ?? null,
           frozen: frozen.length,
           skipped: skipped.length,
+          guardrailBypassed: bypassGuardrail,
         },
       },
     ])
@@ -351,7 +396,10 @@ export class SpamRingService extends BaseService<SpamRing> {
       // freeze 後狀態已變（例如被封存）→ 不復活，僅記錄
       if (user.state !== USER_STATE.banned) {
         const reason = `state changed to ${user.state}`
-        await this.updateMember(member.id, { status: 'skipped', skipReason: reason })
+        await this.updateMember(member.id, {
+          status: 'skipped',
+          skipReason: reason,
+        })
         skipped.push({ user, reason })
         continue
       }
@@ -375,7 +423,12 @@ export class SpamRingService extends BaseService<SpamRing> {
       .update({ status: 'restored', updatedAt: now })
       .returning('*')
     await this.insertEvents([
-      { ringId, actorId, action: 'unfrozen', detail: { unbanned: unbanned.length } },
+      {
+        ringId,
+        actorId,
+        action: 'unfrozen',
+        detail: { unbanned: unbanned.length },
+      },
     ])
 
     return { ring: updatedRing, unbanned, skipped }
@@ -474,7 +527,13 @@ export class SpamRingService extends BaseService<SpamRing> {
       preFreezeState: user.state,
     })
     await this.insertEvents([
-      { ringId, memberId, actorId, action: 'member_skipped', detail: { reason } },
+      {
+        ringId,
+        memberId,
+        actorId,
+        action: 'member_skipped',
+        detail: { reason },
+      },
     ])
   }
 

--- a/src/connectors/systemService.ts
+++ b/src/connectors/systemService.ts
@@ -6,6 +6,15 @@ import type {
   ReportType,
   ReportReason,
   Report,
+  ModerationActorType,
+  ModerationAutomationRole,
+  ModerationCase,
+  ModerationCaseOutcome,
+  ModerationCaseSource,
+  ModerationCaseStatus,
+  ModerationEventType,
+  ModerationNoticeState,
+  ModerationTargetType,
   Asset,
   BaseDBSchema,
   LogRecord,
@@ -30,7 +39,7 @@ import {
   AUDIT_LOG_STATUS,
 } from '#common/enums/index.js'
 import { isTest } from '#common/environment.js'
-import { AssetNotFoundError } from '#common/errors.js'
+import { AssetNotFoundError, UserInputError } from '#common/errors.js'
 import { getLogger, auditLog } from '#common/logger.js'
 import { invalidateFQC } from '@matters/apollo-response-cache'
 import { v4 } from 'uuid'
@@ -550,6 +559,9 @@ export class SystemService extends BaseService<BaseDBSchema> {
     reporterId: string
     reason: ReportReason
   }): Promise<Report> => {
+    let report: Report
+    let collapsed = false
+
     if (targetType === NODE_TYPES.Article) {
       const ret = await this.knex('report')
         .insert({
@@ -558,7 +570,7 @@ export class SystemService extends BaseService<BaseDBSchema> {
           reason,
         })
         .returning('*')
-      return ret[0]
+      report = ret[0]
     } else if (targetType === NODE_TYPES.Moment) {
       const ret = await this.knex('report')
         .insert({
@@ -567,7 +579,7 @@ export class SystemService extends BaseService<BaseDBSchema> {
           reason,
         })
         .returning('*')
-      return ret[0]
+      report = ret[0]
     } else {
       const ret = await this.knex('report')
         .insert({
@@ -577,10 +589,358 @@ export class SystemService extends BaseService<BaseDBSchema> {
         })
         .returning('*')
 
-      await this.tryCollapseComment(targetId)
+      collapsed = await this.tryCollapseComment(targetId)
 
-      return ret[0]
+      report = ret[0]
     }
+
+    let moderationCase: ModerationCase | null = null
+    try {
+      moderationCase = await this.syncDirectReportModerationCase({
+        targetType,
+        targetId,
+        reporterId,
+        reason,
+        reportId: report.id,
+        outcome: collapsed ? 'content_collapsed' : null,
+      })
+    } catch (error) {
+      logger.error(error)
+    }
+
+    return {
+      ...report,
+      moderationCaseId: moderationCase?.id ?? null,
+      moderationOutcome: collapsed ? 'content_collapsed' : null,
+    }
+  }
+
+  public markModerationCaseNoticeSent = async ({
+    id,
+    actorType = 'system',
+    actorId,
+    publicReason,
+    metadata,
+  }: {
+    id: string
+    actorType?: ModerationActorType
+    actorId?: string | null
+    publicReason?: string | null
+    metadata?: Record<string, unknown>
+  }): Promise<ModerationCase | null> =>
+    this.knex.transaction(async (trx) => {
+      const moderationCase = await trx<ModerationCase>('moderation_case')
+        .where({ id })
+        .forUpdate()
+        .first()
+
+      if (!moderationCase) {
+        return null
+      }
+
+      const [updatedCase] = await trx<ModerationCase>('moderation_case')
+        .where({ id })
+        .update({
+          noticeState: 'sent',
+          publicReason:
+            publicReason !== undefined
+              ? publicReason
+              : moderationCase.publicReason,
+          updatedAt: trx.fn.now(),
+        })
+        .returning('*')
+
+      await trx('moderation_event').insert({
+        caseId: moderationCase.id,
+        eventType: 'notified',
+        actorType,
+        actorId,
+        publicReason: updatedCase.publicReason,
+        fromStatus: moderationCase.status,
+        toStatus: updatedCase.status,
+        fromOutcome: moderationCase.outcome,
+        toOutcome: updatedCase.outcome,
+        metadata: {
+          noticeState: updatedCase.noticeState,
+          ...(metadata ?? {}),
+        },
+      })
+
+      return updatedCase
+    })
+
+  public updateModerationCase = async ({
+    id,
+    actorId,
+    status,
+    outcome,
+    noticeState,
+    publicReason,
+    internalNote,
+  }: {
+    id: string
+    actorId: string
+    status?: ModerationCaseStatus | null
+    outcome?: ModerationCaseOutcome | null
+    noticeState?: ModerationNoticeState | null
+    publicReason?: string | null
+    internalNote?: string | null
+  }): Promise<ModerationCase> => {
+    const hasCasePatch =
+      !!status ||
+      outcome !== undefined ||
+      !!noticeState ||
+      publicReason !== undefined
+    const hasEventOnlyPatch = !!internalNote
+
+    if (!hasCasePatch && !hasEventOnlyPatch) {
+      throw new UserInputError('no moderation case update provided')
+    }
+
+    return this.knex.transaction(async (trx) => {
+      const moderationCase = await trx<ModerationCase>('moderation_case')
+        .where({ id })
+        .forUpdate()
+        .first()
+
+      if (!moderationCase) {
+        throw new UserInputError('moderation case not found')
+      }
+
+      const patch: Record<string, unknown> = {
+        updatedAt: trx.fn.now(),
+      }
+      if (status) {
+        patch.status = status
+        if (status === 'resolved' && !moderationCase.resolvedAt) {
+          patch.resolvedAt = trx.fn.now()
+        }
+        if (status === 'closed' && !moderationCase.closedAt) {
+          patch.closedAt = trx.fn.now()
+        }
+      }
+      if (outcome !== undefined) {
+        patch.outcome = outcome
+      }
+      if (noticeState) {
+        patch.noticeState = noticeState
+      }
+      if (publicReason !== undefined) {
+        patch.publicReason = publicReason
+      }
+
+      const [updatedCase] = await trx<ModerationCase>('moderation_case')
+        .where({ id: moderationCase.id })
+        .update(patch)
+        .returning('*')
+
+      const eventType: ModerationEventType =
+        updatedCase.status === 'closed'
+          ? 'closed'
+          : updatedCase.status === 'appealed'
+          ? 'appealed'
+          : updatedCase.outcome === 'restored'
+          ? 'restored'
+          : updatedCase.status === 'action_taken'
+          ? 'actioned'
+          : 'reviewed'
+
+      await trx('moderation_event').insert({
+        caseId: moderationCase.id,
+        eventType,
+        actorType: 'admin',
+        actorId,
+        publicReason: updatedCase.publicReason,
+        internalNote: internalNote || null,
+        fromStatus: moderationCase.status,
+        toStatus: updatedCase.status,
+        fromOutcome: moderationCase.outcome,
+        toOutcome: updatedCase.outcome,
+        metadata: {
+          noticeState: updatedCase.noticeState,
+          source: updatedCase.source,
+          targetType: updatedCase.targetType,
+        },
+      })
+
+      return updatedCase
+    })
+  }
+
+  private toModerationTargetType = (
+    targetType: ReportType
+  ): ModerationTargetType => {
+    if (targetType === NODE_TYPES.Article) {
+      return 'article'
+    }
+    if (targetType === NODE_TYPES.Moment) {
+      return 'moment'
+    }
+    return 'comment'
+  }
+
+  private createModerationEvent = async ({
+    caseId,
+    eventType,
+    actorType,
+    actorId,
+    publicReason,
+    internalNote,
+    fromStatus,
+    toStatus,
+    fromOutcome,
+    toOutcome,
+    metadata,
+  }: {
+    caseId: string
+    eventType: ModerationEventType
+    actorType: ModerationActorType
+    actorId?: string | null
+    publicReason?: string | null
+    internalNote?: string | null
+    fromStatus?: ModerationCaseStatus | null
+    toStatus?: ModerationCaseStatus | null
+    fromOutcome?: ModerationCaseOutcome | null
+    toOutcome?: ModerationCaseOutcome | null
+    metadata?: Record<string, unknown> | null
+  }) =>
+    this.knex('moderation_event').insert({
+      caseId,
+      eventType,
+      actorType,
+      actorId,
+      publicReason,
+      internalNote,
+      fromStatus,
+      toStatus,
+      fromOutcome,
+      toOutcome,
+      metadata,
+    })
+
+  private findOrCreateModerationCase = async ({
+    source,
+    targetType,
+    targetId,
+    reporterId,
+    reason,
+    automationRole = 'none',
+  }: {
+    source: ModerationCaseSource
+    targetType: ModerationTargetType
+    targetId: string
+    reporterId?: string | null
+    reason: string
+    automationRole?: ModerationAutomationRole
+  }): Promise<{ moderationCase: ModerationCase; created: boolean }> => {
+    const base = {
+      source,
+      targetType,
+      targetId,
+      reason,
+    }
+    const [inserted] = await this.knex('moderation_case')
+      .insert({
+        ...base,
+        primaryReporterId: reporterId,
+        automationRole,
+      })
+      .onConflict(['source', 'targetType', 'targetId', 'reason'])
+      .ignore()
+      .returning('*')
+
+    if (inserted) {
+      return { moderationCase: inserted, created: true }
+    }
+
+    const moderationCase = await this.knex<ModerationCase>('moderation_case')
+      .where(base)
+      .first()
+
+    if (!moderationCase) {
+      throw new Error('failed to create or load moderation case')
+    }
+
+    await this.knex('moderation_case')
+      .where({ id: moderationCase.id })
+      .update({ updatedAt: this.knex.fn.now() })
+
+    return { moderationCase, created: false }
+  }
+
+  private syncDirectReportModerationCase = async ({
+    targetType,
+    targetId,
+    reporterId,
+    reason,
+    reportId,
+    outcome,
+  }: {
+    targetType: ReportType
+    targetId: string
+    reporterId: string
+    reason: ReportReason
+    reportId: string
+    outcome: ModerationCaseOutcome | null
+  }): Promise<ModerationCase> => {
+    const { moderationCase, created } = await this.findOrCreateModerationCase({
+      source: 'direct_report',
+      targetType: this.toModerationTargetType(targetType),
+      targetId,
+      reporterId,
+      reason,
+    })
+
+    await this.knex('moderation_case_reporter')
+      .insert({
+        caseId: moderationCase.id,
+        reporterId,
+        reportId,
+      })
+      .onConflict(['caseId', 'reporterId'])
+      .ignore()
+
+    if (created) {
+      await this.createModerationEvent({
+        caseId: moderationCase.id,
+        eventType: 'created',
+        actorType: 'user',
+        actorId: reporterId,
+        toStatus: 'received',
+        metadata: {
+          reportId,
+          targetType: this.toModerationTargetType(targetType),
+        },
+      })
+    }
+
+    if (outcome) {
+      const [updatedCase] = await this.knex<ModerationCase>('moderation_case')
+        .where({ id: moderationCase.id })
+        .update({
+          status: 'action_taken',
+          outcome,
+          resolvedAt: this.knex.fn.now(),
+          updatedAt: this.knex.fn.now(),
+        })
+        .returning('*')
+
+      await this.createModerationEvent({
+        caseId: moderationCase.id,
+        eventType: 'actioned',
+        actorType: 'system',
+        fromStatus: moderationCase.status,
+        toStatus: 'action_taken',
+        fromOutcome: moderationCase.outcome,
+        toOutcome: outcome,
+        publicReason: reason,
+        metadata: { reportId },
+      })
+
+      return updatedCase
+    }
+
+    return moderationCase
   }
 
   /**

--- a/src/connectors/systemService.ts
+++ b/src/connectors/systemService.ts
@@ -168,6 +168,35 @@ export class SystemService extends BaseService<BaseDBSchema> {
   }
 
   /**
+   * Get the topic-channel-only spam threshold from `feature_flag` table.
+   */
+  public getTopicChannelSpamThreshold = async (): Promise<number | null> => {
+    const cache = new Cache(
+      CACHE_PREFIX.TOPIC_CHANNEL_SPAM_THRESHOLD,
+      this.connections.objectCacheRedis
+    )
+    const value = (await cache.getObject({
+      keys: { id: 'topic_channel_spam_threshold' },
+      getter: this._getTopicChannelSpamThreshold,
+      expire: isTest ? CACHE_TTL.INSTANT : CACHE_TTL.SHORT,
+    })) as number | null
+    return value
+  }
+  private _getTopicChannelSpamThreshold = async (): Promise<number | null> => {
+    const threshold = await this.models.findFirst({
+      table: 'feature_flag',
+      where: {
+        name: FEATURE_NAME.topic_channel_spam_filter,
+        flag: FEATURE_FLAG.on,
+      },
+    })
+    if (!threshold || !threshold.value) {
+      return null
+    }
+    return threshold.value
+  }
+
+  /**
    * Get the article channel threshold from `feature_flag` table
    * Use to determine whether a article is in a channel by its score
    */

--- a/src/connectors/transparencyService.ts
+++ b/src/connectors/transparencyService.ts
@@ -1,0 +1,1127 @@
+import type { Connections } from '#definitions/index.js'
+import type { Knex } from 'knex'
+
+export const TRANSPARENCY_SCHEMA_VERSION = '2026-06-20.1'
+
+export type TransparencyDataStatus =
+  | 'complete'
+  | 'partial'
+  | 'experimental'
+  | 'not_recorded'
+
+type CountMap = Record<string, number>
+
+type NullableCountMap = CountMap | Record<string, never>
+
+export interface TransparencyChangeLogEntry {
+  date: string
+  category: string
+  summary: string
+  public_url?: string
+}
+
+export interface TransparencyExternalMetricsInput {
+  government_requests?: {
+    total: number
+    by_jurisdiction?: CountMap
+    by_agency_type?: CountMap
+    by_request_type?: CountMap
+    by_data_type?: CountMap
+    by_result?: CountMap
+    by_user_notice?: CountMap
+  }
+  privacy_requests?: {
+    total: number
+    access?: number
+    correction?: number
+    deletion?: number
+    restriction?: number
+  }
+  policy_changes?: TransparencyChangeLogEntry[]
+  model_changes?: TransparencyChangeLogEntry[]
+  recommendation_changes?: TransparencyChangeLogEntry[]
+}
+
+export interface GovernmentRequestMetrics {
+  total: number | null
+  by_jurisdiction: NullableCountMap
+  by_agency_type: NullableCountMap
+  by_request_type: NullableCountMap
+  by_data_type: NullableCountMap
+  by_result: NullableCountMap
+  by_user_notice: NullableCountMap
+  not_recorded: boolean
+}
+
+export interface PrivacyRequestMetrics {
+  total: number | null
+  access: number | null
+  correction: number | null
+  deletion: number | null
+  restriction: number | null
+  not_recorded: boolean
+}
+
+export interface TransparencyMetricsOptions {
+  start: string
+  end: string
+  timezone?: 'Asia/Taipei' | 'UTC'
+  generatedAt?: Date
+  externalMetrics?: TransparencyExternalMetricsInput
+}
+
+export interface TransparencyMetrics {
+  schema_version: typeof TRANSPARENCY_SCHEMA_VERSION
+  reporting_period: {
+    start: string
+    end: string
+    timezone: 'Asia/Taipei' | 'UTC'
+  }
+  data_status: {
+    overall: 'partial'
+    not_recorded_fields: string[]
+    notes: string[]
+  }
+  moderation_cases: {
+    total: number
+    by_target_type: CountMap
+    by_source: CountMap
+    by_reason: CountMap
+    by_status: CountMap
+    by_outcome: CountMap
+    by_automation_role: CountMap
+    by_notice_state: CountMap
+  }
+  appeals: {
+    total: number
+    upheld: number
+    reversed: number
+    partially_reversed: number
+    pending: number
+    restored_content: number
+  }
+  handling_time: {
+    average_hours: number | null
+    median_hours: number | null
+    p90_hours: number | null
+    not_recorded: boolean
+  }
+  community_watch: {
+    total_actions: number
+    by_reason: CountMap
+    appeals: number
+    restored: number
+    reviewed_by_staff: number
+  }
+  government_requests: GovernmentRequestMetrics
+  privacy_requests: PrivacyRequestMetrics
+  policy_changes: TransparencyChangeLogEntry[]
+  model_changes: TransparencyChangeLogEntry[]
+  recommendation_changes: TransparencyChangeLogEntry[]
+  generated_at: string
+}
+
+interface Period {
+  start: string
+  end: string
+  timezone: 'Asia/Taipei' | 'UTC'
+  startDate: Date
+  endExclusiveDate: Date
+}
+
+const timezoneOffset = {
+  'Asia/Taipei': '+08:00',
+  UTC: '+00:00',
+} as const
+
+const dateOnlyPattern = /^\d{4}-\d{2}-\d{2}$/
+
+const assertDateOnly = (value: string, name: string) => {
+  if (!dateOnlyPattern.test(value)) {
+    throw new Error(`${name} must use YYYY-MM-DD format`)
+  }
+}
+
+const addDays = (date: string, days: number) => {
+  const next = new Date(`${date}T00:00:00.000Z`)
+  next.setUTCDate(next.getUTCDate() + days)
+  return next.toISOString().slice(0, 10)
+}
+
+const toPeriodDate = (
+  date: string,
+  timezone: keyof typeof timezoneOffset
+): Date => new Date(`${date}T00:00:00.000${timezoneOffset[timezone]}`)
+
+const formatGeneratedAt = (
+  date: Date,
+  timezone: keyof typeof timezoneOffset
+): string => {
+  const offset = timezoneOffset[timezone]
+  const offsetHours = offset === '+08:00' ? 8 : 0
+  const shifted = new Date(date.getTime() + offsetHours * 60 * 60 * 1000)
+  return `${shifted.toISOString().slice(0, 19)}${offset}`
+}
+
+const toNumber = (value: unknown): number => {
+  if (typeof value === 'number') {
+    return value
+  }
+  if (typeof value === 'bigint') {
+    return Number(value)
+  }
+  if (typeof value === 'string') {
+    return Number.parseFloat(value)
+  }
+  return 0
+}
+
+const toRoundedHours = (value: unknown): number | null => {
+  if (value === null || value === undefined) {
+    return null
+  }
+  const number = toNumber(value)
+  if (Number.isNaN(number)) {
+    return null
+  }
+  return Math.round(number * 100) / 100
+}
+
+const countRows = async (query: Knex.QueryBuilder): Promise<number> => {
+  const row = (
+    await query.count<Array<{ count: string | number }>>({
+      count: '*',
+    })
+  )[0]
+  return toNumber(row?.count)
+}
+
+const governmentRequestMapFields = [
+  'by_jurisdiction',
+  'by_agency_type',
+  'by_request_type',
+  'by_data_type',
+  'by_result',
+  'by_user_notice',
+] as const
+
+const privacyRequestCountFields = [
+  'access',
+  'correction',
+  'deletion',
+  'restriction',
+] as const
+
+const changeLogFields = [
+  'policy_changes',
+  'model_changes',
+  'recommendation_changes',
+] as const
+
+type ChangeLogField = (typeof changeLogFields)[number]
+
+const changeLogEntryFields = [
+  'date',
+  'category',
+  'summary',
+  'public_url',
+] as const
+
+const changeLogSourceGaps: Record<ChangeLogField, string> = {
+  policy_changes: 'policy_change_source_not_structured',
+  model_changes: 'model_change_source_not_structured',
+  recommendation_changes: 'recommendation_change_source_not_structured',
+}
+
+const toRecord = (value: unknown, path: string): Record<string, unknown> => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${path} must be an object`)
+  }
+  return value as Record<string, unknown>
+}
+
+const assertAllowedKeys = (
+  value: Record<string, unknown>,
+  allowedKeys: readonly string[],
+  path: string
+) => {
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.includes(key)) {
+      throw new Error(`${path}.${key} is not supported`)
+    }
+  }
+}
+
+const normalizeAggregateCount = (value: unknown, path: string): number => {
+  if (!Number.isInteger(value) || (value as number) < 0) {
+    throw new Error(`${path} must be a non-negative integer`)
+  }
+  return value as number
+}
+
+const normalizeDateOnly = (value: unknown, path: string): string => {
+  if (typeof value !== 'string') {
+    throw new Error(`${path} must use YYYY-MM-DD format`)
+  }
+  assertDateOnly(value, path)
+  return value
+}
+
+const normalizeBoundedString = (
+  value: unknown,
+  path: string,
+  maxLength: number
+): string => {
+  if (typeof value !== 'string') {
+    throw new Error(`${path} must be a string`)
+  }
+  const trimmed = value.trim()
+  if (!trimmed || trimmed.length > maxLength) {
+    throw new Error(`${path} must be 1 to ${maxLength} characters`)
+  }
+  return trimmed
+}
+
+const normalizePublicUrl = (
+  value: unknown,
+  path: string
+): string | undefined => {
+  if (value === undefined) {
+    return undefined
+  }
+
+  const url = normalizeBoundedString(value, path, 240)
+  if (
+    !url.startsWith('/') &&
+    !url.startsWith('https://') &&
+    !url.startsWith('http://')
+  ) {
+    throw new Error(
+      `${path} must be a public http(s) URL or site-relative path`
+    )
+  }
+  return url
+}
+
+const normalizeAggregateMap = (value: unknown, path: string): CountMap => {
+  if (value === undefined) {
+    return {}
+  }
+
+  const record = toRecord(value, path)
+  return Object.entries(record).reduce<CountMap>((counts, [bucket, count]) => {
+    if (!bucket || bucket.length > 80) {
+      throw new Error(`${path} bucket names must be 1 to 80 characters`)
+    }
+    counts[bucket] = normalizeAggregateCount(count, `${path}.${bucket}`)
+    return counts
+  }, {})
+}
+
+export class TransparencyService {
+  private readonly knexRO: Knex
+
+  public constructor(connections: Connections) {
+    this.knexRO = connections.knexRO
+  }
+
+  private normalizeExternalMetrics = (
+    input?: TransparencyExternalMetricsInput
+  ): {
+    government_requests?: GovernmentRequestMetrics
+    privacy_requests?: PrivacyRequestMetrics
+    policy_changes?: TransparencyChangeLogEntry[]
+    model_changes?: TransparencyChangeLogEntry[]
+    recommendation_changes?: TransparencyChangeLogEntry[]
+  } => {
+    if (!input) {
+      return {}
+    }
+
+    const record = toRecord(input, 'externalMetrics')
+    assertAllowedKeys(
+      record,
+      ['government_requests', 'privacy_requests', ...changeLogFields],
+      'externalMetrics'
+    )
+
+    return {
+      government_requests: input.government_requests
+        ? this.normalizeGovernmentRequestMetrics(input.government_requests)
+        : undefined,
+      privacy_requests: input.privacy_requests
+        ? this.normalizePrivacyRequestMetrics(input.privacy_requests)
+        : undefined,
+      policy_changes: this.normalizeChangeLogMetrics(
+        input.policy_changes,
+        'externalMetrics.policy_changes'
+      ),
+      model_changes: this.normalizeChangeLogMetrics(
+        input.model_changes,
+        'externalMetrics.model_changes'
+      ),
+      recommendation_changes: this.normalizeChangeLogMetrics(
+        input.recommendation_changes,
+        'externalMetrics.recommendation_changes'
+      ),
+    }
+  }
+
+  private normalizeGovernmentRequestMetrics = (
+    input: NonNullable<TransparencyExternalMetricsInput['government_requests']>
+  ): GovernmentRequestMetrics => {
+    const record = toRecord(input, 'externalMetrics.government_requests')
+    assertAllowedKeys(
+      record,
+      ['total', ...governmentRequestMapFields],
+      'externalMetrics.government_requests'
+    )
+
+    return {
+      total: normalizeAggregateCount(
+        input.total,
+        'externalMetrics.government_requests.total'
+      ),
+      by_jurisdiction: normalizeAggregateMap(
+        input.by_jurisdiction,
+        'externalMetrics.government_requests.by_jurisdiction'
+      ),
+      by_agency_type: normalizeAggregateMap(
+        input.by_agency_type,
+        'externalMetrics.government_requests.by_agency_type'
+      ),
+      by_request_type: normalizeAggregateMap(
+        input.by_request_type,
+        'externalMetrics.government_requests.by_request_type'
+      ),
+      by_data_type: normalizeAggregateMap(
+        input.by_data_type,
+        'externalMetrics.government_requests.by_data_type'
+      ),
+      by_result: normalizeAggregateMap(
+        input.by_result,
+        'externalMetrics.government_requests.by_result'
+      ),
+      by_user_notice: normalizeAggregateMap(
+        input.by_user_notice,
+        'externalMetrics.government_requests.by_user_notice'
+      ),
+      not_recorded: false,
+    }
+  }
+
+  private normalizePrivacyRequestMetrics = (
+    input: NonNullable<TransparencyExternalMetricsInput['privacy_requests']>
+  ): PrivacyRequestMetrics => {
+    const record = toRecord(input, 'externalMetrics.privacy_requests')
+    assertAllowedKeys(
+      record,
+      ['total', ...privacyRequestCountFields],
+      'externalMetrics.privacy_requests'
+    )
+
+    return {
+      total: normalizeAggregateCount(
+        input.total,
+        'externalMetrics.privacy_requests.total'
+      ),
+      access: normalizeAggregateCount(
+        input.access ?? 0,
+        'externalMetrics.privacy_requests.access'
+      ),
+      correction: normalizeAggregateCount(
+        input.correction ?? 0,
+        'externalMetrics.privacy_requests.correction'
+      ),
+      deletion: normalizeAggregateCount(
+        input.deletion ?? 0,
+        'externalMetrics.privacy_requests.deletion'
+      ),
+      restriction: normalizeAggregateCount(
+        input.restriction ?? 0,
+        'externalMetrics.privacy_requests.restriction'
+      ),
+      not_recorded: false,
+    }
+  }
+
+  private normalizeChangeLogMetrics = (
+    input: TransparencyChangeLogEntry[] | undefined,
+    path: string
+  ): TransparencyChangeLogEntry[] | undefined => {
+    if (input === undefined) {
+      return undefined
+    }
+    if (!Array.isArray(input)) {
+      throw new Error(`${path} must be an array`)
+    }
+
+    return input.map((entry, index) => {
+      const entryPath = `${path}[${index}]`
+      const record = toRecord(entry, entryPath)
+      assertAllowedKeys(record, changeLogEntryFields, entryPath)
+
+      const publicUrl = normalizePublicUrl(
+        record.public_url,
+        `${entryPath}.public_url`
+      )
+
+      return {
+        date: normalizeDateOnly(record.date, `${entryPath}.date`),
+        category: normalizeBoundedString(
+          record.category,
+          `${entryPath}.category`,
+          80
+        ),
+        summary: normalizeBoundedString(
+          record.summary,
+          `${entryPath}.summary`,
+          500
+        ),
+        ...(publicUrl ? { public_url: publicUrl } : {}),
+      }
+    })
+  }
+
+  private getEmptyGovernmentRequests = (): GovernmentRequestMetrics => ({
+    total: null,
+    by_jurisdiction: {},
+    by_agency_type: {},
+    by_request_type: {},
+    by_data_type: {},
+    by_result: {},
+    by_user_notice: {},
+    not_recorded: true,
+  })
+
+  private getEmptyPrivacyRequests = (): PrivacyRequestMetrics => ({
+    total: null,
+    access: null,
+    correction: null,
+    deletion: null,
+    restriction: null,
+    not_recorded: true,
+  })
+
+  private getNotRecordedFields = (externalMetrics: {
+    government_requests?: GovernmentRequestMetrics
+    privacy_requests?: PrivacyRequestMetrics
+    policy_changes?: TransparencyChangeLogEntry[]
+    model_changes?: TransparencyChangeLogEntry[]
+    recommendation_changes?: TransparencyChangeLogEntry[]
+  }): string[] => [
+    'legacy_reports_before_moderation_case_schema',
+    ...(externalMetrics.government_requests
+      ? []
+      : ['government_request_log_source_not_configured']),
+    ...(externalMetrics.privacy_requests
+      ? []
+      : ['privacy_request_source_not_structured']),
+    ...(externalMetrics.policy_changes === undefined
+      ? [changeLogSourceGaps.policy_changes]
+      : []),
+    ...(externalMetrics.model_changes === undefined
+      ? [changeLogSourceGaps.model_changes]
+      : []),
+    ...(externalMetrics.recommendation_changes === undefined
+      ? [changeLogSourceGaps.recommendation_changes]
+      : []),
+  ]
+
+  private getDataStatusNotes = (externalMetrics: {
+    government_requests?: GovernmentRequestMetrics
+    privacy_requests?: PrivacyRequestMetrics
+    policy_changes?: TransparencyChangeLogEntry[]
+    model_changes?: TransparencyChangeLogEntry[]
+    recommendation_changes?: TransparencyChangeLogEntry[]
+  }): string[] => {
+    const hasExternalRequestMetrics =
+      externalMetrics.government_requests || externalMetrics.privacy_requests
+    const hasExternalChangeLogs = changeLogFields.some(
+      (field) => externalMetrics[field] !== undefined
+    )
+
+    return [
+      'Fields marked not_recorded are data process gaps, not zero events.',
+      'Only aggregated counts are exported; user ids, emails, IPs, original content, internal notes, and legal document contents are excluded.',
+      ...(hasExternalRequestMetrics
+        ? [
+            'External request metrics were loaded from an aggregate-only private source.',
+          ]
+        : []),
+      ...(hasExternalChangeLogs
+        ? [
+            'Policy, model, or recommendation change logs were loaded from a public-safe structured source.',
+          ]
+        : []),
+    ]
+  }
+
+  public exportMetrics = async (
+    options: TransparencyMetricsOptions
+  ): Promise<TransparencyMetrics> => {
+    const period = this.normalizePeriod(options)
+    const externalMetrics = this.normalizeExternalMetrics(
+      options.externalMetrics
+    )
+    const [moderationCases, appeals, handlingTime, communityWatch] =
+      await Promise.all([
+        this.getModerationCases(period),
+        this.getAppeals(period),
+        this.getHandlingTime(period),
+        this.getCommunityWatch(period),
+      ])
+
+    return {
+      schema_version: TRANSPARENCY_SCHEMA_VERSION,
+      reporting_period: {
+        start: period.start,
+        end: period.end,
+        timezone: period.timezone,
+      },
+      data_status: {
+        overall: 'partial',
+        not_recorded_fields: this.getNotRecordedFields(externalMetrics),
+        notes: this.getDataStatusNotes(externalMetrics),
+      },
+      moderation_cases: moderationCases,
+      appeals,
+      handling_time: handlingTime,
+      community_watch: communityWatch,
+      government_requests:
+        externalMetrics.government_requests ??
+        this.getEmptyGovernmentRequests(),
+      privacy_requests:
+        externalMetrics.privacy_requests ?? this.getEmptyPrivacyRequests(),
+      policy_changes: externalMetrics.policy_changes ?? [],
+      model_changes: externalMetrics.model_changes ?? [],
+      recommendation_changes: externalMetrics.recommendation_changes ?? [],
+      generated_at: formatGeneratedAt(
+        options.generatedAt ?? new Date(),
+        period.timezone
+      ),
+    }
+  }
+
+  public toCsv = (metrics: TransparencyMetrics): string => {
+    const rows: Array<Record<string, string | number | null>> = []
+    const status = metrics.data_status.overall
+    const push = ({
+      metricGroup,
+      metricName,
+      bucket,
+      count,
+      dataStatus = status,
+      note = '',
+    }: {
+      metricGroup: string
+      metricName: string
+      bucket: string
+      count: number | null
+      dataStatus?: TransparencyDataStatus
+      note?: string
+    }) => {
+      rows.push({
+        schema_version: metrics.schema_version,
+        period_start: metrics.reporting_period.start,
+        period_end: metrics.reporting_period.end,
+        metric_group: metricGroup,
+        metric_name: metricName,
+        bucket,
+        count,
+        data_status: dataStatus,
+        note,
+      })
+    }
+
+    push({
+      metricGroup: 'moderation_cases',
+      metricName: 'total',
+      bucket: 'all',
+      count: metrics.moderation_cases.total,
+    })
+    this.pushMapRows(push, 'moderation_cases', metrics.moderation_cases)
+
+    for (const key of [
+      'total',
+      'upheld',
+      'reversed',
+      'partially_reversed',
+      'pending',
+      'restored_content',
+    ] as const) {
+      push({
+        metricGroup: 'appeals',
+        metricName: key,
+        bucket: 'all',
+        count: metrics.appeals[key],
+      })
+    }
+
+    for (const key of ['average_hours', 'median_hours', 'p90_hours'] as const) {
+      push({
+        metricGroup: 'handling_time',
+        metricName: key,
+        bucket: 'all',
+        count: metrics.handling_time[key],
+        dataStatus:
+          metrics.handling_time[key] === null ? 'not_recorded' : status,
+        note:
+          metrics.handling_time[key] === null
+            ? 'no resolved cases in period'
+            : '',
+      })
+    }
+
+    push({
+      metricGroup: 'community_watch',
+      metricName: 'total_actions',
+      bucket: 'all',
+      count: metrics.community_watch.total_actions,
+    })
+    for (const [bucket, count] of Object.entries(
+      metrics.community_watch.by_reason
+    )) {
+      push({
+        metricGroup: 'community_watch',
+        metricName: 'by_reason',
+        bucket,
+        count,
+      })
+    }
+    for (const key of ['appeals', 'restored', 'reviewed_by_staff'] as const) {
+      push({
+        metricGroup: 'community_watch',
+        metricName: key,
+        bucket: 'all',
+        count: metrics.community_watch[key],
+      })
+    }
+
+    if (metrics.government_requests.not_recorded) {
+      for (const key of [
+        'total',
+        'by_jurisdiction',
+        'by_agency_type',
+        'by_request_type',
+        'by_data_type',
+        'by_result',
+        'by_user_notice',
+      ] as const) {
+        push({
+          metricGroup: 'government_requests',
+          metricName: key,
+          bucket: 'all',
+          count: null,
+          dataStatus: 'not_recorded',
+          note: 'source log not configured',
+        })
+      }
+    } else {
+      push({
+        metricGroup: 'government_requests',
+        metricName: 'total',
+        bucket: 'all',
+        count: metrics.government_requests.total,
+      })
+      for (const metricName of governmentRequestMapFields) {
+        this.pushCountMapRows(
+          push,
+          'government_requests',
+          metricName,
+          metrics.government_requests[metricName]
+        )
+      }
+    }
+
+    if (metrics.privacy_requests.not_recorded) {
+      for (const key of [
+        'total',
+        'access',
+        'correction',
+        'deletion',
+        'restriction',
+      ] as const) {
+        push({
+          metricGroup: 'privacy_requests',
+          metricName: key,
+          bucket: 'all',
+          count: null,
+          dataStatus: 'not_recorded',
+          note: 'structured source not configured',
+        })
+      }
+    } else {
+      for (const key of [
+        'total',
+        'access',
+        'correction',
+        'deletion',
+        'restriction',
+      ] as const) {
+        push({
+          metricGroup: 'privacy_requests',
+          metricName: key,
+          bucket: 'all',
+          count: metrics.privacy_requests[key],
+        })
+      }
+    }
+
+    for (const metricGroup of changeLogFields) {
+      this.pushChangeLogRows(
+        push,
+        metricGroup,
+        metrics[metricGroup],
+        metrics.data_status.not_recorded_fields.includes(
+          changeLogSourceGaps[metricGroup]
+        )
+      )
+    }
+
+    const headers = [
+      'schema_version',
+      'period_start',
+      'period_end',
+      'metric_group',
+      'metric_name',
+      'bucket',
+      'count',
+      'data_status',
+      'note',
+    ] as const
+
+    return [
+      headers.join(','),
+      ...rows.map((row) =>
+        headers.map((header) => this.escapeCsv(row[header])).join(',')
+      ),
+      '',
+    ].join('\n')
+  }
+
+  private pushMapRows = (
+    push: (row: {
+      metricGroup: string
+      metricName: string
+      bucket: string
+      count: number | null
+      dataStatus?: TransparencyDataStatus
+      note?: string
+    }) => void,
+    metricGroup: string,
+    metrics: TransparencyMetrics['moderation_cases']
+  ) => {
+    for (const metricName of [
+      'by_target_type',
+      'by_source',
+      'by_reason',
+      'by_status',
+      'by_outcome',
+      'by_automation_role',
+      'by_notice_state',
+    ] as const) {
+      for (const [bucket, count] of Object.entries(metrics[metricName])) {
+        push({
+          metricGroup,
+          metricName,
+          bucket,
+          count,
+        })
+      }
+    }
+  }
+
+  private pushChangeLogRows = (
+    push: (row: {
+      metricGroup: string
+      metricName: string
+      bucket: string
+      count: number | null
+      dataStatus?: TransparencyDataStatus
+      note?: string
+    }) => void,
+    metricGroup: ChangeLogField,
+    changes: TransparencyChangeLogEntry[],
+    sourceNotRecorded: boolean
+  ) => {
+    if (sourceNotRecorded) {
+      push({
+        metricGroup,
+        metricName: 'total',
+        bucket: 'all',
+        count: null,
+        dataStatus: 'not_recorded',
+        note: 'structured source not configured',
+      })
+      return
+    }
+
+    push({
+      metricGroup,
+      metricName: 'total',
+      bucket: 'all',
+      count: changes.length,
+    })
+
+    const byCategory = changes.reduce<CountMap>((counts, change) => {
+      counts[change.category] = (counts[change.category] ?? 0) + 1
+      return counts
+    }, {})
+    this.pushCountMapRows(push, metricGroup, 'by_category', byCategory)
+  }
+
+  private pushCountMapRows = (
+    push: (row: {
+      metricGroup: string
+      metricName: string
+      bucket: string
+      count: number | null
+      dataStatus?: TransparencyDataStatus
+      note?: string
+    }) => void,
+    metricGroup: string,
+    metricName: string,
+    counts: NullableCountMap
+  ) => {
+    for (const [bucket, count] of Object.entries(counts)) {
+      push({
+        metricGroup,
+        metricName,
+        bucket,
+        count,
+      })
+    }
+  }
+
+  private escapeCsv = (value: string | number | null): string => {
+    if (value === null) {
+      return ''
+    }
+    const stringValue = String(value)
+    if (/[",\n]/.test(stringValue)) {
+      return `"${stringValue.replaceAll('"', '""')}"`
+    }
+    return stringValue
+  }
+
+  private normalizePeriod = ({
+    start,
+    end,
+    timezone = 'Asia/Taipei',
+  }: TransparencyMetricsOptions): Period => {
+    assertDateOnly(start, 'start')
+    assertDateOnly(end, 'end')
+
+    if (start > end) {
+      throw new Error('start must be earlier than or equal to end')
+    }
+
+    return {
+      start,
+      end,
+      timezone,
+      startDate: toPeriodDate(start, timezone),
+      endExclusiveDate: toPeriodDate(addDays(end, 1), timezone),
+    }
+  }
+
+  private periodQuery = <TRecord extends Record<string, unknown>>(
+    table: string,
+    period: Period,
+    dateColumn = 'createdAt'
+  ): Knex.QueryBuilder<TRecord> =>
+    this.knexRO<TRecord>(table)
+      .where(dateColumn, '>=', period.startDate)
+      .where(dateColumn, '<', period.endExclusiveDate)
+
+  private countBy = async (
+    table: string,
+    column: string,
+    period: Period,
+    dateColumn = 'createdAt'
+  ): Promise<CountMap> => {
+    const rows = await this.periodQuery(table, period, dateColumn)
+      .select(column)
+      .count<Array<{ count: string | number }>>({ count: '*' })
+      .groupBy(column)
+
+    return rows.reduce<CountMap>((counts, row) => {
+      const record = row as Record<string, unknown> & {
+        count: string | number
+      }
+      const value = record[column] ?? 'unknown'
+      counts[String(value)] = toNumber(record.count)
+      return counts
+    }, {})
+  }
+
+  private getModerationCases = async (
+    period: Period
+  ): Promise<TransparencyMetrics['moderation_cases']> => {
+    const [
+      total,
+      byTargetType,
+      bySource,
+      byReason,
+      byStatus,
+      byOutcome,
+      byAutomationRole,
+      byNoticeState,
+    ] = await Promise.all([
+      countRows(this.periodQuery('moderation_case', period)),
+      this.countBy('moderation_case', 'targetType', period),
+      this.countBy('moderation_case', 'source', period),
+      this.countBy('moderation_case', 'reason', period),
+      this.countBy('moderation_case', 'status', period),
+      this.countBy('moderation_case', 'outcome', period),
+      this.countBy('moderation_case', 'automationRole', period),
+      this.countBy('moderation_case', 'noticeState', period),
+    ])
+
+    return {
+      total,
+      by_target_type: byTargetType,
+      by_source: bySource,
+      by_reason: byReason,
+      by_status: byStatus,
+      by_outcome: byOutcome,
+      by_automation_role: byAutomationRole,
+      by_notice_state: byNoticeState,
+    }
+  }
+
+  private getAppeals = async (
+    period: Period
+  ): Promise<TransparencyMetrics['appeals']> => {
+    const [
+      moderationAppeals,
+      communityAppeals,
+      upheldCases,
+      upheldCommunityReviews,
+      restoredCases,
+      restoredCommunityEvents,
+      partiallyRestoredCases,
+      pendingModerationCases,
+      pendingCommunityAppeals,
+    ] = await Promise.all([
+      countRows(
+        this.periodQuery('moderation_event', period).where({
+          eventType: 'appealed',
+        })
+      ),
+      countRows(
+        this.periodQuery('community_watch_review_event', period).where({
+          eventType: 'appeal_received',
+        })
+      ),
+      countRows(
+        this.periodQuery('moderation_case', period).where({ outcome: 'upheld' })
+      ),
+      countRows(
+        this.periodQuery('community_watch_review_event', period).where({
+          eventType: 'review_upheld',
+        })
+      ),
+      countRows(
+        this.periodQuery('moderation_case', period).where({
+          outcome: 'restored',
+        })
+      ),
+      countRows(
+        this.periodQuery('community_watch_review_event', period).where({
+          eventType: 'comment_restored',
+        })
+      ),
+      countRows(
+        this.periodQuery('moderation_case', period).where({
+          outcome: 'partially_restored',
+        })
+      ),
+      countRows(
+        this.periodQuery('moderation_case', period).where({
+          status: 'appealed',
+        })
+      ),
+      countRows(
+        this.knexRO('community_watch_action')
+          .where({ appealState: 'received' })
+          .where('createdAt', '<', period.endExclusiveDate)
+      ),
+    ])
+
+    return {
+      total: moderationAppeals + communityAppeals,
+      upheld: upheldCases + upheldCommunityReviews,
+      reversed: restoredCases + restoredCommunityEvents,
+      partially_reversed: partiallyRestoredCases,
+      pending: pendingModerationCases + pendingCommunityAppeals,
+      restored_content: restoredCases + restoredCommunityEvents,
+    }
+  }
+
+  private getHandlingTime = async (
+    period: Period
+  ): Promise<TransparencyMetrics['handling_time']> => {
+    const row = await this.periodQuery('moderation_case', period)
+      .whereNotNull('resolvedAt')
+      .select(
+        this.knexRO.raw(
+          'AVG(EXTRACT(EPOCH FROM (resolved_at - created_at)) / 3600)::float as "averageHours"'
+        ),
+        this.knexRO.raw(
+          'PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (resolved_at - created_at)) / 3600)::float as "medianHours"'
+        ),
+        this.knexRO.raw(
+          'PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (resolved_at - created_at)) / 3600)::float as "p90Hours"'
+        )
+      )
+      .first()
+
+    const averageHours = toRoundedHours(row?.averageHours)
+    const medianHours = toRoundedHours(row?.medianHours)
+    const p90Hours = toRoundedHours(row?.p90Hours)
+
+    return {
+      average_hours: averageHours,
+      median_hours: medianHours,
+      p90_hours: p90Hours,
+      not_recorded: averageHours === null,
+    }
+  }
+
+  private getCommunityWatch = async (
+    period: Period
+  ): Promise<TransparencyMetrics['community_watch']> => {
+    const [totalActions, byReason, appeals, restored, reviewedByStaff] =
+      await Promise.all([
+        countRows(this.periodQuery('community_watch_action', period)),
+        this.countBy('community_watch_action', 'reason', period),
+        countRows(
+          this.periodQuery('community_watch_review_event', period).where({
+            eventType: 'appeal_received',
+          })
+        ),
+        countRows(
+          this.periodQuery('community_watch_review_event', period).where({
+            eventType: 'comment_restored',
+          })
+        ),
+        countRows(
+          this.periodQuery(
+            'community_watch_action',
+            period,
+            'reviewedAt'
+          ).whereNotNull('reviewerId')
+        ),
+      ])
+
+    return {
+      total_actions: totalActions,
+      by_reason: byReason,
+      appeals,
+      restored,
+      reviewed_by_staff: reviewedByStaff,
+    }
+  }
+}

--- a/src/connectors/userService.ts
+++ b/src/connectors/userService.ts
@@ -1155,11 +1155,14 @@ export class UserService extends BaseService<User> {
     })
 
   public findScore = async (userId: string) => {
+    // New/inactive accounts have no user_reader_view row (.first() → undefined);
+    // treat a missing row as zero karma instead of throwing. This unblocks
+    // spam-ring freeze, whose members are mostly brand-new throwaway accounts.
     const author = await this.knexRO('user_reader_view')
       .select()
       .where({ id: userId })
       .first()
-    return author.authorScore || 0
+    return author?.authorScore || 0
   }
 
   /*********************************

--- a/src/definitions/article.d.ts
+++ b/src/definitions/article.d.ts
@@ -20,6 +20,10 @@ export interface Article {
   shortHash: string
   spamScore: number | null
   isSpam: boolean | null
+  decision: string | null
+  reason: string | null
+  pSpam: number | null
+  pHam: number | null
   isAd: boolean | null
   channelEnabled: boolean
 }

--- a/src/definitions/index.d.ts
+++ b/src/definitions/index.d.ts
@@ -107,6 +107,11 @@ import type {
   SearchHistory,
 } from './misc.js'
 import type {
+  ModerationCase,
+  ModerationCaseReporter,
+  ModerationEvent,
+} from './moderation.js'
+import type {
   Moment,
   MomentAsset,
   MomentArticle,
@@ -178,6 +183,7 @@ export * from './report.js'
 export * from './spamRing.js'
 export * from './wallet.js'
 export * from './misc.js'
+export * from './moderation.js'
 export * from './schema.js'
 export * from './moment.js'
 export * from './quote.js'
@@ -292,6 +298,9 @@ export interface TableTypeMap {
   spam_ring: SpamRing
   spam_ring_member: SpamRingMember
   spam_ring_event: SpamRingEvent
+  moderation_case: ModerationCase
+  moderation_case_reporter: ModerationCaseReporter
+  moderation_event: ModerationEvent
   crypto_wallet: CryptoWallet
   crypto_wallet_signature: CryptoWalletSignature
   customer: Customer

--- a/src/definitions/moderation.d.ts
+++ b/src/definitions/moderation.d.ts
@@ -1,0 +1,109 @@
+export type ModerationCaseSource =
+  | 'direct_report'
+  | 'community_watch'
+  | 'admin'
+  | 'system'
+  | 'model_assisted'
+  | 'automated'
+
+export type ModerationTargetType =
+  | 'article'
+  | 'comment'
+  | 'moment'
+  | 'user'
+  | 'tag'
+  | 'other'
+
+export type ModerationCaseStatus =
+  | 'received'
+  | 'reviewing'
+  | 'action_taken'
+  | 'rejected'
+  | 'appealed'
+  | 'resolved'
+  | 'closed'
+
+export type ModerationCaseOutcome =
+  | 'no_action'
+  | 'content_collapsed'
+  | 'content_hidden'
+  | 'content_removed'
+  | 'account_limited'
+  | 'restored'
+  | 'partially_restored'
+  | 'upheld'
+
+export type ModerationAutomationRole =
+  | 'none'
+  | 'suggested'
+  | 'assisted'
+  | 'automated'
+
+export type ModerationNoticeState =
+  | 'not_required'
+  | 'pending'
+  | 'sent'
+  | 'delayed'
+  | 'prohibited'
+  | 'failed'
+
+export type ModerationEventType =
+  | 'created'
+  | 'notified'
+  | 'reviewed'
+  | 'actioned'
+  | 'appealed'
+  | 'restored'
+  | 'closed'
+  | 'exported'
+
+export type ModerationActorType =
+  | 'user'
+  | 'community_watcher'
+  | 'admin'
+  | 'system'
+  | 'model'
+
+export interface ModerationCase {
+  id: string
+  source: ModerationCaseSource
+  targetType: ModerationTargetType
+  targetId: string
+  primaryReporterId: string | null
+  reason: string
+  publicReason: string | null
+  status: ModerationCaseStatus
+  outcome: ModerationCaseOutcome | null
+  automationRole: ModerationAutomationRole
+  modelName: string | null
+  modelVersion: string | null
+  noticeState: ModerationNoticeState
+  resolvedAt: Date | null
+  closedAt: Date | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface ModerationCaseReporter {
+  id: string
+  caseId: string
+  reporterId: string
+  reportId: string | null
+  reportedAt: Date
+}
+
+export interface ModerationEvent {
+  id: string
+  caseId: string
+  eventType: ModerationEventType
+  actorType: ModerationActorType
+  actorId: string | null
+  publicReason: string | null
+  internalNote: string | null
+  fromStatus: ModerationCaseStatus | null
+  toStatus: ModerationCaseStatus | null
+  fromOutcome: ModerationCaseOutcome | null
+  toOutcome: ModerationCaseOutcome | null
+  metadata: Record<string, unknown> | null
+  createdAt: Date
+}

--- a/src/definitions/notification.d.ts
+++ b/src/definitions/notification.d.ts
@@ -376,6 +376,12 @@ interface NoticeCommentBannedParams extends NotificationRequiredParams {
   event: OFFICIAL_NOTICE_EXTEND_TYPE.comment_banned
   entities: [NotificationEntity<'target', 'comment'>]
   recipientId: string
+  data?: {
+    link?: string
+    moderationSource?: string
+    publicReason?: string
+    appealLink?: string
+  }
 }
 
 interface NoticeCommunityWatchCommentRestoredParams
@@ -383,7 +389,12 @@ interface NoticeCommunityWatchCommentRestoredParams
   event: OFFICIAL_NOTICE_EXTEND_TYPE.community_watch_comment_restored
   entities: [NotificationEntity<'target', 'comment'>]
   recipientId: string
-  data: { link: string }
+  data: {
+    link: string
+    moderationSource?: string
+    publicReason?: string
+    appealLink?: string
+  }
 }
 
 interface NoticeCommunityWatchActionReversedParams
@@ -391,7 +402,12 @@ interface NoticeCommunityWatchActionReversedParams
   event: OFFICIAL_NOTICE_EXTEND_TYPE.community_watch_action_reversed
   entities: [NotificationEntity<'target', 'comment'>]
   recipientId: string
-  data: { link: string }
+  data: {
+    link: string
+    moderationSource?: string
+    publicReason?: string
+    appealLink?: string
+  }
 }
 
 interface NoticeCommunityWatchEnabledParams extends NotificationRequiredParams {
@@ -515,6 +531,9 @@ type NoticeMessage = string
 interface NoticeData {
   // used by official announcement notices
   link?: string
+  moderationSource?: string
+  publicReason?: string
+  appealLink?: string
   // reason for banned/frozen users, not in used
   reason?: string
 

--- a/src/definitions/report.d.ts
+++ b/src/definitions/report.d.ts
@@ -1,3 +1,5 @@
+import type { ModerationCaseOutcome } from './moderation.js'
+
 import { NODE_TYPES } from '#common/enums/index.js'
 
 export type ReportType =
@@ -29,4 +31,9 @@ export interface Report {
    * from a `community_watch_action` row. Set by resolvers, not stored in DB.
    */
   source?: ReportSource
+  /**
+   * Runtime context set by moderation sync paths, not stored in `report`.
+   */
+  moderationCaseId?: string | null
+  moderationOutcome?: ModerationCaseOutcome | null
 }

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -1,170 +1,212 @@
-import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
-import { User as UserModel, OAuthClientDB as OAuthClientDBModel } from './user.js';
-import { ETHWallet as ETHWalletModel } from './wallet.js';
-import { Tag as TagModel } from './tag.js';
-import { Collection as CollectionModel } from './collection.js';
-import { Comment as CommentModel } from './comment.js';
-import { CommunityWatchAction as CommunityWatchActionModel } from './communityWatch.js';
-import { Article as ArticleModel, ArticleVersion as ArticleVersionModel } from './article.js';
-import { Draft as DraftModel } from './draft.js';
-import { Circle as CircleModel, CircleInvitation as CircleInvitationModel, CircleMember as CircleMemberModel } from './circle.js';
-import { CirclePrice as CirclePriceModel, Transaction as TransactionModel, Writing as WritingModel, Context } from './index.js';
-import { PayoutAccount as PayoutAccountModel } from './payment.js';
-import { Asset as AssetModel } from './asset.js';
-import { NoticeItem as NoticeItemModel } from './notification.js';
-import { Appreciation as AppreciationModel } from './appreciation.js';
-import { Report as ReportModel } from './report.js';
-import { SpamRing as SpamRingModel, SpamRingMember as SpamRingMemberModel, SpamRingEvent as SpamRingEventModel, SpamRingSignals as SpamRingSignalsModel } from './spamRing.js';
-import { MattersChoiceTopic as MattersChoiceTopicModel } from './misc.js';
-import { Moment as MomentModel, MomentFeedUser as MomentFeedUserModel } from './moment.js';
-import { Quote as QuoteModel } from './quote.js';
-import { Campaign as CampaignModel, CampaignStage as CampaignStageModel } from './campaign.js';
-import { TopicChannel as TopicChannelModel, CurationChannel as CurationChannelModel } from './channel.js';
-import { Announcement as AnnouncementModel } from './announcement.js';
-import { TopicChannelFeedback as TopicChannelFeedbackModel } from './feedback.js';
+import {
+  GraphQLResolveInfo,
+  GraphQLScalarType,
+  GraphQLScalarTypeConfig,
+} from 'graphql'
+import {
+  User as UserModel,
+  OAuthClientDB as OAuthClientDBModel,
+} from './user.js'
+import { ETHWallet as ETHWalletModel } from './wallet.js'
+import { Tag as TagModel } from './tag.js'
+import { Collection as CollectionModel } from './collection.js'
+import { Comment as CommentModel } from './comment.js'
+import { CommunityWatchAction as CommunityWatchActionModel } from './communityWatch.js'
+import {
+  Article as ArticleModel,
+  ArticleVersion as ArticleVersionModel,
+} from './article.js'
+import { Draft as DraftModel } from './draft.js'
+import {
+  Circle as CircleModel,
+  CircleInvitation as CircleInvitationModel,
+  CircleMember as CircleMemberModel,
+} from './circle.js'
+import {
+  CirclePrice as CirclePriceModel,
+  Transaction as TransactionModel,
+  Writing as WritingModel,
+  Context,
+} from './index.js'
+import { PayoutAccount as PayoutAccountModel } from './payment.js'
+import { Asset as AssetModel } from './asset.js'
+import { NoticeItem as NoticeItemModel } from './notification.js'
+import { Appreciation as AppreciationModel } from './appreciation.js'
+import { Report as ReportModel } from './report.js'
+import {
+  SpamRing as SpamRingModel,
+  SpamRingMember as SpamRingMemberModel,
+  SpamRingEvent as SpamRingEventModel,
+  SpamRingSignals as SpamRingSignalsModel,
+} from './spamRing.js'
+import { MattersChoiceTopic as MattersChoiceTopicModel } from './misc.js'
+import {
+  Moment as MomentModel,
+  MomentFeedUser as MomentFeedUserModel,
+} from './moment.js'
+import { Quote as QuoteModel } from './quote.js'
+import {
+  Campaign as CampaignModel,
+  CampaignStage as CampaignStageModel,
+} from './campaign.js'
+import {
+  TopicChannel as TopicChannelModel,
+  CurationChannel as CurationChannelModel,
+} from './channel.js'
+import { Announcement as AnnouncementModel } from './announcement.js'
+import { TopicChannelFeedback as TopicChannelFeedbackModel } from './feedback.js'
 import { GlobalId } from './nominal.js'
-export type Maybe<T> = T | null;
-export type InputMaybe<T> = T | undefined;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
-export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-export type RequireFields<T, K extends keyof T> = Omit<T, K> & { [P in K]-?: NonNullable<T[P]> };
+export type Maybe<T> = T | null
+export type InputMaybe<T> = T | undefined
+export type Exact<T extends { [key: string]: unknown }> = {
+  [K in keyof T]: T[K]
+}
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]?: Maybe<T[SubKey]>
+}
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]: Maybe<T[SubKey]>
+}
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T
+> = { [_ in K]?: never }
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never
+    }
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
+export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
+  [P in K]-?: NonNullable<T[P]>
+}
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: GlobalId; output: GlobalId; }
-  String: { input: string; output: string; }
-  Boolean: { input: boolean; output: boolean; }
-  Int: { input: number; output: number; }
-  Float: { input: number; output: number; }
-  DateTime: { input: any; output: any; }
-  Upload: { input: any; output: any; }
-};
+  ID: { input: GlobalId; output: GlobalId }
+  String: { input: string; output: string }
+  Boolean: { input: boolean; output: boolean }
+  Int: { input: number; output: number }
+  Float: { input: number; output: number }
+  DateTime: { input: any; output: any }
+  Upload: { input: any; output: any }
+}
 
 export type GQLAdStatus = {
-  __typename?: 'AdStatus';
+  __typename?: 'AdStatus'
   /** Whether this article is labeled as ad by human, null for not labeled yet.  */
-  isAd?: Maybe<Scalars['Boolean']['output']>;
-};
+  isAd?: Maybe<Scalars['Boolean']['output']>
+}
 
 export type GQLAddCollectionsArticlesInput = {
-  articles: Array<Scalars['ID']['input']>;
-  collections: Array<Scalars['ID']['input']>;
-};
+  articles: Array<Scalars['ID']['input']>
+  collections: Array<Scalars['ID']['input']>
+}
 
 export type GQLAddCreditInput = {
-  amount: Scalars['Float']['input'];
-};
+  amount: Scalars['Float']['input']
+}
 
 export type GQLAddCreditResult = {
-  __typename?: 'AddCreditResult';
+  __typename?: 'AddCreditResult'
   /** The client secret of this PaymentIntent. */
-  client_secret: Scalars['String']['output'];
-  transaction: GQLTransaction;
-};
+  client_secret: Scalars['String']['output']
+  transaction: GQLTransaction
+}
 
 export type GQLAddCurationChannelArticlesInput = {
-  articles: Array<Scalars['ID']['input']>;
-  channel: Scalars['ID']['input'];
-};
+  articles: Array<Scalars['ID']['input']>
+  channel: Scalars['ID']['input']
+}
 
 export type GQLAnnouncement = {
-  __typename?: 'Announcement';
-  channels: Array<GQLAnnouncementChannel>;
-  content?: Maybe<Scalars['String']['output']>;
-  cover?: Maybe<Scalars['String']['output']>;
-  createdAt: Scalars['DateTime']['output'];
-  expiredAt?: Maybe<Scalars['DateTime']['output']>;
-  id: Scalars['ID']['output'];
-  link?: Maybe<Scalars['String']['output']>;
-  order: Scalars['Int']['output'];
-  title?: Maybe<Scalars['String']['output']>;
+  __typename?: 'Announcement'
+  channels: Array<GQLAnnouncementChannel>
+  content?: Maybe<Scalars['String']['output']>
+  cover?: Maybe<Scalars['String']['output']>
+  createdAt: Scalars['DateTime']['output']
+  expiredAt?: Maybe<Scalars['DateTime']['output']>
+  id: Scalars['ID']['output']
+  link?: Maybe<Scalars['String']['output']>
+  order: Scalars['Int']['output']
+  title?: Maybe<Scalars['String']['output']>
   /** @deprecated Use title, content, link with TranslationArgs instead */
-  translations?: Maybe<Array<GQLTranslatedAnnouncement>>;
-  type: GQLAnnouncementType;
-  updatedAt: Scalars['DateTime']['output'];
-  visible: Scalars['Boolean']['output'];
-};
-
+  translations?: Maybe<Array<GQLTranslatedAnnouncement>>
+  type: GQLAnnouncementType
+  updatedAt: Scalars['DateTime']['output']
+  visible: Scalars['Boolean']['output']
+}
 
 export type GQLAnnouncementContentArgs = {
-  input?: InputMaybe<GQLTranslationArgs>;
-};
-
+  input?: InputMaybe<GQLTranslationArgs>
+}
 
 export type GQLAnnouncementLinkArgs = {
-  input?: InputMaybe<GQLTranslationArgs>;
-};
-
+  input?: InputMaybe<GQLTranslationArgs>
+}
 
 export type GQLAnnouncementTitleArgs = {
-  input?: InputMaybe<GQLTranslationArgs>;
-};
+  input?: InputMaybe<GQLTranslationArgs>
+}
 
 export type GQLAnnouncementChannel = {
-  __typename?: 'AnnouncementChannel';
-  channel: GQLChannel;
-  order: Scalars['Int']['output'];
-  visible: Scalars['Boolean']['output'];
-};
+  __typename?: 'AnnouncementChannel'
+  channel: GQLChannel
+  order: Scalars['Int']['output']
+  visible: Scalars['Boolean']['output']
+}
 
 export type GQLAnnouncementChannelInput = {
-  channel: Scalars['ID']['input'];
-  order: Scalars['Int']['input'];
-  visible: Scalars['Boolean']['input'];
-};
+  channel: Scalars['ID']['input']
+  order: Scalars['Int']['input']
+  visible: Scalars['Boolean']['input']
+}
 
-export type GQLAnnouncementType =
-  | 'community'
-  | 'product'
-  | 'seminar';
+export type GQLAnnouncementType = 'community' | 'product' | 'seminar'
 
 export type GQLAnnouncementsInput = {
-  channel?: InputMaybe<GQLIdentityInput>;
-  id?: InputMaybe<Scalars['ID']['input']>;
-  visible?: InputMaybe<Scalars['Boolean']['input']>;
-};
+  channel?: InputMaybe<GQLIdentityInput>
+  id?: InputMaybe<Scalars['ID']['input']>
+  visible?: InputMaybe<Scalars['Boolean']['input']>
+}
 
 export type GQLApplyCampaignInput = {
-  id: Scalars['ID']['input'];
-};
+  id: Scalars['ID']['input']
+}
 
 export type GQLAppreciateArticleInput = {
-  amount: Scalars['Int']['input'];
-  id: Scalars['ID']['input'];
-  superLike?: InputMaybe<Scalars['Boolean']['input']>;
-  token?: InputMaybe<Scalars['String']['input']>;
-};
+  amount: Scalars['Int']['input']
+  id: Scalars['ID']['input']
+  superLike?: InputMaybe<Scalars['Boolean']['input']>
+  token?: InputMaybe<Scalars['String']['input']>
+}
 
 export type GQLAppreciation = {
-  __typename?: 'Appreciation';
-  amount: Scalars['Int']['output'];
-  content: Scalars['String']['output'];
+  __typename?: 'Appreciation'
+  amount: Scalars['Int']['output']
+  content: Scalars['String']['output']
   /** Timestamp of appreciation. */
-  createdAt: Scalars['DateTime']['output'];
-  purpose: GQLAppreciationPurpose;
+  createdAt: Scalars['DateTime']['output']
+  purpose: GQLAppreciationPurpose
   /** Recipient of appreciation. */
-  recipient: GQLUser;
+  recipient: GQLUser
   /** Sender of appreciation. */
-  sender?: Maybe<GQLUser>;
+  sender?: Maybe<GQLUser>
   /** Object that appreciation is meant for. */
-  target?: Maybe<GQLArticle>;
-};
+  target?: Maybe<GQLArticle>
+}
 
 export type GQLAppreciationConnection = GQLConnection & {
-  __typename?: 'AppreciationConnection';
-  edges?: Maybe<Array<GQLAppreciationEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'AppreciationConnection'
+  edges?: Maybe<Array<GQLAppreciationEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLAppreciationEdge = {
-  __typename?: 'AppreciationEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLAppreciation;
-};
+  __typename?: 'AppreciationEdge'
+  cursor: Scalars['String']['output']
+  node: GQLAppreciation
+}
 
 export type GQLAppreciationPurpose =
   | 'appreciate'
@@ -174,427 +216,411 @@ export type GQLAppreciationPurpose =
   | 'invitationAccepted'
   | 'joinByInvitation'
   | 'joinByTask'
-  | 'systemSubsidy';
+  | 'systemSubsidy'
 
 export type GQLArchiveUserFailure = {
-  __typename?: 'ArchiveUserFailure';
-  id: Scalars['ID']['output'];
-  message: Scalars['String']['output'];
-};
+  __typename?: 'ArchiveUserFailure'
+  id: Scalars['ID']['output']
+  message: Scalars['String']['output']
+}
 
 export type GQLArchiveUsersInput = {
-  ids: Array<Scalars['ID']['input']>;
-  password: Scalars['String']['input'];
-};
+  ids: Array<Scalars['ID']['input']>
+  password: Scalars['String']['input']
+}
 
 export type GQLArchiveUsersResult = {
-  __typename?: 'ArchiveUsersResult';
-  archived: Array<GQLUser>;
-  skipped: Array<GQLArchiveUserFailure>;
-};
+  __typename?: 'ArchiveUsersResult'
+  archived: Array<GQLUser>
+  skipped: Array<GQLArchiveUserFailure>
+}
 
 /**
  * This type contains metadata, content, hash and related data of an article. If you
  * want information about article's comments. Please check Comment type.
  */
-export type GQLArticle = GQLNode & GQLPinnableWork & {
-  __typename?: 'Article';
-  /** Access related fields on circle */
-  access: GQLArticleAccess;
-  /** Number represents how many times per user can appreciate this article. */
-  appreciateLeft: Scalars['Int']['output'];
-  /** Limit the nuhmber of appreciate per user. */
-  appreciateLimit: Scalars['Int']['output'];
-  /** Appreciations history of this article. */
-  appreciationsReceived: GQLAppreciationConnection;
-  /** Total number of appreciations recieved of this article. */
-  appreciationsReceivedTotal: Scalars['Int']['output'];
-  /** List of assets are belonged to this article (Only the author can access currently). */
-  assets: Array<GQLAsset>;
-  /** Author of this article. */
-  author: GQLUser;
-  /** Available translation languages. */
-  availableTranslations?: Maybe<Array<GQLUserLanguage>>;
-  /** The number of users who bookmarked this article. */
-  bookmarkCount: Scalars['Int']['output'];
-  bookmarked: Scalars['Boolean']['output'];
-  /** Associated campaigns */
-  campaigns: Array<GQLArticleCampaign>;
-  /** Whether readers can comment */
-  canComment: Scalars['Boolean']['output'];
-  /** This value determines if current viewer can SuperLike or not. */
-  canSuperLike: Scalars['Boolean']['output'];
-  /** Classifications status */
-  classification: GQLArticleClassification;
-  /**
-   * List of articles added into this article's connections.
-   * @deprecated Use connections instead
-   */
-  collection: GQLArticleConnection;
-  /** Collections of this article. */
-  collections: GQLCollectionConnection;
-  /** The counting number of comments. */
-  commentCount: Scalars['Int']['output'];
-  /** List of comments of this article. */
-  comments: GQLCommentConnection;
-  /** List of articles which added this article into their connections. */
-  connectedBy: GQLArticleConnection;
-  connections: GQLArticleConnection;
-  /** Content (HTML) of this article. */
-  content: Scalars['String']['output'];
-  /** Different foramts of content. */
-  contents: GQLArticleContents;
-  /** Article cover's link, set by author */
-  cover?: Maybe<Scalars['String']['output']>;
-  /** Time of this article was created. */
-  createdAt: Scalars['DateTime']['output'];
-  /** IPFS hash of this article. */
-  dataHash: Scalars['String']['output'];
-  /** Cover link that is displayed on the article page */
-  displayCover?: Maybe<Scalars['String']['output']>;
-  /** Whether current viewer has donated to this article */
-  donated: Scalars['Boolean']['output'];
-  /** Total number of donation recieved of this article. */
-  donationCount: Scalars['Int']['output'];
-  /** Donations of this article, grouped by sender */
-  donations: GQLArticleDonationConnection;
-  /** List of featured comments of this article. */
-  featuredComments: GQLCommentConnection;
-  /** Computed federation export eligibility for this article. */
-  federationEligibility: GQLArticleFederationEligibility;
-  /** Article-level federation setting override. */
-  federationSetting?: Maybe<GQLArticleFederationSetting>;
-  /** This value determines if current viewer has appreciated or not. */
-  hasAppreciate: Scalars['Boolean']['output'];
-  /** Unique ID of this article */
-  id: Scalars['ID']['output'];
-  /** Whether the first line of paragraph should be indented */
-  indentFirstLine: Scalars['Boolean']['output'];
-  /** The iscnId if published to ISCN */
-  iscnId?: Maybe<Scalars['String']['output']>;
-  /** Original language of content */
-  language?: Maybe<Scalars['String']['output']>;
-  /** License Type */
-  license: GQLArticleLicenseType;
-  /** Media hash, composed of cid encoding, of this article. */
-  mediaHash: Scalars['String']['output'];
-  /** Whether this article is noindex */
-  noindex: Scalars['Boolean']['output'];
-  oss: GQLArticleOss;
-  /** The number determines how many comments can be set as pinned comment. */
-  pinCommentLeft: Scalars['Int']['output'];
-  /** The number determines how many pinned comments can be set. */
-  pinCommentLimit: Scalars['Int']['output'];
-  /** This value determines if this article is an author selected article or not. */
-  pinned: Scalars['Boolean']['output'];
-  /** List of pinned comments. */
-  pinnedComments?: Maybe<Array<GQLComment>>;
-  /** Cumulative reading time in seconds */
-  readTime: Scalars['Float']['output'];
-  /** Total number of readers of this article. */
-  readerCount: Scalars['Int']['output'];
-  /** Related articles to this article. */
-  relatedArticles: GQLArticleConnection;
-  /** Donation-related articles to this article. */
-  relatedDonationArticles: GQLArticleConnection;
-  remark?: Maybe<Scalars['String']['output']>;
-  /** Creator message after support */
-  replyToDonator?: Maybe<Scalars['String']['output']>;
-  /** Creator message asking for support */
-  requestForDonation?: Maybe<Scalars['String']['output']>;
-  /** The counting number of this article. */
-  responseCount: Scalars['Int']['output'];
-  /** List of responses of a article. */
-  responses: GQLResponseConnection;
-  /** Time of this article was revised. */
-  revisedAt?: Maybe<Scalars['DateTime']['output']>;
-  /** Revision Count */
-  revisionCount: Scalars['Int']['output'];
-  /** Whether content is marked as sensitive by admin */
-  sensitiveByAdmin: Scalars['Boolean']['output'];
-  /** whether content is marked as sensitive by author */
-  sensitiveByAuthor: Scalars['Boolean']['output'];
-  /** Short hash for shorter url addressing */
-  shortHash: Scalars['String']['output'];
-  /** Slugified article title. */
-  slug: Scalars['String']['output'];
-  /** State of this article. */
-  state: GQLArticleState;
-  /**
-   * This value determines if current Viewer has bookmarked of not.
-   * @deprecated Use bookmarked instead
-   */
-  subscribed: Scalars['Boolean']['output'];
-  /** A short summary for this article. */
-  summary: Scalars['String']['output'];
-  /** This value determines if the summary is customized or not. */
-  summaryCustomized: Scalars['Boolean']['output'];
-  /** Tags attached to this article. */
-  tags?: Maybe<Array<GQLTag>>;
-  /** Article title. */
-  title: Scalars['String']['output'];
-  /** Transactions history of this article. */
-  transactionsReceivedBy: GQLUserConnection;
-  /** Translation of article title and content. */
-  translation?: Maybe<GQLArticleTranslation>;
-  /** History versions */
-  versions: GQLArticleVersionsConnection;
-  /** Word count of this article. */
-  wordCount?: Maybe<Scalars['Int']['output']>;
-};
-
+export type GQLArticle = GQLNode &
+  GQLPinnableWork & {
+    __typename?: 'Article'
+    /** Access related fields on circle */
+    access: GQLArticleAccess
+    /** Number represents how many times per user can appreciate this article. */
+    appreciateLeft: Scalars['Int']['output']
+    /** Limit the nuhmber of appreciate per user. */
+    appreciateLimit: Scalars['Int']['output']
+    /** Appreciations history of this article. */
+    appreciationsReceived: GQLAppreciationConnection
+    /** Total number of appreciations recieved of this article. */
+    appreciationsReceivedTotal: Scalars['Int']['output']
+    /** List of assets are belonged to this article (Only the author can access currently). */
+    assets: Array<GQLAsset>
+    /** Author of this article. */
+    author: GQLUser
+    /** Available translation languages. */
+    availableTranslations?: Maybe<Array<GQLUserLanguage>>
+    /** The number of users who bookmarked this article. */
+    bookmarkCount: Scalars['Int']['output']
+    bookmarked: Scalars['Boolean']['output']
+    /** Associated campaigns */
+    campaigns: Array<GQLArticleCampaign>
+    /** Whether readers can comment */
+    canComment: Scalars['Boolean']['output']
+    /** This value determines if current viewer can SuperLike or not. */
+    canSuperLike: Scalars['Boolean']['output']
+    /** Classifications status */
+    classification: GQLArticleClassification
+    /**
+     * List of articles added into this article's connections.
+     * @deprecated Use connections instead
+     */
+    collection: GQLArticleConnection
+    /** Collections of this article. */
+    collections: GQLCollectionConnection
+    /** The counting number of comments. */
+    commentCount: Scalars['Int']['output']
+    /** List of comments of this article. */
+    comments: GQLCommentConnection
+    /** List of articles which added this article into their connections. */
+    connectedBy: GQLArticleConnection
+    connections: GQLArticleConnection
+    /** Content (HTML) of this article. */
+    content: Scalars['String']['output']
+    /** Different foramts of content. */
+    contents: GQLArticleContents
+    /** Article cover's link, set by author */
+    cover?: Maybe<Scalars['String']['output']>
+    /** Time of this article was created. */
+    createdAt: Scalars['DateTime']['output']
+    /** IPFS hash of this article. */
+    dataHash: Scalars['String']['output']
+    /** Cover link that is displayed on the article page */
+    displayCover?: Maybe<Scalars['String']['output']>
+    /** Whether current viewer has donated to this article */
+    donated: Scalars['Boolean']['output']
+    /** Total number of donation recieved of this article. */
+    donationCount: Scalars['Int']['output']
+    /** Donations of this article, grouped by sender */
+    donations: GQLArticleDonationConnection
+    /** List of featured comments of this article. */
+    featuredComments: GQLCommentConnection
+    /** Computed federation export eligibility for this article. */
+    federationEligibility: GQLArticleFederationEligibility
+    /** Article-level federation setting override. */
+    federationSetting?: Maybe<GQLArticleFederationSetting>
+    /** This value determines if current viewer has appreciated or not. */
+    hasAppreciate: Scalars['Boolean']['output']
+    /** Unique ID of this article */
+    id: Scalars['ID']['output']
+    /** Whether the first line of paragraph should be indented */
+    indentFirstLine: Scalars['Boolean']['output']
+    /** The iscnId if published to ISCN */
+    iscnId?: Maybe<Scalars['String']['output']>
+    /** Original language of content */
+    language?: Maybe<Scalars['String']['output']>
+    /** License Type */
+    license: GQLArticleLicenseType
+    /** Media hash, composed of cid encoding, of this article. */
+    mediaHash: Scalars['String']['output']
+    /** Whether this article is noindex */
+    noindex: Scalars['Boolean']['output']
+    oss: GQLArticleOss
+    /** The number determines how many comments can be set as pinned comment. */
+    pinCommentLeft: Scalars['Int']['output']
+    /** The number determines how many pinned comments can be set. */
+    pinCommentLimit: Scalars['Int']['output']
+    /** This value determines if this article is an author selected article or not. */
+    pinned: Scalars['Boolean']['output']
+    /** List of pinned comments. */
+    pinnedComments?: Maybe<Array<GQLComment>>
+    /** Cumulative reading time in seconds */
+    readTime: Scalars['Float']['output']
+    /** Total number of readers of this article. */
+    readerCount: Scalars['Int']['output']
+    /** Related articles to this article. */
+    relatedArticles: GQLArticleConnection
+    /** Donation-related articles to this article. */
+    relatedDonationArticles: GQLArticleConnection
+    remark?: Maybe<Scalars['String']['output']>
+    /** Creator message after support */
+    replyToDonator?: Maybe<Scalars['String']['output']>
+    /** Creator message asking for support */
+    requestForDonation?: Maybe<Scalars['String']['output']>
+    /** The counting number of this article. */
+    responseCount: Scalars['Int']['output']
+    /** List of responses of a article. */
+    responses: GQLResponseConnection
+    /** Time of this article was revised. */
+    revisedAt?: Maybe<Scalars['DateTime']['output']>
+    /** Revision Count */
+    revisionCount: Scalars['Int']['output']
+    /** Whether content is marked as sensitive by admin */
+    sensitiveByAdmin: Scalars['Boolean']['output']
+    /** whether content is marked as sensitive by author */
+    sensitiveByAuthor: Scalars['Boolean']['output']
+    /** Short hash for shorter url addressing */
+    shortHash: Scalars['String']['output']
+    /** Slugified article title. */
+    slug: Scalars['String']['output']
+    /** State of this article. */
+    state: GQLArticleState
+    /**
+     * This value determines if current Viewer has bookmarked of not.
+     * @deprecated Use bookmarked instead
+     */
+    subscribed: Scalars['Boolean']['output']
+    /** A short summary for this article. */
+    summary: Scalars['String']['output']
+    /** This value determines if the summary is customized or not. */
+    summaryCustomized: Scalars['Boolean']['output']
+    /** Tags attached to this article. */
+    tags?: Maybe<Array<GQLTag>>
+    /** Article title. */
+    title: Scalars['String']['output']
+    /** Transactions history of this article. */
+    transactionsReceivedBy: GQLUserConnection
+    /** Translation of article title and content. */
+    translation?: Maybe<GQLArticleTranslation>
+    /** History versions */
+    versions: GQLArticleVersionsConnection
+    /** Word count of this article. */
+    wordCount?: Maybe<Scalars['Int']['output']>
+  }
 
 /**
  * This type contains metadata, content, hash and related data of an article. If you
  * want information about article's comments. Please check Comment type.
  */
 export type GQLArticleAppreciationsReceivedArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 /**
  * This type contains metadata, content, hash and related data of an article. If you
  * want information about article's comments. Please check Comment type.
  */
 export type GQLArticleCollectionArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 /**
  * This type contains metadata, content, hash and related data of an article. If you
  * want information about article's comments. Please check Comment type.
  */
 export type GQLArticleCollectionsArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 /**
  * This type contains metadata, content, hash and related data of an article. If you
  * want information about article's comments. Please check Comment type.
  */
 export type GQLArticleCommentsArgs = {
-  input: GQLCommentsInput;
-};
-
+  input: GQLCommentsInput
+}
 
 /**
  * This type contains metadata, content, hash and related data of an article. If you
  * want information about article's comments. Please check Comment type.
  */
 export type GQLArticleConnectedByArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 /**
  * This type contains metadata, content, hash and related data of an article. If you
  * want information about article's comments. Please check Comment type.
  */
 export type GQLArticleConnectionsArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 /**
  * This type contains metadata, content, hash and related data of an article. If you
  * want information about article's comments. Please check Comment type.
  */
 export type GQLArticleDonationsArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 /**
  * This type contains metadata, content, hash and related data of an article. If you
  * want information about article's comments. Please check Comment type.
  */
 export type GQLArticleFeaturedCommentsArgs = {
-  input: GQLFeaturedCommentsInput;
-};
-
+  input: GQLFeaturedCommentsInput
+}
 
 /**
  * This type contains metadata, content, hash and related data of an article. If you
  * want information about article's comments. Please check Comment type.
  */
 export type GQLArticleRelatedArticlesArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 /**
  * This type contains metadata, content, hash and related data of an article. If you
  * want information about article's comments. Please check Comment type.
  */
 export type GQLArticleRelatedDonationArticlesArgs = {
-  input: GQLRelatedDonationArticlesInput;
-};
-
+  input: GQLRelatedDonationArticlesInput
+}
 
 /**
  * This type contains metadata, content, hash and related data of an article. If you
  * want information about article's comments. Please check Comment type.
  */
 export type GQLArticleResponsesArgs = {
-  input: GQLResponsesInput;
-};
-
+  input: GQLResponsesInput
+}
 
 /**
  * This type contains metadata, content, hash and related data of an article. If you
  * want information about article's comments. Please check Comment type.
  */
 export type GQLArticleTransactionsReceivedByArgs = {
-  input: GQLTransactionsReceivedByArgs;
-};
-
+  input: GQLTransactionsReceivedByArgs
+}
 
 /**
  * This type contains metadata, content, hash and related data of an article. If you
  * want information about article's comments. Please check Comment type.
  */
 export type GQLArticleTranslationArgs = {
-  input?: InputMaybe<GQLArticleTranslationInput>;
-};
-
+  input?: InputMaybe<GQLArticleTranslationInput>
+}
 
 /**
  * This type contains metadata, content, hash and related data of an article. If you
  * want information about article's comments. Please check Comment type.
  */
 export type GQLArticleVersionsArgs = {
-  input: GQLArticleVersionsInput;
-};
+  input: GQLArticleVersionsInput
+}
 
 export type GQLArticleAccess = {
-  __typename?: 'ArticleAccess';
-  circle?: Maybe<GQLCircle>;
-  secret?: Maybe<Scalars['String']['output']>;
-  type: GQLArticleAccessType;
-};
+  __typename?: 'ArticleAccess'
+  circle?: Maybe<GQLCircle>
+  secret?: Maybe<Scalars['String']['output']>
+  type: GQLArticleAccessType
+}
 
 /** Enums for types of article access */
-export type GQLArticleAccessType =
-  | 'paywall'
-  | 'public';
+export type GQLArticleAccessType = 'paywall' | 'public'
 
 export type GQLArticleArticleNotice = GQLNotice & {
-  __typename?: 'ArticleArticleNotice';
+  __typename?: 'ArticleArticleNotice'
   /** List of notice actors. */
-  actors?: Maybe<Array<GQLUser>>;
-  article: GQLArticle;
+  actors?: Maybe<Array<GQLUser>>
+  article: GQLArticle
   /** Time of this notice was created. */
-  createdAt: Scalars['DateTime']['output'];
+  createdAt: Scalars['DateTime']['output']
   /** Unique ID of this notice. */
-  id: Scalars['ID']['output'];
-  target: GQLArticle;
-  type: GQLArticleArticleNoticeType;
+  id: Scalars['ID']['output']
+  target: GQLArticle
+  type: GQLArticleArticleNoticeType
   /** The value determines if the notice is unread or not. */
-  unread: Scalars['Boolean']['output'];
-};
+  unread: Scalars['Boolean']['output']
+}
 
-export type GQLArticleArticleNoticeType =
-  | 'ArticleNewCollected';
+export type GQLArticleArticleNoticeType = 'ArticleNewCollected'
 
 export type GQLArticleCampaign = {
-  __typename?: 'ArticleCampaign';
-  campaign: GQLCampaign;
-  stage?: Maybe<GQLCampaignStage>;
-};
+  __typename?: 'ArticleCampaign'
+  campaign: GQLCampaign
+  stage?: Maybe<GQLCampaignStage>
+}
 
 export type GQLArticleCampaignInput = {
-  campaign: Scalars['ID']['input'];
-  stage?: InputMaybe<Scalars['ID']['input']>;
-};
+  campaign: Scalars['ID']['input']
+  stage?: InputMaybe<Scalars['ID']['input']>
+}
 
 export type GQLArticleClassification = {
-  __typename?: 'ArticleClassification';
-  topicChannel: GQLTopicChannelClassification;
-};
+  __typename?: 'ArticleClassification'
+  topicChannel: GQLTopicChannelClassification
+}
 
 export type GQLArticleConnection = GQLConnection & {
-  __typename?: 'ArticleConnection';
-  edges?: Maybe<Array<GQLArticleEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'ArticleConnection'
+  edges?: Maybe<Array<GQLArticleEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLArticleContents = {
-  __typename?: 'ArticleContents';
+  __typename?: 'ArticleContents'
   /** HTML content of this article. */
-  html: Scalars['String']['output'];
+  html: Scalars['String']['output']
   /** Markdown content of this article. */
-  markdown: Scalars['String']['output'];
-};
+  markdown: Scalars['String']['output']
+}
 
 export type GQLArticleDonation = {
-  __typename?: 'ArticleDonation';
-  id: Scalars['ID']['output'];
-  sender?: Maybe<GQLUser>;
-};
+  __typename?: 'ArticleDonation'
+  id: Scalars['ID']['output']
+  sender?: Maybe<GQLUser>
+}
 
 export type GQLArticleDonationConnection = {
-  __typename?: 'ArticleDonationConnection';
-  edges?: Maybe<Array<GQLArticleDonationEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'ArticleDonationConnection'
+  edges?: Maybe<Array<GQLArticleDonationEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLArticleDonationEdge = {
-  __typename?: 'ArticleDonationEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLArticleDonation;
-};
+  __typename?: 'ArticleDonationEdge'
+  cursor: Scalars['String']['output']
+  node: GQLArticleDonation
+}
 
 export type GQLArticleEdge = {
-  __typename?: 'ArticleEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLArticle;
-};
+  __typename?: 'ArticleEdge'
+  cursor: Scalars['String']['output']
+  node: GQLArticle
+}
 
 export type GQLArticleFederationEligibility = {
-  __typename?: 'ArticleFederationEligibility';
-  effectiveArticleSetting: GQLFederationArticleSettingState;
-  eligible: Scalars['Boolean']['output'];
-  reason: GQLFederationExportDecisionReason;
-};
+  __typename?: 'ArticleFederationEligibility'
+  effectiveArticleSetting: GQLFederationArticleSettingState
+  eligible: Scalars['Boolean']['output']
+  reason: GQLFederationExportDecisionReason
+}
 
 export type GQLArticleFederationSetting = {
-  __typename?: 'ArticleFederationSetting';
-  articleId: Scalars['ID']['output'];
-  state: GQLFederationArticleSettingState;
-  updatedBy?: Maybe<Scalars['ID']['output']>;
-};
+  __typename?: 'ArticleFederationSetting'
+  articleId: Scalars['ID']['output']
+  state: GQLFederationArticleSettingState
+  updatedBy?: Maybe<Scalars['ID']['output']>
+}
 
 export type GQLArticleInput = {
-  mediaHash?: InputMaybe<Scalars['String']['input']>;
-  shortHash?: InputMaybe<Scalars['String']['input']>;
-};
+  mediaHash?: InputMaybe<Scalars['String']['input']>
+  shortHash?: InputMaybe<Scalars['String']['input']>
+}
 
 /** Enums for types of article license */
 export type GQLArticleLicenseType =
   | 'arr'
   | 'cc_0'
   | 'cc_by_nc_nd_2'
-  | 'cc_by_nc_nd_4';
+  | 'cc_by_nc_nd_4'
 
 export type GQLArticleNotice = GQLNotice & {
-  __typename?: 'ArticleNotice';
+  __typename?: 'ArticleNotice'
   /** List of notice actors. */
-  actors?: Maybe<Array<GQLUser>>;
+  actors?: Maybe<Array<GQLUser>>
   /** Time of this notice was created. */
-  createdAt: Scalars['DateTime']['output'];
-  entities: Array<GQLNode>;
+  createdAt: Scalars['DateTime']['output']
+  entities: Array<GQLNode>
   /** Unique ID of this notice. */
-  id: Scalars['ID']['output'];
-  target: GQLArticle;
-  type: GQLArticleNoticeType;
+  id: Scalars['ID']['output']
+  target: GQLArticle
+  type: GQLArticleNoticeType
   /** The value determines if the notice is unread or not. */
-  unread: Scalars['Boolean']['output'];
-};
+  unread: Scalars['Boolean']['output']
+}
 
 export type GQLArticleNoticeType =
   | 'ArticleMentionedYou'
@@ -605,107 +631,103 @@ export type GQLArticleNoticeType =
   | 'RevisedArticleNotPublished'
   | 'RevisedArticlePublished'
   | 'ScheduledArticlePublished'
-  | 'TopicChannelFeedbackAccepted';
+  | 'TopicChannelFeedbackAccepted'
 
 export type GQLArticleOss = {
-  __typename?: 'ArticleOSS';
-  adStatus: GQLAdStatus;
-  boost: Scalars['Float']['output'];
-  inRecommendHottest: Scalars['Boolean']['output'];
-  inRecommendIcymi: Scalars['Boolean']['output'];
-  inRecommendNewest: Scalars['Boolean']['output'];
-  inSearch: Scalars['Boolean']['output'];
-  pinHistory: Array<Maybe<GQLPinHistory>>;
-  score: Scalars['Float']['output'];
-  spamStatus: GQLSpamStatus;
+  __typename?: 'ArticleOSS'
+  adStatus: GQLAdStatus
+  boost: Scalars['Float']['output']
+  inRecommendHottest: Scalars['Boolean']['output']
+  inRecommendIcymi: Scalars['Boolean']['output']
+  inRecommendNewest: Scalars['Boolean']['output']
+  inSearch: Scalars['Boolean']['output']
+  pinHistory: Array<Maybe<GQLPinHistory>>
+  score: Scalars['Float']['output']
+  spamStatus: GQLSpamStatus
   /** @deprecated Use classification.topicChannel.channels instead */
-  topicChannels?: Maybe<Array<GQLArticleTopicChannel>>;
-};
+  topicChannels?: Maybe<Array<GQLArticleTopicChannel>>
+}
 
 export type GQLArticleRecommendationActivity = {
-  __typename?: 'ArticleRecommendationActivity';
+  __typename?: 'ArticleRecommendationActivity'
   /** Recommended articles */
-  nodes?: Maybe<Array<GQLArticle>>;
+  nodes?: Maybe<Array<GQLArticle>>
   /** The source type of recommendation */
-  source?: Maybe<GQLArticleRecommendationActivitySource>;
-};
+  source?: Maybe<GQLArticleRecommendationActivitySource>
+}
 
 export type GQLArticleRecommendationActivitySource =
   | 'ReadArticlesTags'
-  | 'UserDonation';
+  | 'UserDonation'
 
 /** Enums for an article state. */
-export type GQLArticleState =
-  | 'active'
-  | 'archived'
-  | 'banned';
+export type GQLArticleState = 'active' | 'archived' | 'banned'
 
 export type GQLArticleTopicChannel = {
-  __typename?: 'ArticleTopicChannel';
+  __typename?: 'ArticleTopicChannel'
   /** Whether this article is filtered out by anti-flood in this channel */
-  antiFlooded: Scalars['Boolean']['output'];
-  channel: GQLTopicChannel;
+  antiFlooded: Scalars['Boolean']['output']
+  channel: GQLTopicChannel
   /** Datetime when this article is classified */
-  classicfiedAt: Scalars['DateTime']['output'];
+  classicfiedAt: Scalars['DateTime']['output']
   /** Whether this article channel is enabled */
-  enabled: Scalars['Boolean']['output'];
+  enabled: Scalars['Boolean']['output']
   /** Whether this article is labeled by human, null for not labeled yet.  */
-  isLabeled: Scalars['Boolean']['output'];
+  isLabeled: Scalars['Boolean']['output']
   /** Whether this article is pinned */
-  pinned: Scalars['Boolean']['output'];
+  pinned: Scalars['Boolean']['output']
   /** Confident score by machine */
-  score?: Maybe<Scalars['Float']['output']>;
-};
+  score?: Maybe<Scalars['Float']['output']>
+}
 
 export type GQLArticleTranslation = {
-  __typename?: 'ArticleTranslation';
-  content?: Maybe<Scalars['String']['output']>;
-  language?: Maybe<Scalars['String']['output']>;
-  model?: Maybe<GQLTranslationModel>;
-  summary?: Maybe<Scalars['String']['output']>;
-  title?: Maybe<Scalars['String']['output']>;
-};
+  __typename?: 'ArticleTranslation'
+  content?: Maybe<Scalars['String']['output']>
+  language?: Maybe<Scalars['String']['output']>
+  model?: Maybe<GQLTranslationModel>
+  summary?: Maybe<Scalars['String']['output']>
+  title?: Maybe<Scalars['String']['output']>
+}
 
 export type GQLArticleTranslationInput = {
-  language: GQLUserLanguage;
-  model?: InputMaybe<GQLTranslationModel>;
-};
+  language: GQLUserLanguage
+  model?: InputMaybe<GQLTranslationModel>
+}
 
 export type GQLArticleVersion = GQLNode & {
-  __typename?: 'ArticleVersion';
-  contents: GQLArticleContents;
-  createdAt: Scalars['DateTime']['output'];
-  dataHash?: Maybe<Scalars['String']['output']>;
-  description?: Maybe<Scalars['String']['output']>;
-  id: Scalars['ID']['output'];
-  mediaHash?: Maybe<Scalars['String']['output']>;
-  summary: Scalars['String']['output'];
-  title: Scalars['String']['output'];
-  translation?: Maybe<GQLArticleTranslation>;
-};
-
+  __typename?: 'ArticleVersion'
+  contents: GQLArticleContents
+  createdAt: Scalars['DateTime']['output']
+  dataHash?: Maybe<Scalars['String']['output']>
+  description?: Maybe<Scalars['String']['output']>
+  id: Scalars['ID']['output']
+  mediaHash?: Maybe<Scalars['String']['output']>
+  summary: Scalars['String']['output']
+  title: Scalars['String']['output']
+  translation?: Maybe<GQLArticleTranslation>
+}
 
 export type GQLArticleVersionTranslationArgs = {
-  input?: InputMaybe<GQLArticleTranslationInput>;
-};
+  input?: InputMaybe<GQLArticleTranslationInput>
+}
 
 export type GQLArticleVersionEdge = {
-  __typename?: 'ArticleVersionEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLArticleVersion;
-};
+  __typename?: 'ArticleVersionEdge'
+  cursor: Scalars['String']['output']
+  node: GQLArticleVersion
+}
 
 export type GQLArticleVersionsConnection = GQLConnection & {
-  __typename?: 'ArticleVersionsConnection';
-  edges: Array<Maybe<GQLArticleVersionEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'ArticleVersionsConnection'
+  edges: Array<Maybe<GQLArticleVersionEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLArticleVersionsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+}
 
 export type GQLArticlesSort =
   | 'mostAppreciations'
@@ -715,22 +737,22 @@ export type GQLArticlesSort =
   | 'mostReadTime'
   /** Order by spam score from high to low (only scored articles) */
   | 'mostSpam'
-  | 'newest';
+  | 'newest'
 
 /** This type contains type, link and related data of an asset. */
 export type GQLAsset = {
-  __typename?: 'Asset';
+  __typename?: 'Asset'
   /** Time of this asset was created. */
-  createdAt: Scalars['DateTime']['output'];
-  draft?: Maybe<Scalars['Boolean']['output']>;
+  createdAt: Scalars['DateTime']['output']
+  draft?: Maybe<Scalars['Boolean']['output']>
   /** Unique ID of this Asset. */
-  id: Scalars['ID']['output'];
+  id: Scalars['ID']['output']
   /** Link of this asset. */
-  path: Scalars['String']['output'];
+  path: Scalars['String']['output']
   /** Types of this asset. */
-  type: GQLAssetType;
-  uploadURL?: Maybe<Scalars['String']['output']>;
-};
+  type: GQLAssetType
+  uploadURL?: Maybe<Scalars['String']['output']>
+}
 
 /** Enums for asset types. */
 export type GQLAssetType =
@@ -746,31 +768,24 @@ export type GQLAssetType =
   | 'moment'
   | 'oauthClientAvatar'
   | 'profileCover'
-  | 'tagCover';
+  | 'tagCover'
 
 export type GQLAuthResult = {
-  __typename?: 'AuthResult';
-  auth: Scalars['Boolean']['output'];
-  token?: Maybe<Scalars['String']['output']>;
-  type: GQLAuthResultType;
-  user?: Maybe<GQLUser>;
-};
+  __typename?: 'AuthResult'
+  auth: Scalars['Boolean']['output']
+  token?: Maybe<Scalars['String']['output']>
+  type: GQLAuthResultType
+  user?: Maybe<GQLUser>
+}
 
-export type GQLAuthResultType =
-  | 'LinkAccount'
-  | 'Login'
-  | 'Signup';
+export type GQLAuthResultType = 'LinkAccount' | 'Login' | 'Signup'
 
-export type GQLAuthorsType =
-  | 'active'
-  | 'appreciated'
-  | 'default'
-  | 'trendy';
+export type GQLAuthorsType = 'active' | 'appreciated' | 'default' | 'trendy'
 
 export type GQLBadge = {
-  __typename?: 'Badge';
-  type: GQLBadgeType;
-};
+  __typename?: 'Badge'
+  type: GQLBadgeType
+}
 
 export type GQLBadgeType =
   | 'architect'
@@ -782,451 +797,424 @@ export type GQLBadgeType =
   | 'nomad2'
   | 'nomad3'
   | 'nomad4'
-  | 'seed';
+  | 'seed'
 
 export type GQLBadgedUsersInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  type?: InputMaybe<GQLBadgeType>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  type?: InputMaybe<GQLBadgeType>
+}
 
 export type GQLBalance = {
-  __typename?: 'Balance';
-  HKD: Scalars['Float']['output'];
-};
+  __typename?: 'Balance'
+  HKD: Scalars['Float']['output']
+}
 
 export type GQLBanCampaignArticlesInput = {
-  articles: Array<Scalars['ID']['input']>;
-  campaign: Scalars['ID']['input'];
-};
+  articles: Array<Scalars['ID']['input']>
+  campaign: Scalars['ID']['input']
+}
 
 export type GQLBlockchainTransaction = {
-  __typename?: 'BlockchainTransaction';
-  chain: GQLChain;
-  txHash: Scalars['String']['output'];
-};
+  __typename?: 'BlockchainTransaction'
+  chain: GQLChain
+  txHash: Scalars['String']['output']
+}
 
 export type GQLBlockedSearchKeyword = {
-  __typename?: 'BlockedSearchKeyword';
+  __typename?: 'BlockedSearchKeyword'
   /** Time of this search keyword was created. */
-  createdAt: Scalars['DateTime']['output'];
+  createdAt: Scalars['DateTime']['output']
   /** Unique ID of bloked search keyword. */
-  id: Scalars['ID']['output'];
+  id: Scalars['ID']['output']
   /** Types of this search keyword. */
-  searchKey: Scalars['String']['output'];
-};
+  searchKey: Scalars['String']['output']
+}
 
-export type GQLBoostTypes =
-  | 'Article'
-  | 'Campaign'
-  | 'Tag'
-  | 'User';
+export type GQLBoostTypes = 'Article' | 'Campaign' | 'Tag' | 'User'
 
-export type GQLCacheControlScope =
-  | 'PRIVATE'
-  | 'PUBLIC';
+export type GQLCacheControlScope = 'PRIVATE' | 'PUBLIC'
 
 export type GQLCampaign = {
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
-  shortHash: Scalars['String']['output'];
-  state: GQLCampaignState;
-};
+  id: Scalars['ID']['output']
+  name: Scalars['String']['output']
+  shortHash: Scalars['String']['output']
+  state: GQLCampaignState
+}
 
 export type GQLCampaignApplication = {
-  __typename?: 'CampaignApplication';
-  createdAt: Scalars['DateTime']['output'];
-  state: GQLCampaignApplicationState;
-};
+  __typename?: 'CampaignApplication'
+  createdAt: Scalars['DateTime']['output']
+  state: GQLCampaignApplicationState
+}
 
-export type GQLCampaignApplicationState =
-  | 'pending'
-  | 'rejected'
-  | 'succeeded';
+export type GQLCampaignApplicationState = 'pending' | 'rejected' | 'succeeded'
 
 export type GQLCampaignArticleConnection = GQLConnection & {
-  __typename?: 'CampaignArticleConnection';
-  edges: Array<GQLCampaignArticleEdge>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'CampaignArticleConnection'
+  edges: Array<GQLCampaignArticleEdge>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLCampaignArticleEdge = {
-  __typename?: 'CampaignArticleEdge';
-  announcement: Scalars['Boolean']['output'];
-  cursor: Scalars['String']['output'];
-  featured: Scalars['Boolean']['output'];
-  node: GQLArticle;
-};
+  __typename?: 'CampaignArticleEdge'
+  announcement: Scalars['Boolean']['output']
+  cursor: Scalars['String']['output']
+  featured: Scalars['Boolean']['output']
+  node: GQLArticle
+}
 
 export type GQLCampaignArticleNotice = GQLNotice & {
-  __typename?: 'CampaignArticleNotice';
+  __typename?: 'CampaignArticleNotice'
   /** List of notice actors. */
-  actors?: Maybe<Array<GQLUser>>;
-  article: GQLArticle;
+  actors?: Maybe<Array<GQLUser>>
+  article: GQLArticle
   /** Time of this notice was created. */
-  createdAt: Scalars['DateTime']['output'];
+  createdAt: Scalars['DateTime']['output']
   /** Unique ID of this notice. */
-  id: Scalars['ID']['output'];
-  target: GQLCampaign;
-  type: GQLCampaignArticleNoticeType;
+  id: Scalars['ID']['output']
+  target: GQLCampaign
+  type: GQLCampaignArticleNoticeType
   /** The value determines if the notice is unread or not. */
-  unread: Scalars['Boolean']['output'];
-};
+  unread: Scalars['Boolean']['output']
+}
 
-export type GQLCampaignArticleNoticeType =
-  | 'CampaignArticleFeatured';
+export type GQLCampaignArticleNoticeType = 'CampaignArticleFeatured'
 
 export type GQLCampaignArticlesFilter = {
-  featured?: InputMaybe<Scalars['Boolean']['input']>;
-  stage?: InputMaybe<Scalars['ID']['input']>;
-};
+  featured?: InputMaybe<Scalars['Boolean']['input']>
+  stage?: InputMaybe<Scalars['ID']['input']>
+}
 
 export type GQLCampaignArticlesInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<GQLCampaignArticlesFilter>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<GQLCampaignArticlesFilter>
+  first?: InputMaybe<Scalars['Int']['input']>
+}
 
 export type GQLCampaignConnection = GQLConnection & {
-  __typename?: 'CampaignConnection';
-  edges?: Maybe<Array<GQLCampaignEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'CampaignConnection'
+  edges?: Maybe<Array<GQLCampaignEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLCampaignEdge = {
-  __typename?: 'CampaignEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLCampaign;
-};
+  __typename?: 'CampaignEdge'
+  cursor: Scalars['String']['output']
+  node: GQLCampaign
+}
 
 export type GQLCampaignInput = {
-  shortHash: Scalars['String']['input'];
-};
+  shortHash: Scalars['String']['input']
+}
 
 export type GQLCampaignOss = {
-  __typename?: 'CampaignOSS';
-  boost: Scalars['Float']['output'];
-  exclusive: Scalars['Boolean']['output'];
-  managers: Array<GQLUser>;
-};
+  __typename?: 'CampaignOSS'
+  boost: Scalars['Float']['output']
+  exclusive: Scalars['Boolean']['output']
+  managers: Array<GQLUser>
+}
 
 export type GQLCampaignParticipantConnection = GQLConnection & {
-  __typename?: 'CampaignParticipantConnection';
-  edges?: Maybe<Array<GQLCampaignParticipantEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'CampaignParticipantConnection'
+  edges?: Maybe<Array<GQLCampaignParticipantEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLCampaignParticipantEdge = {
-  __typename?: 'CampaignParticipantEdge';
-  application?: Maybe<GQLCampaignApplication>;
-  cursor: Scalars['String']['output'];
-  node: GQLUser;
-};
+  __typename?: 'CampaignParticipantEdge'
+  application?: Maybe<GQLCampaignApplication>
+  cursor: Scalars['String']['output']
+  node: GQLUser
+}
 
 export type GQLCampaignParticipantsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
+  after?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
   /** return all state participants */
-  oss?: InputMaybe<Scalars['Boolean']['input']>;
-};
+  oss?: InputMaybe<Scalars['Boolean']['input']>
+}
 
 export type GQLCampaignStage = {
-  __typename?: 'CampaignStage';
-  description: Scalars['String']['output'];
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
-  period?: Maybe<GQLDatetimeRange>;
-};
-
+  __typename?: 'CampaignStage'
+  description: Scalars['String']['output']
+  id: Scalars['ID']['output']
+  name: Scalars['String']['output']
+  period?: Maybe<GQLDatetimeRange>
+}
 
 export type GQLCampaignStageDescriptionArgs = {
-  input?: InputMaybe<GQLTranslationArgs>;
-};
-
+  input?: InputMaybe<GQLTranslationArgs>
+}
 
 export type GQLCampaignStageNameArgs = {
-  input?: InputMaybe<GQLTranslationArgs>;
-};
+  input?: InputMaybe<GQLTranslationArgs>
+}
 
 export type GQLCampaignStageInput = {
-  description?: InputMaybe<Array<GQLTranslationInput>>;
-  name: Array<GQLTranslationInput>;
-  period?: InputMaybe<GQLDatetimeRangeInput>;
-};
+  description?: InputMaybe<Array<GQLTranslationInput>>
+  name: Array<GQLTranslationInput>
+  period?: InputMaybe<GQLDatetimeRangeInput>
+}
 
-export type GQLCampaignState =
-  | 'active'
-  | 'archived'
-  | 'finished'
-  | 'pending';
+export type GQLCampaignState = 'active' | 'archived' | 'finished' | 'pending'
 
 export type GQLCampaignsFilter = {
-  excludes?: InputMaybe<Array<Scalars['ID']['input']>>;
-  sort?: InputMaybe<GQLCampaignsFilterSort>;
-  state?: InputMaybe<GQLCampaignsFilterState>;
-};
+  excludes?: InputMaybe<Array<Scalars['ID']['input']>>
+  sort?: InputMaybe<GQLCampaignsFilterSort>
+  state?: InputMaybe<GQLCampaignsFilterState>
+}
 
-export type GQLCampaignsFilterSort =
-  | 'writingPeriod';
+export type GQLCampaignsFilterSort = 'writingPeriod'
 
-export type GQLCampaignsFilterState =
-  | 'active'
-  | 'finished';
+export type GQLCampaignsFilterState = 'active' | 'finished'
 
 export type GQLCampaignsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<GQLCampaignsFilter>;
-  first?: InputMaybe<Scalars['Int']['input']>;
+  after?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<GQLCampaignsFilter>
+  first?: InputMaybe<Scalars['Int']['input']>
   /** return pending and archived campaigns */
-  oss?: InputMaybe<Scalars['Boolean']['input']>;
-};
+  oss?: InputMaybe<Scalars['Boolean']['input']>
+}
 
-export type GQLChain =
-  | 'Optimism'
-  | 'Polygon';
+export type GQLChain = 'Optimism' | 'Polygon'
 
 export type GQLChannel = {
-  id: Scalars['ID']['output'];
-  navbarTitle: Scalars['String']['output'];
-  shortHash: Scalars['String']['output'];
-};
-
+  id: Scalars['ID']['output']
+  navbarTitle: Scalars['String']['output']
+  shortHash: Scalars['String']['output']
+}
 
 export type GQLChannelNavbarTitleArgs = {
-  input?: InputMaybe<GQLTranslationArgs>;
-};
+  input?: InputMaybe<GQLTranslationArgs>
+}
 
 export type GQLChannelArticleConnection = GQLConnection & {
-  __typename?: 'ChannelArticleConnection';
-  edges?: Maybe<Array<GQLChannelArticleEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'ChannelArticleConnection'
+  edges?: Maybe<Array<GQLChannelArticleEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLChannelArticleEdge = {
-  __typename?: 'ChannelArticleEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLArticle;
-  pinned: Scalars['Boolean']['output'];
-};
+  __typename?: 'ChannelArticleEdge'
+  cursor: Scalars['String']['output']
+  node: GQLArticle
+  pinned: Scalars['Boolean']['output']
+}
 
 export type GQLChannelArticlesFilter = {
-  datetimeRange?: InputMaybe<GQLDatetimeRangeInput>;
-  searchKey?: InputMaybe<Scalars['String']['input']>;
-};
+  datetimeRange?: InputMaybe<GQLDatetimeRangeInput>
+  searchKey?: InputMaybe<Scalars['String']['input']>
+}
 
 export type GQLChannelArticlesInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<GQLChannelArticlesFilter>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  oss?: InputMaybe<Scalars['Boolean']['input']>;
-  sort?: InputMaybe<GQLArticlesSort>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<GQLChannelArticlesFilter>
+  first?: InputMaybe<Scalars['Int']['input']>
+  oss?: InputMaybe<Scalars['Boolean']['input']>
+  sort?: InputMaybe<GQLArticlesSort>
+}
 
 export type GQLChannelInput = {
-  shortHash: Scalars['String']['input'];
-};
+  shortHash: Scalars['String']['input']
+}
 
 export type GQLChannelsInput = {
   /** return all channels if true, only active channels by default */
-  oss?: InputMaybe<Scalars['Boolean']['input']>;
-};
+  oss?: InputMaybe<Scalars['Boolean']['input']>
+}
 
 export type GQLCircle = GQLNode & {
-  __typename?: 'Circle';
+  __typename?: 'Circle'
   /** Analytics dashboard. */
-  analytics: GQLCircleAnalytics;
+  analytics: GQLCircleAnalytics
   /**
    * Circle avatar's link.
    * @deprecated No longer in use
    */
-  avatar?: Maybe<Scalars['String']['output']>;
+  avatar?: Maybe<Scalars['String']['output']>
   /** Comments broadcasted by Circle owner. */
-  broadcast: GQLCommentConnection;
+  broadcast: GQLCommentConnection
   /**
    * Circle cover's link.
    * @deprecated No longer in use
    */
-  cover?: Maybe<Scalars['String']['output']>;
+  cover?: Maybe<Scalars['String']['output']>
   /**
    * Created time.
    * @deprecated No longer in use
    */
-  createdAt: Scalars['DateTime']['output'];
+  createdAt: Scalars['DateTime']['output']
   /** A short description of this Circle. */
-  description?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>
   /** Comments made by Circle member. */
-  discussion: GQLCommentConnection;
+  discussion: GQLCommentConnection
   /** Discussion (include replies) count of this circle. */
-  discussionCount: Scalars['Int']['output'];
+  discussionCount: Scalars['Int']['output']
   /** Discussion (exclude replies) count of this circle. */
-  discussionThreadCount: Scalars['Int']['output'];
+  discussionThreadCount: Scalars['Int']['output']
   /**
    * Human readable name of this Circle.
    * @deprecated No longer in use
    */
-  displayName: Scalars['String']['output'];
+  displayName: Scalars['String']['output']
   /**
    * List of Circle follower.
    * @deprecated No longer in use
    */
-  followers: GQLUserConnection;
+  followers: GQLUserConnection
   /** Unique ID. */
-  id: Scalars['ID']['output'];
+  id: Scalars['ID']['output']
   /** Invitation used by current viewer. */
-  invitedBy?: Maybe<GQLInvitation>;
+  invitedBy?: Maybe<GQLInvitation>
   /** Invitations belonged to this Circle. */
-  invites: GQLInvites;
+  invites: GQLInvites
   /**
    * This value determines if current viewer is following Circle or not.
    * @deprecated No longer in use
    */
-  isFollower: Scalars['Boolean']['output'];
+  isFollower: Scalars['Boolean']['output']
   /**
    * This value determines if current viewer is Member or not.
    * @deprecated No longer in use
    */
-  isMember: Scalars['Boolean']['output'];
+  isMember: Scalars['Boolean']['output']
   /**
    * List of Circle member.
    * @deprecated No longer in use
    */
-  members: GQLMemberConnection;
+  members: GQLMemberConnection
   /**
    * Slugified name of this Circle.
    * @deprecated No longer in use
    */
-  name: Scalars['String']['output'];
+  name: Scalars['String']['output']
   /** Circle owner. */
-  owner: GQLUser;
+  owner: GQLUser
   /** Pinned comments broadcasted by Circle owner. */
-  pinnedBroadcast?: Maybe<Array<GQLComment>>;
+  pinnedBroadcast?: Maybe<Array<GQLComment>>
   /** Prices offered by this Circle. */
-  prices?: Maybe<Array<GQLPrice>>;
+  prices?: Maybe<Array<GQLPrice>>
   /**
    * State of this Circle.
    * @deprecated No longer in use
    */
-  state: GQLCircleState;
+  state: GQLCircleState
   /**
    * Updated time.
    * @deprecated No longer in use
    */
-  updatedAt: Scalars['DateTime']['output'];
+  updatedAt: Scalars['DateTime']['output']
   /**
    * List of works belong to this Circle.
    * @deprecated No longer in use
    */
-  works: GQLArticleConnection;
-};
-
+  works: GQLArticleConnection
+}
 
 export type GQLCircleBroadcastArgs = {
-  input: GQLCommentsInput;
-};
-
+  input: GQLCommentsInput
+}
 
 export type GQLCircleDiscussionArgs = {
-  input: GQLCommentsInput;
-};
-
+  input: GQLCommentsInput
+}
 
 export type GQLCircleFollowersArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLCircleMembersArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLCircleWorksArgs = {
-  input: GQLConnectionArgs;
-};
+  input: GQLConnectionArgs
+}
 
 export type GQLCircleAnalytics = {
-  __typename?: 'CircleAnalytics';
-  content: GQLCircleContentAnalytics;
-  follower: GQLCircleFollowerAnalytics;
-  income: GQLCircleIncomeAnalytics;
-  subscriber: GQLCircleSubscriberAnalytics;
-};
+  __typename?: 'CircleAnalytics'
+  content: GQLCircleContentAnalytics
+  follower: GQLCircleFollowerAnalytics
+  income: GQLCircleIncomeAnalytics
+  subscriber: GQLCircleSubscriberAnalytics
+}
 
 export type GQLCircleConnection = GQLConnection & {
-  __typename?: 'CircleConnection';
-  edges?: Maybe<Array<GQLCircleEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'CircleConnection'
+  edges?: Maybe<Array<GQLCircleEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLCircleContentAnalytics = {
-  __typename?: 'CircleContentAnalytics';
-  paywall?: Maybe<Array<GQLCircleContentAnalyticsDatum>>;
-  public?: Maybe<Array<GQLCircleContentAnalyticsDatum>>;
-};
+  __typename?: 'CircleContentAnalytics'
+  paywall?: Maybe<Array<GQLCircleContentAnalyticsDatum>>
+  public?: Maybe<Array<GQLCircleContentAnalyticsDatum>>
+}
 
 export type GQLCircleContentAnalyticsDatum = {
-  __typename?: 'CircleContentAnalyticsDatum';
-  node: GQLArticle;
-  readCount: Scalars['Int']['output'];
-};
+  __typename?: 'CircleContentAnalyticsDatum'
+  node: GQLArticle
+  readCount: Scalars['Int']['output']
+}
 
 export type GQLCircleEdge = {
-  __typename?: 'CircleEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLCircle;
-};
+  __typename?: 'CircleEdge'
+  cursor: Scalars['String']['output']
+  node: GQLCircle
+}
 
 export type GQLCircleFollowerAnalytics = {
-  __typename?: 'CircleFollowerAnalytics';
+  __typename?: 'CircleFollowerAnalytics'
   /** current follower count */
-  current: Scalars['Int']['output'];
+  current: Scalars['Int']['output']
   /** the percentage of follower count in reader count of circle articles */
-  followerPercentage: Scalars['Float']['output'];
+  followerPercentage: Scalars['Float']['output']
   /** subscriber count history of last 4 months */
-  history: Array<GQLMonthlyDatum>;
-};
+  history: Array<GQLMonthlyDatum>
+}
 
 export type GQLCircleIncomeAnalytics = {
-  __typename?: 'CircleIncomeAnalytics';
+  __typename?: 'CircleIncomeAnalytics'
   /** income history of last 4 months */
-  history: Array<GQLMonthlyDatum>;
+  history: Array<GQLMonthlyDatum>
   /** income of next month */
-  nextMonth: Scalars['Float']['output'];
+  nextMonth: Scalars['Float']['output']
   /** income of this month */
-  thisMonth: Scalars['Float']['output'];
+  thisMonth: Scalars['Float']['output']
   /** total income of all time */
-  total: Scalars['Float']['output'];
-};
+  total: Scalars['Float']['output']
+}
 
 export type GQLCircleInput = {
   /** Slugified name of a Circle. */
-  name: Scalars['String']['input'];
-};
+  name: Scalars['String']['input']
+}
 
 export type GQLCircleNotice = GQLNotice & {
-  __typename?: 'CircleNotice';
+  __typename?: 'CircleNotice'
   /** List of notice actors. */
-  actors?: Maybe<Array<GQLUser>>;
+  actors?: Maybe<Array<GQLUser>>
   /** Optional discussion/broadcast comments for bundled notices */
-  comments?: Maybe<Array<GQLComment>>;
+  comments?: Maybe<Array<GQLComment>>
   /** Time of this notice was created. */
-  createdAt: Scalars['DateTime']['output'];
+  createdAt: Scalars['DateTime']['output']
   /** Unique ID of this notice. */
-  id: Scalars['ID']['output'];
+  id: Scalars['ID']['output']
   /** Optional mention comments for bundled notices */
-  mentions?: Maybe<Array<GQLComment>>;
+  mentions?: Maybe<Array<GQLComment>>
   /** Optional discussion/broadcast replies for bundled notices */
-  replies?: Maybe<Array<GQLComment>>;
-  target: GQLCircle;
-  type: GQLCircleNoticeType;
+  replies?: Maybe<Array<GQLComment>>
+  target: GQLCircle
+  type: GQLCircleNoticeType
   /** The value determines if the notice is unread or not. */
-  unread: Scalars['Boolean']['output'];
-};
+  unread: Scalars['Boolean']['output']
+}
 
 export type GQLCircleNoticeType =
   | 'CircleInvitation'
@@ -1234,133 +1222,129 @@ export type GQLCircleNoticeType =
   | 'CircleNewDiscussionComments'
   | 'CircleNewFollower'
   | 'CircleNewSubscriber'
-  | 'CircleNewUnsubscriber';
+  | 'CircleNewUnsubscriber'
 
 export type GQLCircleRecommendationActivity = {
-  __typename?: 'CircleRecommendationActivity';
+  __typename?: 'CircleRecommendationActivity'
   /** Recommended circles */
-  nodes?: Maybe<Array<GQLCircle>>;
+  nodes?: Maybe<Array<GQLCircle>>
   /** The source type of recommendation */
-  source?: Maybe<GQLCircleRecommendationActivitySource>;
-};
+  source?: Maybe<GQLCircleRecommendationActivitySource>
+}
 
-export type GQLCircleRecommendationActivitySource =
-  | 'UserSubscription';
+export type GQLCircleRecommendationActivitySource = 'UserSubscription'
 
-export type GQLCircleState =
-  | 'active'
-  | 'archived';
+export type GQLCircleState = 'active' | 'archived'
 
 export type GQLCircleSubscriberAnalytics = {
-  __typename?: 'CircleSubscriberAnalytics';
+  __typename?: 'CircleSubscriberAnalytics'
   /** current invitee count */
-  currentInvitee: Scalars['Int']['output'];
+  currentInvitee: Scalars['Int']['output']
   /** current subscriber count */
-  currentSubscriber: Scalars['Int']['output'];
+  currentSubscriber: Scalars['Int']['output']
   /** invitee count history of last 4 months */
-  inviteeHistory: Array<GQLMonthlyDatum>;
+  inviteeHistory: Array<GQLMonthlyDatum>
   /** subscriber count history of last 4 months */
-  subscriberHistory: Array<GQLMonthlyDatum>;
-};
+  subscriberHistory: Array<GQLMonthlyDatum>
+}
 
 export type GQLClaimLogbooksInput = {
-  ethAddress: Scalars['String']['input'];
+  ethAddress: Scalars['String']['input']
   /** nonce from generateSigningMessage */
-  nonce: Scalars['String']['input'];
+  nonce: Scalars['String']['input']
   /** sign'ed by wallet */
-  signature: Scalars['String']['input'];
+  signature: Scalars['String']['input']
   /** the message being sign'ed, including nonce */
-  signedMessage: Scalars['String']['input'];
-};
+  signedMessage: Scalars['String']['input']
+}
 
 export type GQLClaimLogbooksResult = {
-  __typename?: 'ClaimLogbooksResult';
-  ids?: Maybe<Array<Scalars['ID']['output']>>;
-  txHash: Scalars['String']['output'];
-};
+  __typename?: 'ClaimLogbooksResult'
+  ids?: Maybe<Array<Scalars['ID']['output']>>
+  txHash: Scalars['String']['output']
+}
 
 export type GQLClaimPersonhoodBadgeInput = {
-  certChainProof: Scalars['String']['input'];
-  certChainType?: InputMaybe<Scalars['String']['input']>;
-  handoffToken: Scalars['String']['input'];
-  userSigProof: Scalars['String']['input'];
-};
+  certChainProof: Scalars['String']['input']
+  certChainType?: InputMaybe<Scalars['String']['input']>
+  handoffToken: Scalars['String']['input']
+  userSigProof: Scalars['String']['input']
+}
 
 export type GQLClassifyArticlesChannelsInput = {
-  ids: Array<Scalars['ID']['input']>;
-};
+  ids: Array<Scalars['ID']['input']>
+}
 
 export type GQLClearCommunityWatchOriginalContentInput = {
-  note?: InputMaybe<Scalars['String']['input']>;
-  uuid: Scalars['ID']['input'];
-};
+  note?: InputMaybe<Scalars['String']['input']>
+  uuid: Scalars['ID']['input']
+}
 
 export type GQLClearReadHistoryInput = {
-  id?: InputMaybe<Scalars['ID']['input']>;
-};
+  id?: InputMaybe<Scalars['ID']['input']>
+}
 
-export type GQLCollection = GQLNode & GQLPinnableWork & {
-  __typename?: 'Collection';
-  articles: GQLArticleConnection;
-  author: GQLUser;
-  /** Check if the collection contains the article */
-  contains: Scalars['Boolean']['output'];
-  cover?: Maybe<Scalars['String']['output']>;
-  description?: Maybe<Scalars['String']['output']>;
-  id: Scalars['ID']['output'];
-  likeCount: Scalars['Int']['output'];
-  /** whether current user has liked it */
-  liked: Scalars['Boolean']['output'];
-  pinned: Scalars['Boolean']['output'];
-  title: Scalars['String']['output'];
-  updatedAt: Scalars['DateTime']['output'];
-};
-
+export type GQLCollection = GQLNode &
+  GQLPinnableWork & {
+    __typename?: 'Collection'
+    articles: GQLArticleConnection
+    author: GQLUser
+    /** Check if the collection contains the article */
+    contains: Scalars['Boolean']['output']
+    cover?: Maybe<Scalars['String']['output']>
+    description?: Maybe<Scalars['String']['output']>
+    id: Scalars['ID']['output']
+    likeCount: Scalars['Int']['output']
+    /** whether current user has liked it */
+    liked: Scalars['Boolean']['output']
+    pinned: Scalars['Boolean']['output']
+    title: Scalars['String']['output']
+    updatedAt: Scalars['DateTime']['output']
+  }
 
 export type GQLCollectionArticlesArgs = {
-  input: GQLCollectionArticlesInput;
-};
-
+  input: GQLCollectionArticlesInput
+}
 
 export type GQLCollectionContainsArgs = {
-  input: GQLNodeInput;
-};
+  input: GQLNodeInput
+}
 
 export type GQLCollectionArticlesInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  includeAfter?: Scalars['Boolean']['input'];
-  includeBefore?: Scalars['Boolean']['input'];
-  last?: InputMaybe<Scalars['Int']['input']>;
-  reversed?: Scalars['Boolean']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  before?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  includeAfter?: Scalars['Boolean']['input']
+  includeBefore?: Scalars['Boolean']['input']
+  last?: InputMaybe<Scalars['Int']['input']>
+  reversed?: Scalars['Boolean']['input']
+}
 
 export type GQLCollectionConnection = GQLConnection & {
-  __typename?: 'CollectionConnection';
-  edges?: Maybe<Array<GQLCollectionEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'CollectionConnection'
+  edges?: Maybe<Array<GQLCollectionEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLCollectionEdge = {
-  __typename?: 'CollectionEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLCollection;
-};
+  __typename?: 'CollectionEdge'
+  cursor: Scalars['String']['output']
+  node: GQLCollection
+}
 
 export type GQLCollectionNotice = GQLNotice & {
-  __typename?: 'CollectionNotice';
+  __typename?: 'CollectionNotice'
   /** List of notice actors. */
-  actors?: Maybe<Array<GQLUser>>;
+  actors?: Maybe<Array<GQLUser>>
   /** Time of this notice was created. */
-  createdAt: Scalars['DateTime']['output'];
+  createdAt: Scalars['DateTime']['output']
   /** Unique ID of this notice. */
-  id: Scalars['ID']['output'];
-  target: GQLCollection;
+  id: Scalars['ID']['output']
+  target: GQLCollection
   /** The value determines if the notice is unread or not. */
-  unread: Scalars['Boolean']['output'];
-};
+  unread: Scalars['Boolean']['output']
+}
 
 export type GQLColor =
   | 'brown'
@@ -1370,118 +1354,116 @@ export type GQLColor =
   | 'pink'
   | 'purple'
   | 'red'
-  | 'yellow';
+  | 'yellow'
 
 /** This type contains content, author, descendant comments and related data of a comment. */
 export type GQLComment = GQLNode & {
-  __typename?: 'Comment';
+  __typename?: 'Comment'
   /** Author of this comment. */
-  author: GQLUser;
+  author: GQLUser
   /** Descendant comments of this comment. */
-  comments: GQLCommentConnection;
+  comments: GQLCommentConnection
   /** Community Watch audit action when this comment was removed by Community Watch. */
-  communityWatchAction?: Maybe<GQLCommunityWatchAction>;
+  communityWatchAction?: Maybe<GQLCommunityWatchAction>
   /** Content of this comment. */
-  content?: Maybe<Scalars['String']['output']>;
+  content?: Maybe<Scalars['String']['output']>
   /** Time of this comment was created. */
-  createdAt: Scalars['DateTime']['output'];
+  createdAt: Scalars['DateTime']['output']
   /**
    * The counting number of downvotes.
    * @deprecated No longer in use in querying
    */
-  downvotes: Scalars['Int']['output'];
+  downvotes: Scalars['Int']['output']
   /** This value determines this comment is from article donator or not. */
-  fromDonator: Scalars['Boolean']['output'];
+  fromDonator: Scalars['Boolean']['output']
   /** Unique ID of this comment. */
-  id: Scalars['ID']['output'];
+  id: Scalars['ID']['output']
   /** The value determines current user's vote. */
-  myVote?: Maybe<GQLVote>;
+  myVote?: Maybe<GQLVote>
   /** Current comment belongs to which Node. */
-  node: GQLNode;
+  node: GQLNode
   /** Parent comment of this comment. */
-  parentComment?: Maybe<GQLComment>;
+  parentComment?: Maybe<GQLComment>
   /** This value determines this comment is pinned or not. */
-  pinned: Scalars['Boolean']['output'];
-  remark?: Maybe<Scalars['String']['output']>;
+  pinned: Scalars['Boolean']['output']
+  remark?: Maybe<Scalars['String']['output']>
   /** A Comment that this comment replied to. */
-  replyTo?: Maybe<GQLComment>;
-  spamStatus: GQLSpamStatus;
+  replyTo?: Maybe<GQLComment>
+  spamStatus: GQLSpamStatus
   /** State of this comment. */
-  state: GQLCommentState;
-  type: GQLCommentType;
+  state: GQLCommentState
+  type: GQLCommentType
   /** The counting number of upvotes. */
-  upvotes: Scalars['Int']['output'];
-};
-
+  upvotes: Scalars['Int']['output']
+}
 
 /** This type contains content, author, descendant comments and related data of a comment. */
 export type GQLCommentCommentsArgs = {
-  input: GQLCommentCommentsInput;
-};
+  input: GQLCommentCommentsInput
+}
 
 export type GQLCommentCommentNotice = GQLNotice & {
-  __typename?: 'CommentCommentNotice';
+  __typename?: 'CommentCommentNotice'
   /** List of notice actors. */
-  actors?: Maybe<Array<GQLUser>>;
-  comment: GQLComment;
+  actors?: Maybe<Array<GQLUser>>
+  comment: GQLComment
   /** Time of this notice was created. */
-  createdAt: Scalars['DateTime']['output'];
+  createdAt: Scalars['DateTime']['output']
   /** Unique ID of this notice. */
-  id: Scalars['ID']['output'];
-  target: GQLComment;
-  type: GQLCommentCommentNoticeType;
+  id: Scalars['ID']['output']
+  target: GQLComment
+  type: GQLCommentCommentNoticeType
   /** The value determines if the notice is unread or not. */
-  unread: Scalars['Boolean']['output'];
-};
+  unread: Scalars['Boolean']['output']
+}
 
-export type GQLCommentCommentNoticeType =
-  | 'CommentNewReply';
+export type GQLCommentCommentNoticeType = 'CommentNewReply'
 
 export type GQLCommentCommentsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  author?: InputMaybe<Scalars['ID']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  sort?: InputMaybe<GQLCommentSort>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  author?: InputMaybe<Scalars['ID']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  sort?: InputMaybe<GQLCommentSort>
+}
 
 export type GQLCommentConnection = GQLConnection & {
-  __typename?: 'CommentConnection';
-  edges?: Maybe<Array<GQLCommentEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'CommentConnection'
+  edges?: Maybe<Array<GQLCommentEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLCommentEdge = {
-  __typename?: 'CommentEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLComment;
-};
+  __typename?: 'CommentEdge'
+  cursor: Scalars['String']['output']
+  node: GQLComment
+}
 
 export type GQLCommentInput = {
-  articleId?: InputMaybe<Scalars['ID']['input']>;
-  campaignId?: InputMaybe<Scalars['ID']['input']>;
-  circleId?: InputMaybe<Scalars['ID']['input']>;
-  content: Scalars['String']['input'];
-  mentions?: InputMaybe<Array<Scalars['ID']['input']>>;
-  momentId?: InputMaybe<Scalars['ID']['input']>;
-  parentId?: InputMaybe<Scalars['ID']['input']>;
-  replyTo?: InputMaybe<Scalars['ID']['input']>;
-  type: GQLCommentType;
-};
+  articleId?: InputMaybe<Scalars['ID']['input']>
+  campaignId?: InputMaybe<Scalars['ID']['input']>
+  circleId?: InputMaybe<Scalars['ID']['input']>
+  content: Scalars['String']['input']
+  mentions?: InputMaybe<Array<Scalars['ID']['input']>>
+  momentId?: InputMaybe<Scalars['ID']['input']>
+  parentId?: InputMaybe<Scalars['ID']['input']>
+  replyTo?: InputMaybe<Scalars['ID']['input']>
+  type: GQLCommentType
+}
 
 export type GQLCommentNotice = GQLNotice & {
-  __typename?: 'CommentNotice';
+  __typename?: 'CommentNotice'
   /** List of notice actors. */
-  actors?: Maybe<Array<GQLUser>>;
+  actors?: Maybe<Array<GQLUser>>
   /** Time of this notice was created. */
-  createdAt: Scalars['DateTime']['output'];
+  createdAt: Scalars['DateTime']['output']
   /** Unique ID of this notice. */
-  id: Scalars['ID']['output'];
-  target: GQLComment;
-  type: GQLCommentNoticeType;
+  id: Scalars['ID']['output']
+  target: GQLComment
+  type: GQLCommentNoticeType
   /** The value determines if the notice is unread or not. */
-  unread: Scalars['Boolean']['output'];
-};
+  unread: Scalars['Boolean']['output']
+}
 
 export type GQLCommentNoticeType =
   | 'ArticleNewComment'
@@ -1490,411 +1472,386 @@ export type GQLCommentNoticeType =
   | 'CommentMentionedYou'
   | 'CommentPinned'
   | 'MomentNewComment'
-  | 'SubscribedArticleNewComment';
+  | 'SubscribedArticleNewComment'
 
 /** Enums for sorting comments by time. */
-export type GQLCommentSort =
-  | 'newest'
-  | 'oldest';
+export type GQLCommentSort = 'newest' | 'oldest'
 
 /** Enums for comment state. */
-export type GQLCommentState =
-  | 'active'
-  | 'archived'
-  | 'banned'
-  | 'collapsed';
+export type GQLCommentState = 'active' | 'archived' | 'banned' | 'collapsed'
 
 export type GQLCommentType =
   | 'article'
   | 'campaignDiscussion'
   | 'circleBroadcast'
   | 'circleDiscussion'
-  | 'moment';
+  | 'moment'
 
 export type GQLCommentsFilter = {
-  author?: InputMaybe<Scalars['ID']['input']>;
-  parentComment?: InputMaybe<Scalars['ID']['input']>;
-  state?: InputMaybe<GQLCommentState>;
-};
+  author?: InputMaybe<Scalars['ID']['input']>
+  parentComment?: InputMaybe<Scalars['ID']['input']>
+  state?: InputMaybe<GQLCommentState>
+}
 
 export type GQLCommentsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<GQLCommentsFilter>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  includeAfter?: InputMaybe<Scalars['Boolean']['input']>;
-  includeBefore?: InputMaybe<Scalars['Boolean']['input']>;
-  sort?: InputMaybe<GQLCommentSort>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  before?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<GQLCommentsFilter>
+  first?: InputMaybe<Scalars['Int']['input']>
+  includeAfter?: InputMaybe<Scalars['Boolean']['input']>
+  includeBefore?: InputMaybe<Scalars['Boolean']['input']>
+  sort?: InputMaybe<GQLCommentSort>
+}
 
 export type GQLCommunityWatchAction = {
-  __typename?: 'CommunityWatchAction';
-  actionState: GQLCommunityWatchActionState;
-  actorDisplayName: Scalars['String']['output'];
-  appealState: GQLCommunityWatchAppealState;
-  commentId: Scalars['ID']['output'];
-  contentCleared: Scalars['Boolean']['output'];
+  __typename?: 'CommunityWatchAction'
+  actionState: GQLCommunityWatchActionState
+  actorDisplayName: Scalars['String']['output']
+  appealState: GQLCommunityWatchAppealState
+  commentId: Scalars['ID']['output']
+  contentCleared: Scalars['Boolean']['output']
   /** SHA-256 hash of normalized original content for OSS clustering without re-spreading spam text. */
-  contentHash?: Maybe<Scalars['String']['output']>;
-  createdAt: Scalars['DateTime']['output'];
-  originalContent?: Maybe<Scalars['String']['output']>;
-  reason: GQLCommunityWatchRemoveCommentReason;
+  contentHash?: Maybe<Scalars['String']['output']>
+  createdAt: Scalars['DateTime']['output']
+  originalContent?: Maybe<Scalars['String']['output']>
+  reason: GQLCommunityWatchRemoveCommentReason
   /** Whether this Community Watch action also created the normal user report flow for staff review. */
-  reportSynced: Scalars['Boolean']['output'];
-  reviewState: GQLCommunityWatchReviewState;
-  sourceId: Scalars['ID']['output'];
-  sourceTitle: Scalars['String']['output'];
-  sourceType: GQLCommunityWatchActionSourceType;
+  reportSynced: Scalars['Boolean']['output']
+  reviewState: GQLCommunityWatchReviewState
+  sourceId: Scalars['ID']['output']
+  sourceTitle: Scalars['String']['output']
+  sourceType: GQLCommunityWatchActionSourceType
   /** Public Matters URL for the removed comment when the source still has a public route. */
-  sourceUrl?: Maybe<Scalars['String']['output']>;
+  sourceUrl?: Maybe<Scalars['String']['output']>
   /** Public identifier used by the Community Watch transparency page. */
-  uuid: Scalars['ID']['output'];
-};
+  uuid: Scalars['ID']['output']
+}
 
 export type GQLCommunityWatchActionConnection = GQLConnection & {
-  __typename?: 'CommunityWatchActionConnection';
-  edges?: Maybe<Array<GQLCommunityWatchActionEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'CommunityWatchActionConnection'
+  edges?: Maybe<Array<GQLCommunityWatchActionEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLCommunityWatchActionEdge = {
-  __typename?: 'CommunityWatchActionEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLCommunityWatchAction;
-};
+  __typename?: 'CommunityWatchActionEdge'
+  cursor: Scalars['String']['output']
+  node: GQLCommunityWatchAction
+}
 
 export type GQLCommunityWatchActionInput = {
-  uuid: Scalars['ID']['input'];
-};
+  uuid: Scalars['ID']['input']
+}
 
-export type GQLCommunityWatchActionSourceType =
-  | 'article'
-  | 'moment';
+export type GQLCommunityWatchActionSourceType = 'article' | 'moment'
 
-export type GQLCommunityWatchActionState =
-  | 'active'
-  | 'restored'
-  | 'voided';
+export type GQLCommunityWatchActionState = 'active' | 'restored' | 'voided'
 
 export type GQLCommunityWatchActionsInput = {
-  actionState?: InputMaybe<GQLCommunityWatchActionState>;
-  after?: InputMaybe<Scalars['String']['input']>;
-  appealState?: InputMaybe<GQLCommunityWatchAppealState>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  reason?: InputMaybe<GQLCommunityWatchRemoveCommentReason>;
-  reviewState?: InputMaybe<GQLCommunityWatchReviewState>;
-};
+  actionState?: InputMaybe<GQLCommunityWatchActionState>
+  after?: InputMaybe<Scalars['String']['input']>
+  appealState?: InputMaybe<GQLCommunityWatchAppealState>
+  first?: InputMaybe<Scalars['Int']['input']>
+  reason?: InputMaybe<GQLCommunityWatchRemoveCommentReason>
+  reviewState?: InputMaybe<GQLCommunityWatchReviewState>
+}
 
-export type GQLCommunityWatchAppealState =
-  | 'none'
-  | 'received'
-  | 'resolved';
+export type GQLCommunityWatchAppealState = 'none' | 'received' | 'resolved'
 
 export type GQLCommunityWatchRemoveCommentInput = {
-  id: Scalars['ID']['input'];
-  reason: GQLCommunityWatchRemoveCommentReason;
-};
+  id: Scalars['ID']['input']
+  reason: GQLCommunityWatchRemoveCommentReason
+}
 
-export type GQLCommunityWatchRemoveCommentReason =
-  | 'porn_ad'
-  | 'spam_ad';
+export type GQLCommunityWatchRemoveCommentReason = 'porn_ad' | 'spam_ad'
 
 export type GQLCommunityWatchReviewState =
   | 'pending'
   | 'reason_adjusted'
   | 'reversed'
-  | 'upheld';
+  | 'upheld'
 
 export type GQLConfirmVerificationCodeInput = {
-  code: Scalars['String']['input'];
-  email: Scalars['String']['input'];
-  type: GQLVerificationCodeType;
-};
+  code: Scalars['String']['input']
+  email: Scalars['String']['input']
+  type: GQLVerificationCodeType
+}
 
 export type GQLConnectStripeAccountInput = {
-  country: GQLStripeAccountCountry;
-};
+  country: GQLStripeAccountCountry
+}
 
 export type GQLConnectStripeAccountResult = {
-  __typename?: 'ConnectStripeAccountResult';
-  redirectUrl: Scalars['String']['output'];
-};
+  __typename?: 'ConnectStripeAccountResult'
+  redirectUrl: Scalars['String']['output']
+}
 
 export type GQLConnection = {
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLConnectionArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<GQLFilterInput>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  oss?: InputMaybe<Scalars['Boolean']['input']>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<GQLFilterInput>
+  first?: InputMaybe<Scalars['Int']['input']>
+  oss?: InputMaybe<Scalars['Boolean']['input']>
+}
 
 export type GQLCreatePersonhoodHandoffInput = {
-  challenge: Scalars['String']['input'];
-  challengeExpiresAt?: InputMaybe<Scalars['DateTime']['input']>;
-};
+  challenge: Scalars['String']['input']
+  challengeExpiresAt?: InputMaybe<Scalars['DateTime']['input']>
+}
 
 export type GQLCryptoWallet = {
-  __typename?: 'CryptoWallet';
-  address: Scalars['String']['output'];
+  __typename?: 'CryptoWallet'
+  address: Scalars['String']['output']
   /**  does this address own any Travelogger NFTs? this value is cached at most 1day, and refreshed at next `nfts` query  */
-  hasNFTs: Scalars['Boolean']['output'];
-  id: Scalars['ID']['output'];
+  hasNFTs: Scalars['Boolean']['output']
+  id: Scalars['ID']['output']
   /** NFT assets owned by this wallet address */
-  nfts?: Maybe<Array<GQLNftAsset>>;
-};
+  nfts?: Maybe<Array<GQLNftAsset>>
+}
 
 export type GQLCryptoWalletSignaturePurpose =
   | 'airdrop'
   | 'connect'
   | 'login'
-  | 'signup';
+  | 'signup'
 
-export type GQLCurationChannel = GQLChannel & GQLNode & {
-  __typename?: 'CurationChannel';
-  /** both activePeriod and state determine if the channel is active */
-  activePeriod: GQLDatetimeRange;
-  articles: GQLChannelArticleConnection;
-  color: GQLColor;
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
-  navbarTitle: Scalars['String']['output'];
-  note?: Maybe<Scalars['String']['output']>;
-  pinAmount: Scalars['Int']['output'];
-  shortHash: Scalars['String']['output'];
-  showRecommendation: Scalars['Boolean']['output'];
-  state: GQLCurationChannelState;
-};
-
+export type GQLCurationChannel = GQLChannel &
+  GQLNode & {
+    __typename?: 'CurationChannel'
+    /** both activePeriod and state determine if the channel is active */
+    activePeriod: GQLDatetimeRange
+    articles: GQLChannelArticleConnection
+    color: GQLColor
+    id: Scalars['ID']['output']
+    name: Scalars['String']['output']
+    navbarTitle: Scalars['String']['output']
+    note?: Maybe<Scalars['String']['output']>
+    pinAmount: Scalars['Int']['output']
+    shortHash: Scalars['String']['output']
+    showRecommendation: Scalars['Boolean']['output']
+    state: GQLCurationChannelState
+  }
 
 export type GQLCurationChannelArticlesArgs = {
-  input: GQLChannelArticlesInput;
-};
-
+  input: GQLChannelArticlesInput
+}
 
 export type GQLCurationChannelNameArgs = {
-  input?: InputMaybe<GQLTranslationArgs>;
-};
-
+  input?: InputMaybe<GQLTranslationArgs>
+}
 
 export type GQLCurationChannelNavbarTitleArgs = {
-  input?: InputMaybe<GQLTranslationArgs>;
-};
-
+  input?: InputMaybe<GQLTranslationArgs>
+}
 
 export type GQLCurationChannelNoteArgs = {
-  input?: InputMaybe<GQLTranslationArgs>;
-};
+  input?: InputMaybe<GQLTranslationArgs>
+}
 
-export type GQLCurationChannelState =
-  | 'archived'
-  | 'editing'
-  | 'published';
+export type GQLCurationChannelState = 'archived' | 'editing' | 'published'
 
 export type GQLDatetimeRange = {
-  __typename?: 'DatetimeRange';
-  end?: Maybe<Scalars['DateTime']['output']>;
-  start: Scalars['DateTime']['output'];
-};
+  __typename?: 'DatetimeRange'
+  end?: Maybe<Scalars['DateTime']['output']>
+  start: Scalars['DateTime']['output']
+}
 
 export type GQLDatetimeRangeInput = {
-  end?: InputMaybe<Scalars['DateTime']['input']>;
-  start: Scalars['DateTime']['input'];
-};
+  end?: InputMaybe<Scalars['DateTime']['input']>
+  start: Scalars['DateTime']['input']
+}
 
 export type GQLDeleteAnnouncementsInput = {
-  ids?: InputMaybe<Array<Scalars['ID']['input']>>;
-};
+  ids?: InputMaybe<Array<Scalars['ID']['input']>>
+}
 
 export type GQLDeleteCollectionArticlesInput = {
-  articles: Array<Scalars['ID']['input']>;
-  collection: Scalars['ID']['input'];
-};
+  articles: Array<Scalars['ID']['input']>
+  collection: Scalars['ID']['input']
+}
 
 export type GQLDeleteCollectionsInput = {
-  ids: Array<Scalars['ID']['input']>;
-};
+  ids: Array<Scalars['ID']['input']>
+}
 
 export type GQLDeleteCommentInput = {
-  id: Scalars['ID']['input'];
-};
+  id: Scalars['ID']['input']
+}
 
 export type GQLDeleteCurationChannelArticlesInput = {
-  articles: Array<Scalars['ID']['input']>;
-  channel: Scalars['ID']['input'];
-};
+  articles: Array<Scalars['ID']['input']>
+  channel: Scalars['ID']['input']
+}
 
 export type GQLDeleteDraftInput = {
-  id: Scalars['ID']['input'];
-};
+  id: Scalars['ID']['input']
+}
 
 export type GQLDeleteMomentInput = {
-  id: Scalars['ID']['input'];
-};
+  id: Scalars['ID']['input']
+}
 
 export type GQLDeleteQuoteInput = {
-  id: Scalars['ID']['input'];
-};
+  id: Scalars['ID']['input']
+}
 
 export type GQLDeleteTagsInput = {
-  ids: Array<Scalars['ID']['input']>;
-};
+  ids: Array<Scalars['ID']['input']>
+}
 
 export type GQLDirectImageUploadInput = {
-  draft?: InputMaybe<Scalars['Boolean']['input']>;
-  entityId?: InputMaybe<Scalars['ID']['input']>;
-  entityType: GQLEntityType;
-  mime?: InputMaybe<Scalars['String']['input']>;
-  type: GQLAssetType;
-  url?: InputMaybe<Scalars['String']['input']>;
-};
+  draft?: InputMaybe<Scalars['Boolean']['input']>
+  entityId?: InputMaybe<Scalars['ID']['input']>
+  entityType: GQLEntityType
+  mime?: InputMaybe<Scalars['String']['input']>
+  type: GQLAssetType
+  url?: InputMaybe<Scalars['String']['input']>
+}
 
 export type GQLDismissSpamRingInput = {
-  id: Scalars['ID']['input'];
-  note?: InputMaybe<Scalars['String']['input']>;
-};
+  id: Scalars['ID']['input']
+  note?: InputMaybe<Scalars['String']['input']>
+}
 
-export type GQLDonator = GQLCryptoWallet | GQLUser;
+export type GQLDonator = GQLCryptoWallet | GQLUser
 
 /** This type contains content, collections, assets and related data of a draft. */
 export type GQLDraft = GQLNode & {
-  __typename?: 'Draft';
+  __typename?: 'Draft'
   /** Access related fields on circle */
-  access: GQLDraftAccess;
+  access: GQLDraftAccess
   /** Published article */
-  article?: Maybe<GQLArticle>;
+  article?: Maybe<GQLArticle>
   /** List of assets are belonged to this draft. */
-  assets: Array<GQLAsset>;
+  assets: Array<GQLAsset>
   /** Associated campaigns */
-  campaigns: Array<GQLArticleCampaign>;
+  campaigns: Array<GQLArticleCampaign>
   /** Whether readers can comment */
-  canComment: Scalars['Boolean']['output'];
+  canComment: Scalars['Boolean']['output']
   /** @deprecated Use connections instead */
-  collection: GQLArticleConnection;
+  collection: GQLArticleConnection
   /** Collections of this draft. */
-  collections: GQLCollectionConnection;
+  collections: GQLCollectionConnection
   /** Connection articles of this draft. */
-  connections: GQLArticleConnection;
+  connections: GQLArticleConnection
   /** Content (HTML) of this draft. */
-  content?: Maybe<Scalars['String']['output']>;
+  content?: Maybe<Scalars['String']['output']>
   /** Draft's cover link. */
-  cover?: Maybe<Scalars['String']['output']>;
+  cover?: Maybe<Scalars['String']['output']>
   /** Time of this draft was created. */
-  createdAt: Scalars['DateTime']['output'];
+  createdAt: Scalars['DateTime']['output']
   /** Unique ID of this draft. */
-  id: Scalars['ID']['output'];
+  id: Scalars['ID']['output']
   /** Whether the first line of paragraph should be indented */
-  indentFirstLine: Scalars['Boolean']['output'];
+  indentFirstLine: Scalars['Boolean']['output']
   /** Whether publish to ISCN */
-  iscnPublish?: Maybe<Scalars['Boolean']['output']>;
+  iscnPublish?: Maybe<Scalars['Boolean']['output']>
   /** License Type */
-  license: GQLArticleLicenseType;
+  license: GQLArticleLicenseType
   /** Media hash, composed of cid encoding, of this draft. */
-  mediaHash?: Maybe<Scalars['String']['output']>;
+  mediaHash?: Maybe<Scalars['String']['output']>
   /** Scheduled publish date of the article. */
-  publishAt?: Maybe<Scalars['DateTime']['output']>;
+  publishAt?: Maybe<Scalars['DateTime']['output']>
   /** State of draft during publihsing. */
-  publishState: GQLPublishState;
+  publishState: GQLPublishState
   /** Creator message after support */
-  replyToDonator?: Maybe<Scalars['String']['output']>;
+  replyToDonator?: Maybe<Scalars['String']['output']>
   /** Creator message asking for support */
-  requestForDonation?: Maybe<Scalars['String']['output']>;
+  requestForDonation?: Maybe<Scalars['String']['output']>
   /** Whether content is marked as sensitive by author */
-  sensitiveByAuthor: Scalars['Boolean']['output'];
+  sensitiveByAuthor: Scalars['Boolean']['output']
   /** Slugified draft title. */
-  slug: Scalars['String']['output'];
+  slug: Scalars['String']['output']
   /** Summary of this draft. */
-  summary?: Maybe<Scalars['String']['output']>;
+  summary?: Maybe<Scalars['String']['output']>
   /** This value determines if the summary is customized or not. */
-  summaryCustomized: Scalars['Boolean']['output'];
+  summaryCustomized: Scalars['Boolean']['output']
   /** Tags are attached to this draft. */
-  tags?: Maybe<Array<Scalars['String']['output']>>;
+  tags?: Maybe<Array<Scalars['String']['output']>>
   /** Draft title. */
-  title?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>
   /** Last time of this draft was upadted. */
-  updatedAt: Scalars['DateTime']['output'];
+  updatedAt: Scalars['DateTime']['output']
   /** The counting number of words in this draft. */
-  wordCount: Scalars['Int']['output'];
-};
-
+  wordCount: Scalars['Int']['output']
+}
 
 /** This type contains content, collections, assets and related data of a draft. */
 export type GQLDraftCollectionArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 /** This type contains content, collections, assets and related data of a draft. */
 export type GQLDraftCollectionsArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 /** This type contains content, collections, assets and related data of a draft. */
 export type GQLDraftConnectionsArgs = {
-  input: GQLConnectionArgs;
-};
+  input: GQLConnectionArgs
+}
 
 export type GQLDraftAccess = {
-  __typename?: 'DraftAccess';
-  circle?: Maybe<GQLCircle>;
-  type: GQLArticleAccessType;
-};
+  __typename?: 'DraftAccess'
+  circle?: Maybe<GQLCircle>
+  type: GQLArticleAccessType
+}
 
 export type GQLDraftConnection = GQLConnection & {
-  __typename?: 'DraftConnection';
-  edges?: Maybe<Array<GQLDraftEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'DraftConnection'
+  edges?: Maybe<Array<GQLDraftEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLDraftEdge = {
-  __typename?: 'DraftEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLDraft;
-};
+  __typename?: 'DraftEdge'
+  cursor: Scalars['String']['output']
+  node: GQLDraft
+}
 
 export type GQLEditArticleInput = {
-  accessType?: InputMaybe<GQLArticleAccessType>;
+  accessType?: InputMaybe<GQLArticleAccessType>
   /** which campaigns to attach */
-  campaigns?: InputMaybe<Array<GQLArticleCampaignInput>>;
+  campaigns?: InputMaybe<Array<GQLArticleCampaignInput>>
   /** whether readers can comment */
-  canComment?: InputMaybe<Scalars['Boolean']['input']>;
-  circle?: InputMaybe<Scalars['ID']['input']>;
+  canComment?: InputMaybe<Scalars['Boolean']['input']>
+  circle?: InputMaybe<Scalars['ID']['input']>
   /** Deprecated, use connections instead */
-  collection?: InputMaybe<Array<Scalars['ID']['input']>>;
-  collections?: InputMaybe<Array<Scalars['ID']['input']>>;
-  connections?: InputMaybe<Array<Scalars['ID']['input']>>;
-  content?: InputMaybe<Scalars['String']['input']>;
-  cover?: InputMaybe<Scalars['ID']['input']>;
+  collection?: InputMaybe<Array<Scalars['ID']['input']>>
+  collections?: InputMaybe<Array<Scalars['ID']['input']>>
+  connections?: InputMaybe<Array<Scalars['ID']['input']>>
+  content?: InputMaybe<Scalars['String']['input']>
+  cover?: InputMaybe<Scalars['ID']['input']>
   /** revision description */
-  description?: InputMaybe<Scalars['String']['input']>;
-  id: Scalars['ID']['input'];
-  indentFirstLine?: InputMaybe<Scalars['Boolean']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>
+  id: Scalars['ID']['input']
+  indentFirstLine?: InputMaybe<Scalars['Boolean']['input']>
   /** whether publish to ISCN */
-  iscnPublish?: InputMaybe<Scalars['Boolean']['input']>;
-  license?: InputMaybe<GQLArticleLicenseType>;
-  pinned?: InputMaybe<Scalars['Boolean']['input']>;
-  replyToDonator?: InputMaybe<Scalars['String']['input']>;
-  requestForDonation?: InputMaybe<Scalars['String']['input']>;
-  sensitive?: InputMaybe<Scalars['Boolean']['input']>;
-  state?: InputMaybe<GQLArticleState>;
-  summary?: InputMaybe<Scalars['String']['input']>;
-  tags?: InputMaybe<Array<Scalars['String']['input']>>;
-  title?: InputMaybe<Scalars['String']['input']>;
-};
+  iscnPublish?: InputMaybe<Scalars['Boolean']['input']>
+  license?: InputMaybe<GQLArticleLicenseType>
+  pinned?: InputMaybe<Scalars['Boolean']['input']>
+  replyToDonator?: InputMaybe<Scalars['String']['input']>
+  requestForDonation?: InputMaybe<Scalars['String']['input']>
+  sensitive?: InputMaybe<Scalars['Boolean']['input']>
+  state?: InputMaybe<GQLArticleState>
+  summary?: InputMaybe<Scalars['String']['input']>
+  tags?: InputMaybe<Array<Scalars['String']['input']>>
+  title?: InputMaybe<Scalars['String']['input']>
+}
 
 export type GQLEmailLoginInput = {
-  email: Scalars['String']['input'];
+  email: Scalars['String']['input']
   /** used in register */
-  language?: InputMaybe<GQLUserLanguage>;
-  passwordOrCode: Scalars['String']['input'];
-  referralCode?: InputMaybe<Scalars['String']['input']>;
-};
+  language?: InputMaybe<GQLUserLanguage>
+  passwordOrCode: Scalars['String']['input']
+  referralCode?: InputMaybe<Scalars['String']['input']>
+}
 
 export type GQLEntityType =
   | 'announcement'
@@ -1905,34 +1862,30 @@ export type GQLEntityType =
   | 'draft'
   | 'moment'
   | 'tag'
-  | 'user';
+  | 'user'
 
 export type GQLExchangeRate = {
-  __typename?: 'ExchangeRate';
-  from: GQLTransactionCurrency;
-  rate: Scalars['Float']['output'];
-  to: GQLQuoteCurrency;
+  __typename?: 'ExchangeRate'
+  from: GQLTransactionCurrency
+  rate: Scalars['Float']['output']
+  to: GQLQuoteCurrency
   /** Last updated time from currency convertor APIs */
-  updatedAt: Scalars['DateTime']['output'];
-};
+  updatedAt: Scalars['DateTime']['output']
+}
 
 export type GQLExchangeRatesInput = {
-  from?: InputMaybe<GQLTransactionCurrency>;
-  to?: InputMaybe<GQLQuoteCurrency>;
-};
+  from?: InputMaybe<GQLTransactionCurrency>
+  to?: InputMaybe<GQLQuoteCurrency>
+}
 
 export type GQLFeature = {
-  __typename?: 'Feature';
-  enabled: Scalars['Boolean']['output'];
-  name: GQLFeatureName;
-  value?: Maybe<Scalars['Float']['output']>;
-};
+  __typename?: 'Feature'
+  enabled: Scalars['Boolean']['output']
+  name: GQLFeatureName
+  value?: Maybe<Scalars['Float']['output']>
+}
 
-export type GQLFeatureFlag =
-  | 'admin'
-  | 'off'
-  | 'on'
-  | 'seeding';
+export type GQLFeatureFlag = 'admin' | 'off' | 'on' | 'seeding'
 
 export type GQLFeatureName =
   | 'add_credit'
@@ -1945,1335 +1898,1262 @@ export type GQLFeatureName =
   | 'payout'
   | 'spam_detection'
   | 'tag_adoption'
-  | 'verify_appreciate';
+  | 'verify_appreciate'
 
 export type GQLFeaturedCommentsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  sort?: InputMaybe<GQLCommentSort>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  sort?: InputMaybe<GQLCommentSort>
+}
 
 export type GQLFeaturedTagsInput = {
   /**  tagIds  */
-  ids: Array<Scalars['ID']['input']>;
-};
+  ids: Array<Scalars['ID']['input']>
+}
 
 export type GQLFederationArticleSettingState =
   | 'disabled'
   | 'enabled'
-  | 'inherit';
+  | 'inherit'
 
-export type GQLFederationAuthorSettingState =
-  | 'disabled'
-  | 'enabled';
+export type GQLFederationAuthorSettingState = 'disabled' | 'enabled'
 
 export type GQLFederationExportDecisionReason =
   | 'article_disabled'
   | 'article_not_public'
   | 'author_not_opted_in'
-  | 'eligible';
+  | 'eligible'
 
 export type GQLFilterInput = {
-  inRangeEnd?: InputMaybe<Scalars['DateTime']['input']>;
-  inRangeStart?: InputMaybe<Scalars['DateTime']['input']>;
+  inRangeEnd?: InputMaybe<Scalars['DateTime']['input']>
+  inRangeStart?: InputMaybe<Scalars['DateTime']['input']>
   /** Used in User Articles filter, by tags or by time range, or both */
-  tagIds?: InputMaybe<Array<Scalars['ID']['input']>>;
-};
+  tagIds?: InputMaybe<Array<Scalars['ID']['input']>>
+}
 
 export type GQLFollowing = {
-  __typename?: 'Following';
-  circles: GQLCircleConnection;
-  users: GQLUserConnection;
-};
-
+  __typename?: 'Following'
+  circles: GQLCircleConnection
+  users: GQLUserConnection
+}
 
 export type GQLFollowingCirclesArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLFollowingUsersArgs = {
-  input: GQLConnectionArgs;
-};
+  input: GQLConnectionArgs
+}
 
-export type GQLFollowingActivity = GQLArticleRecommendationActivity | GQLCircleRecommendationActivity | GQLUserAddArticleTagActivity | GQLUserBroadcastCircleActivity | GQLUserCreateCircleActivity | GQLUserPostMomentActivity | GQLUserPublishArticleActivity | GQLUserRecommendationActivity;
+export type GQLFollowingActivity =
+  | GQLArticleRecommendationActivity
+  | GQLCircleRecommendationActivity
+  | GQLUserAddArticleTagActivity
+  | GQLUserBroadcastCircleActivity
+  | GQLUserCreateCircleActivity
+  | GQLUserPostMomentActivity
+  | GQLUserPublishArticleActivity
+  | GQLUserRecommendationActivity
 
 export type GQLFollowingActivityConnection = GQLConnection & {
-  __typename?: 'FollowingActivityConnection';
-  edges?: Maybe<Array<GQLFollowingActivityEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'FollowingActivityConnection'
+  edges?: Maybe<Array<GQLFollowingActivityEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLFollowingActivityEdge = {
-  __typename?: 'FollowingActivityEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLFollowingActivity;
-};
+  __typename?: 'FollowingActivityEdge'
+  cursor: Scalars['String']['output']
+  node: GQLFollowingActivity
+}
 
 export type GQLFreezeSpamRingInput = {
-  id: Scalars['ID']['input'];
-  remark?: InputMaybe<Scalars['String']['input']>;
-};
+  id: Scalars['ID']['input']
+  remark?: InputMaybe<Scalars['String']['input']>
+}
 
 export type GQLFreezeSpamRingResult = {
-  __typename?: 'FreezeSpamRingResult';
-  frozen: Array<GQLUser>;
-  ring: GQLSpamRing;
+  __typename?: 'FreezeSpamRingResult'
+  frozen: Array<GQLUser>
+  ring: GQLSpamRing
   /** Members not banned (old account, high karma, already banned, archived…) — for manual review. */
-  skipped: Array<GQLSpamRingSkip>;
-};
+  skipped: Array<GQLSpamRingSkip>
+}
 
 export type GQLFrequentSearchInput = {
-  first?: InputMaybe<Scalars['Int']['input']>;
-  key?: InputMaybe<Scalars['String']['input']>;
-};
+  first?: InputMaybe<Scalars['Int']['input']>
+  key?: InputMaybe<Scalars['String']['input']>
+}
 
 export type GQLGenerateSigningMessageInput = {
-  address: Scalars['String']['input'];
-  purpose?: InputMaybe<GQLSigningMessagePurpose>;
-};
+  address: Scalars['String']['input']
+  purpose?: InputMaybe<GQLSigningMessagePurpose>
+}
 
-export type GQLGrantType =
-  | 'authorization_code'
-  | 'refresh_token';
+export type GQLGrantType = 'authorization_code' | 'refresh_token'
 
 export type GQLIcymiTopic = GQLNode & {
-  __typename?: 'IcymiTopic';
-  archivedAt?: Maybe<Scalars['DateTime']['output']>;
-  articles: Array<GQLArticle>;
-  id: Scalars['ID']['output'];
-  note?: Maybe<Scalars['String']['output']>;
-  pinAmount: Scalars['Int']['output'];
-  publishedAt?: Maybe<Scalars['DateTime']['output']>;
-  state: GQLIcymiTopicState;
-  title: Scalars['String']['output'];
-};
-
+  __typename?: 'IcymiTopic'
+  archivedAt?: Maybe<Scalars['DateTime']['output']>
+  articles: Array<GQLArticle>
+  id: Scalars['ID']['output']
+  note?: Maybe<Scalars['String']['output']>
+  pinAmount: Scalars['Int']['output']
+  publishedAt?: Maybe<Scalars['DateTime']['output']>
+  state: GQLIcymiTopicState
+  title: Scalars['String']['output']
+}
 
 export type GQLIcymiTopicNoteArgs = {
-  input?: InputMaybe<GQLTranslationArgs>;
-};
-
+  input?: InputMaybe<GQLTranslationArgs>
+}
 
 export type GQLIcymiTopicTitleArgs = {
-  input?: InputMaybe<GQLTranslationArgs>;
-};
+  input?: InputMaybe<GQLTranslationArgs>
+}
 
 export type GQLIcymiTopicConnection = GQLConnection & {
-  __typename?: 'IcymiTopicConnection';
-  edges: Array<GQLIcymiTopicEdge>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'IcymiTopicConnection'
+  edges: Array<GQLIcymiTopicEdge>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLIcymiTopicEdge = {
-  __typename?: 'IcymiTopicEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLIcymiTopic;
-};
+  __typename?: 'IcymiTopicEdge'
+  cursor: Scalars['String']['output']
+  node: GQLIcymiTopic
+}
 
-export type GQLIcymiTopicState =
-  | 'archived'
-  | 'editing'
-  | 'published';
+export type GQLIcymiTopicState = 'archived' | 'editing' | 'published'
 
 export type GQLIdentityInput = {
-  id?: InputMaybe<Scalars['ID']['input']>;
-  shortHash?: InputMaybe<Scalars['String']['input']>;
-};
+  id?: InputMaybe<Scalars['ID']['input']>
+  shortHash?: InputMaybe<Scalars['String']['input']>
+}
 
 export type GQLInvitation = {
-  __typename?: 'Invitation';
+  __typename?: 'Invitation'
   /** Accepted time. */
-  acceptedAt?: Maybe<Scalars['DateTime']['output']>;
+  acceptedAt?: Maybe<Scalars['DateTime']['output']>
   /** Invitation of current Circle. */
-  circle: GQLCircle;
+  circle: GQLCircle
   /** Created time. */
-  createdAt: Scalars['DateTime']['output'];
+  createdAt: Scalars['DateTime']['output']
   /** Free period of this invitation. */
-  freePeriod: Scalars['Int']['output'];
+  freePeriod: Scalars['Int']['output']
   /** Unique ID. */
-  id: Scalars['ID']['output'];
+  id: Scalars['ID']['output']
   /** Target person of this invitation. */
-  invitee: GQLInvitee;
+  invitee: GQLInvitee
   /** Creator of this invitation. */
-  inviter: GQLUser;
+  inviter: GQLUser
   /** Sent time. */
-  sentAt: Scalars['DateTime']['output'];
+  sentAt: Scalars['DateTime']['output']
   /** Determine it's specific state. */
-  state: GQLInvitationState;
-};
+  state: GQLInvitationState
+}
 
 export type GQLInvitationConnection = GQLConnection & {
-  __typename?: 'InvitationConnection';
-  edges?: Maybe<Array<GQLInvitationEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'InvitationConnection'
+  edges?: Maybe<Array<GQLInvitationEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLInvitationEdge = {
-  __typename?: 'InvitationEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLInvitation;
-};
+  __typename?: 'InvitationEdge'
+  cursor: Scalars['String']['output']
+  node: GQLInvitation
+}
 
 export type GQLInvitationState =
   | 'accepted'
   | 'pending'
   | 'transfer_failed'
-  | 'transfer_succeeded';
+  | 'transfer_succeeded'
 
 export type GQLInviteCircleInput = {
-  circleId: Scalars['ID']['input'];
-  freePeriod: Scalars['Int']['input'];
-  invitees: Array<GQLInviteCircleInvitee>;
-};
+  circleId: Scalars['ID']['input']
+  freePeriod: Scalars['Int']['input']
+  invitees: Array<GQLInviteCircleInvitee>
+}
 
 export type GQLInviteCircleInvitee = {
-  email?: InputMaybe<Scalars['String']['input']>;
-  id?: InputMaybe<Scalars['ID']['input']>;
-};
+  email?: InputMaybe<Scalars['String']['input']>
+  id?: InputMaybe<Scalars['ID']['input']>
+}
 
-export type GQLInvitee = GQLPerson | GQLUser;
+export type GQLInvitee = GQLPerson | GQLUser
 
 export type GQLInvites = {
-  __typename?: 'Invites';
+  __typename?: 'Invites'
   /** Accepted invitation list */
-  accepted: GQLInvitationConnection;
+  accepted: GQLInvitationConnection
   /** Pending invitation list */
-  pending: GQLInvitationConnection;
-};
-
+  pending: GQLInvitationConnection
+}
 
 export type GQLInvitesAcceptedArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLInvitesPendingArgs = {
-  input: GQLConnectionArgs;
-};
+  input: GQLConnectionArgs
+}
 
 export type GQLKeywordInput = {
-  keyword: Scalars['String']['input'];
-};
+  keyword: Scalars['String']['input']
+}
 
 export type GQLKeywordsInput = {
-  keywords?: InputMaybe<Array<Scalars['String']['input']>>;
-};
+  keywords?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type GQLLikeCollectionInput = {
-  id: Scalars['ID']['input'];
-};
+  id: Scalars['ID']['input']
+}
 
 export type GQLLikeMomentInput = {
-  id: Scalars['ID']['input'];
-};
+  id: Scalars['ID']['input']
+}
 
 export type GQLLiker = {
-  __typename?: 'Liker';
+  __typename?: 'Liker'
   /** Whether liker is a civic liker */
-  civicLiker: Scalars['Boolean']['output'];
+  civicLiker: Scalars['Boolean']['output']
   /** Liker ID of LikeCoin */
-  likerId?: Maybe<Scalars['String']['output']>;
+  likerId?: Maybe<Scalars['String']['output']>
   /** Total LIKE left in wallet. */
-  total: Scalars['Float']['output'];
-};
+  total: Scalars['Float']['output']
+}
 
 export type GQLLogRecordInput = {
-  type: GQLLogRecordTypes;
-};
+  type: GQLLogRecordTypes
+}
 
 export type GQLLogRecordTypes =
   | 'ReadFolloweeArticles'
   | 'ReadFollowingFeed'
-  | 'ReadResponseInfoPopUp';
+  | 'ReadResponseInfoPopUp'
 
 export type GQLMember = {
-  __typename?: 'Member';
+  __typename?: 'Member'
   /** Price chosen by user when joining a Circle. */
-  price: GQLPrice;
+  price: GQLPrice
   /** User who join to a Circle. */
-  user: GQLUser;
-};
+  user: GQLUser
+}
 
 export type GQLMemberConnection = GQLConnection & {
-  __typename?: 'MemberConnection';
-  edges?: Maybe<Array<GQLMemberEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'MemberConnection'
+  edges?: Maybe<Array<GQLMemberEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLMemberEdge = {
-  __typename?: 'MemberEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLMember;
-};
+  __typename?: 'MemberEdge'
+  cursor: Scalars['String']['output']
+  node: GQLMember
+}
 
 export type GQLMergeTagsInput = {
-  content: Scalars['String']['input'];
-  ids: Array<Scalars['ID']['input']>;
-};
+  content: Scalars['String']['input']
+  ids: Array<Scalars['ID']['input']>
+}
 
 export type GQLMigrationInput = {
-  files: Array<InputMaybe<Scalars['Upload']['input']>>;
-  type?: InputMaybe<GQLMigrationType>;
-};
+  files: Array<InputMaybe<Scalars['Upload']['input']>>
+  type?: InputMaybe<GQLMigrationType>
+}
 
-export type GQLMigrationType =
-  | 'medium';
+export type GQLMigrationType = 'medium'
+
+export type GQLModerationAutomationRole =
+  | 'assisted'
+  | 'automated'
+  | 'none'
+  | 'suggested'
+
+export type GQLModerationCase = {
+  __typename?: 'ModerationCase'
+  automationRole: GQLModerationAutomationRole
+  closedAt?: Maybe<Scalars['DateTime']['output']>
+  createdAt: Scalars['DateTime']['output']
+  id: Scalars['ID']['output']
+  noticeState: GQLModerationNoticeState
+  outcome?: Maybe<GQLModerationCaseOutcome>
+  publicReason?: Maybe<Scalars['String']['output']>
+  reason: Scalars['String']['output']
+  resolvedAt?: Maybe<Scalars['DateTime']['output']>
+  source: GQLModerationCaseSource
+  status: GQLModerationCaseStatus
+  targetType: GQLModerationTargetType
+}
+
+export type GQLModerationCaseOutcome =
+  | 'account_limited'
+  | 'content_collapsed'
+  | 'content_hidden'
+  | 'content_removed'
+  | 'no_action'
+  | 'partially_restored'
+  | 'restored'
+  | 'upheld'
+
+export type GQLModerationCaseSource =
+  | 'admin'
+  | 'automated'
+  | 'community_watch'
+  | 'direct_report'
+  | 'model_assisted'
+  | 'system'
+
+export type GQLModerationCaseStatus =
+  | 'action_taken'
+  | 'appealed'
+  | 'closed'
+  | 'received'
+  | 'rejected'
+  | 'resolved'
+  | 'reviewing'
+
+export type GQLModerationNoticeState =
+  | 'delayed'
+  | 'failed'
+  | 'not_required'
+  | 'pending'
+  | 'prohibited'
+  | 'sent'
+
+export type GQLModerationTargetType =
+  | 'article'
+  | 'comment'
+  | 'moment'
+  | 'other'
+  | 'tag'
+  | 'user'
 
 export type GQLMoment = GQLNode & {
-  __typename?: 'Moment';
-  adStatus: GQLAdStatus;
-  articles: Array<GQLArticle>;
-  assets: Array<GQLAsset>;
-  author: GQLUser;
-  commentCount: Scalars['Int']['output'];
-  commentedFollowees: Array<GQLUser>;
-  comments: GQLCommentConnection;
-  content?: Maybe<Scalars['String']['output']>;
-  createdAt: Scalars['DateTime']['output'];
-  id: Scalars['ID']['output'];
-  likeCount: Scalars['Int']['output'];
+  __typename?: 'Moment'
+  adStatus: GQLAdStatus
+  articles: Array<GQLArticle>
+  assets: Array<GQLAsset>
+  author: GQLUser
+  commentCount: Scalars['Int']['output']
+  commentedFollowees: Array<GQLUser>
+  comments: GQLCommentConnection
+  content?: Maybe<Scalars['String']['output']>
+  createdAt: Scalars['DateTime']['output']
+  id: Scalars['ID']['output']
+  likeCount: Scalars['Int']['output']
   /** whether current user has liked it */
-  liked: Scalars['Boolean']['output'];
-  shortHash: Scalars['String']['output'];
-  spamStatus: GQLSpamStatus;
-  state: GQLMomentState;
-  tags: Array<Maybe<GQLTag>>;
-};
-
+  liked: Scalars['Boolean']['output']
+  shortHash: Scalars['String']['output']
+  spamStatus: GQLSpamStatus
+  state: GQLMomentState
+  tags: Array<Maybe<GQLTag>>
+}
 
 export type GQLMomentCommentsArgs = {
-  input: GQLCommentsInput;
-};
+  input: GQLCommentsInput
+}
 
 export type GQLMomentConnection = GQLConnection & {
-  __typename?: 'MomentConnection';
-  edges?: Maybe<Array<GQLMomentEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'MomentConnection'
+  edges?: Maybe<Array<GQLMomentEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLMomentEdge = {
-  __typename?: 'MomentEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLMoment;
-};
+  __typename?: 'MomentEdge'
+  cursor: Scalars['String']['output']
+  node: GQLMoment
+}
 
 export type GQLMomentFeedApplication = {
-  __typename?: 'MomentFeedApplication';
-  createdAt: Scalars['DateTime']['output'];
-  reviewedBy?: Maybe<GQLMomentFeedUserReviewedBy>;
-  reviewer?: Maybe<GQLUser>;
-  state: GQLMomentFeedUserState;
-  updatedAt: Scalars['DateTime']['output'];
-};
+  __typename?: 'MomentFeedApplication'
+  createdAt: Scalars['DateTime']['output']
+  reviewedBy?: Maybe<GQLMomentFeedUserReviewedBy>
+  reviewer?: Maybe<GQLUser>
+  state: GQLMomentFeedUserState
+  updatedAt: Scalars['DateTime']['output']
+}
 
-export type GQLMomentFeedUserReviewedBy =
-  | 'admin'
-  | 'seed'
-  | 'system';
+export type GQLMomentFeedUserReviewedBy = 'admin' | 'seed' | 'system'
 
 export type GQLMomentFeedUserState =
   | 'approved'
   | 'pending'
   | 'rejected'
-  | 'revoked';
+  | 'revoked'
 
 export type GQLMomentFeedUsersInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  states?: InputMaybe<Array<GQLMomentFeedUserState>>;
-  userName?: InputMaybe<Scalars['String']['input']>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  states?: InputMaybe<Array<GQLMomentFeedUserState>>
+  userName?: InputMaybe<Scalars['String']['input']>
+}
 
 export type GQLMomentInput = {
-  shortHash: Scalars['String']['input'];
-};
+  shortHash: Scalars['String']['input']
+}
 
 export type GQLMomentNotice = GQLNotice & {
-  __typename?: 'MomentNotice';
+  __typename?: 'MomentNotice'
   /** List of notice actors. */
-  actors?: Maybe<Array<GQLUser>>;
+  actors?: Maybe<Array<GQLUser>>
   /** Time of this notice was created. */
-  createdAt: Scalars['DateTime']['output'];
+  createdAt: Scalars['DateTime']['output']
   /** Unique ID of this notice. */
-  id: Scalars['ID']['output'];
-  target: GQLMoment;
-  type: GQLMomentNoticeType;
+  id: Scalars['ID']['output']
+  target: GQLMoment
+  type: GQLMomentNoticeType
   /** The value determines if the notice is unread or not. */
-  unread: Scalars['Boolean']['output'];
-};
+  unread: Scalars['Boolean']['output']
+}
 
-export type GQLMomentNoticeType =
-  | 'MomentLiked'
-  | 'MomentMentionedYou';
+export type GQLMomentNoticeType = 'MomentLiked' | 'MomentMentionedYou'
 
-export type GQLMomentState =
-  | 'active'
-  | 'archived';
+export type GQLMomentState = 'active' | 'archived'
 
 export type GQLMonthlyDatum = {
-  __typename?: 'MonthlyDatum';
-  date: Scalars['DateTime']['output'];
-  value: Scalars['Float']['output'];
-};
+  __typename?: 'MonthlyDatum'
+  date: Scalars['DateTime']['output']
+  value: Scalars['Float']['output']
+}
 
 export type GQLMutation = {
-  __typename?: 'Mutation';
+  __typename?: 'Mutation'
   /** Add blocked search keyword to blocked_search_word db */
-  addBlockedSearchKeyword: GQLBlockedSearchKeyword;
+  addBlockedSearchKeyword: GQLBlockedSearchKeyword
   /** Add articles to the begining of the collections. */
-  addCollectionsArticles: Array<GQLCollection>;
+  addCollectionsArticles: Array<GQLCollection>
   /** Add Credit to User Wallet */
-  addCredit: GQLAddCreditResult;
-  addCurationChannelArticles: GQLCurationChannel;
+  addCredit: GQLAddCreditResult
+  addCurationChannelArticles: GQLCurationChannel
   /** Add a social login to current user. */
-  addSocialLogin: GQLUser;
+  addSocialLogin: GQLUser
   /** Add a wallet login to current user. */
-  addWalletLogin: GQLUser;
-  applyCampaign: GQLCampaign;
-  applyMomentFeed: GQLUser;
+  addWalletLogin: GQLUser
+  applyCampaign: GQLCampaign
+  applyMomentFeed: GQLUser
   /** Appreciate an article. */
-  appreciateArticle: GQLArticle;
+  appreciateArticle: GQLArticle
   /** Archive multiple users from OSS with per-user results. */
-  archiveUsers: GQLArchiveUsersResult;
-  banCampaignArticles: GQLCampaign;
+  archiveUsers: GQLArchiveUsersResult
+  banCampaignArticles: GQLCampaign
   /** Let Traveloggers owner claims a Logbook, returns transaction hash */
-  claimLogbooks: GQLClaimLogbooksResult;
+  claimLogbooks: GQLClaimLogbooksResult
   /** Claim the carbon based badge with a verified zkID personhood proof. */
-  claimPersonhoodBadge: GQLUser;
-  classifyArticlesChannels: Scalars['Boolean']['output'];
+  claimPersonhoodBadge: GQLUser
+  classifyArticlesChannels: Scalars['Boolean']['output']
   /** Clear stored original content for a Community Watch action as staff. */
-  clearCommunityWatchOriginalContent: GQLCommunityWatchAction;
+  clearCommunityWatchOriginalContent: GQLCommunityWatchAction
   /** Clear read history for user. */
-  clearReadHistory: GQLUser;
+  clearReadHistory: GQLUser
   /** Clear search history for user. */
-  clearSearchHistory?: Maybe<Scalars['Boolean']['output']>;
+  clearSearchHistory?: Maybe<Scalars['Boolean']['output']>
   /** Remove a spam comment as a Community Watch member. */
-  communityWatchRemoveComment: GQLComment;
+  communityWatchRemoveComment: GQLComment
   /** Confirm verification code from email. */
-  confirmVerificationCode: Scalars['ID']['output'];
+  confirmVerificationCode: Scalars['ID']['output']
   /** Create Stripe Connect account for Payout */
-  connectStripeAccount: GQLConnectStripeAccountResult;
+  connectStripeAccount: GQLConnectStripeAccountResult
   /** Create a short-lived token that binds a verifier challenge to the current viewer. */
-  createPersonhoodHandoff: GQLPersonhoodHandoff;
-  deleteAnnouncements: Scalars['Boolean']['output'];
+  createPersonhoodHandoff: GQLPersonhoodHandoff
+  deleteAnnouncements: Scalars['Boolean']['output']
   /** Delete blocked search keywords from search_history db */
-  deleteBlockedSearchKeywords?: Maybe<Scalars['Boolean']['output']>;
+  deleteBlockedSearchKeywords?: Maybe<Scalars['Boolean']['output']>
   /** Remove articles from the collection. */
-  deleteCollectionArticles: GQLCollection;
-  deleteCollections: Scalars['Boolean']['output'];
+  deleteCollectionArticles: GQLCollection
+  deleteCollections: Scalars['Boolean']['output']
   /** Remove a comment. */
-  deleteComment: GQLComment;
-  deleteCurationChannelArticles: GQLCurationChannel;
+  deleteComment: GQLComment
+  deleteCurationChannelArticles: GQLCurationChannel
   /** Remove a draft. */
-  deleteDraft?: Maybe<Scalars['Boolean']['output']>;
-  deleteMoment: GQLMoment;
+  deleteDraft?: Maybe<Scalars['Boolean']['output']>
+  deleteMoment: GQLMoment
   /** Retract a quote from the wall (poster, source article author, or admin). */
-  deleteQuote: Scalars['Boolean']['output'];
-  deleteTags?: Maybe<Scalars['Boolean']['output']>;
-  directImageUpload: GQLAsset;
+  deleteQuote: Scalars['Boolean']['output']
+  deleteTags?: Maybe<Scalars['Boolean']['output']>
+  directImageUpload: GQLAsset
   /** Mark a spam ring as a false positive (feeds training as ham). OSS. */
-  dismissSpamRing: GQLSpamRing;
+  dismissSpamRing: GQLSpamRing
   /** Edit an article. */
-  editArticle: GQLArticle;
+  editArticle: GQLArticle
   /** Login user. */
-  emailLogin: GQLAuthResult;
+  emailLogin: GQLAuthResult
   /** Freeze a spam ring: permanently (but reversibly) ban all member accounts. OSS. */
-  freezeSpamRing: GQLFreezeSpamRingResult;
+  freezeSpamRing: GQLFreezeSpamRingResult
   /** Get signing message. */
-  generateSigningMessage: GQLSigningMessageResult;
+  generateSigningMessage: GQLSigningMessageResult
   /** Invite others to join circle */
-  invite?: Maybe<Array<GQLInvitation>>;
-  likeCollection: GQLCollection;
-  likeMoment: GQLMoment;
+  invite?: Maybe<Array<GQLInvitation>>
+  likeCollection: GQLCollection
+  likeMoment: GQLMoment
   /** Add specific user behavior record. */
-  logRecord?: Maybe<Scalars['Boolean']['output']>;
+  logRecord?: Maybe<Scalars['Boolean']['output']>
   /** Mark all received notices as read. */
-  markAllNoticesAsRead?: Maybe<Scalars['Boolean']['output']>;
-  mergeTags: GQLTag;
+  markAllNoticesAsRead?: Maybe<Scalars['Boolean']['output']>
+  mergeTags: GQLTag
   /** Migrate articles from other service provider. */
-  migration?: Maybe<Scalars['Boolean']['output']>;
+  migration?: Maybe<Scalars['Boolean']['output']>
   /** Pay to another user or article */
-  payTo: GQLPayToResult;
+  payTo: GQLPayToResult
   /** Payout to user */
-  payout: GQLTransaction;
+  payout: GQLTransaction
   /** Pin a comment. */
-  pinComment: GQLComment;
+  pinComment: GQLComment
   /** Publish an article onto IPFS. */
-  publishArticle: GQLDraft;
-  putAnnouncement: GQLAnnouncement;
-  putArticleFederationSetting: GQLArticleFederationSetting;
+  publishArticle: GQLDraft
+  putAnnouncement: GQLAnnouncement
+  putArticleFederationSetting: GQLArticleFederationSetting
   /** Create or update a Circle. */
-  putCircle: GQLCircle;
+  putCircle: GQLCircle
   /**
    * Add or remove Circle's articles
    * @deprecated No longer in use
    */
-  putCircleArticles: GQLCircle;
-  putCollection: GQLCollection;
+  putCircleArticles: GQLCircle
+  putCollection: GQLCollection
   /** Publish or update a comment. */
-  putComment: GQLComment;
-  putCurationChannel: GQLCurationChannel;
+  putComment: GQLComment
+  putCurationChannel: GQLCurationChannel
   /** Create or update a draft. */
-  putDraft: GQLDraft;
+  putDraft: GQLDraft
   /** update tags for showing on profile page */
-  putFeaturedTags?: Maybe<Array<GQLTag>>;
-  putIcymiTopic?: Maybe<GQLIcymiTopic>;
-  putMoment: GQLMoment;
+  putFeaturedTags?: Maybe<Array<GQLTag>>
+  putIcymiTopic?: Maybe<GQLIcymiTopic>
+  putMoment: GQLMoment
   /** Create or Update an OAuth Client, used in OSS. */
-  putOAuthClient?: Maybe<GQLOAuthClient>;
+  putOAuthClient?: Maybe<GQLOAuthClient>
   /** Post a quote (selected from an article) onto the campaign quote wall. */
-  putQuote: GQLQuote;
-  putRemark?: Maybe<Scalars['String']['output']>;
-  putRestrictedUsers: Array<GQLUser>;
-  putSkippedListItem?: Maybe<Array<GQLSkippedListItem>>;
-  putTagChannel: GQLTag;
-  putTopicChannel: GQLTopicChannel;
-  putUserFeatureFlags: Array<GQLUser>;
-  putUserFederationSetting: GQLUserFederationSetting;
-  putWritingChallenge: GQLWritingChallenge;
+  putQuote: GQLQuote
+  putRemark?: Maybe<Scalars['String']['output']>
+  putRestrictedUsers: Array<GQLUser>
+  putSkippedListItem?: Maybe<Array<GQLSkippedListItem>>
+  putTagChannel: GQLTag
+  putTopicChannel: GQLTopicChannel
+  putUserFeatureFlags: Array<GQLUser>
+  putUserFederationSetting: GQLUserFederationSetting
+  putWritingChallenge: GQLWritingChallenge
   /** Read an article. */
-  readArticle: GQLArticle;
+  readArticle: GQLArticle
   /** Remove a social login from current user. */
-  removeSocialLogin: GQLUser;
+  removeSocialLogin: GQLUser
   /** Remove a wallet login from current user. */
-  removeWalletLogin: GQLUser;
-  renameTag: GQLTag;
-  reorderChannels: Scalars['Boolean']['output'];
+  removeWalletLogin: GQLUser
+  renameTag: GQLTag
+  reorderChannels: Scalars['Boolean']['output']
   /** Reorder articles in the collection. */
-  reorderCollectionArticles: GQLCollection;
+  reorderCollectionArticles: GQLCollection
   /** Reset Liker ID */
-  resetLikerId: GQLUser;
+  resetLikerId: GQLUser
   /** Reset user or payment password. */
-  resetPassword?: Maybe<Scalars['Boolean']['output']>;
+  resetPassword?: Maybe<Scalars['Boolean']['output']>
   /** Restore a comment removed by Community Watch as staff. */
-  restoreCommunityWatchComment: GQLCommunityWatchAction;
-  reviewTopicChannelFeedback: GQLTopicChannelFeedback;
-  sendCampaignAnnouncement?: Maybe<Scalars['Boolean']['output']>;
+  restoreCommunityWatchComment: GQLCommunityWatchAction
+  reviewTopicChannelFeedback: GQLTopicChannelFeedback
+  sendCampaignAnnouncement?: Maybe<Scalars['Boolean']['output']>
   /** Send verification code for email. */
-  sendVerificationCode?: Maybe<Scalars['Boolean']['output']>;
-  setAdStatus: GQLArticle;
+  sendVerificationCode?: Maybe<Scalars['Boolean']['output']>
+  setAdStatus: GQLArticle
   /** Set current author's Fediverse federation preference for an article. */
-  setArticleFederationSetting: GQLArticleFederationSetting;
-  setArticleTopicChannels: GQLArticle;
-  setBoost: GQLNode;
+  setArticleFederationSetting: GQLArticleFederationSetting
+  setArticleTopicChannels: GQLArticle
+  setBoost: GQLNode
   /** Set user currency preference. */
-  setCurrency: GQLUser;
+  setCurrency: GQLUser
   /** Set user email. */
-  setEmail: GQLUser;
-  setFeature: GQLFeature;
+  setEmail: GQLUser
+  setFeature: GQLFeature
   /** Set user email login password. */
-  setPassword: GQLUser;
-  setSpamStatus: GQLWriting;
+  setPassword: GQLUser
+  setSpamStatus: GQLWriting
   /** Set user name. */
-  setUserName: GQLUser;
+  setUserName: GQLUser
   /** Set current viewer's Fediverse federation preference. */
-  setViewerFederationSetting: GQLUserFederationSetting;
-  setWritingAdStatus: GQLWriting;
+  setViewerFederationSetting: GQLUserFederationSetting
+  setWritingAdStatus: GQLWriting
   /** Upload a single file. */
-  singleFileUpload: GQLAsset;
+  singleFileUpload: GQLAsset
   /** Login/Signup via social accounts. */
-  socialLogin: GQLAuthResult;
+  socialLogin: GQLAuthResult
   /** Submit inappropriate content report */
-  submitReport: GQLReport;
+  submitReport: GQLReport
   /** Feedback on topic channel classification */
-  submitTopicChannelFeedback: GQLTopicChannelFeedback;
+  submitTopicChannelFeedback: GQLTopicChannelFeedback
   /** Subscribe a Circle. */
-  subscribeCircle: GQLSubscribeCircleResult;
-  toggleArticleRecommend: GQLArticle;
+  subscribeCircle: GQLSubscribeCircleResult
+  toggleArticleRecommend: GQLArticle
   /** Block or Unblock a given user. */
-  toggleBlockUser: GQLUser;
-  toggleBookmarkArticle: GQLArticle;
-  toggleBookmarkTag: GQLTag;
+  toggleBlockUser: GQLUser
+  toggleBookmarkArticle: GQLArticle
+  toggleBookmarkTag: GQLTag
   /**
    * Follow or unfollow a Circle.
    * @deprecated No longer in use
    */
-  toggleFollowCircle: GQLCircle;
+  toggleFollowCircle: GQLCircle
   /**
    * Bookmark or unbookmark tag.
    * @deprecated Use toggleBookmarkTag instead
    */
-  toggleFollowTag: GQLTag;
+  toggleFollowTag: GQLTag
   /** Follow or Unfollow current user. */
-  toggleFollowUser: GQLUser;
-  togglePinChannelArticles: Array<GQLChannel>;
+  toggleFollowUser: GQLUser
+  togglePinChannelArticles: Array<GQLChannel>
   /** Pin or Unpin a comment. */
-  togglePinComment: GQLComment;
-  toggleSeedingUsers: Array<Maybe<GQLUser>>;
+  togglePinComment: GQLComment
+  toggleSeedingUsers: Array<Maybe<GQLUser>>
   /**
    * Bookmark or unbookmark article
    * @deprecated Use toggleBookmarkArticle instead
    */
-  toggleSubscribeArticle: GQLArticle;
-  toggleUsersBadge: Array<Maybe<GQLUser>>;
-  toggleWritingChallengeFeaturedArticles: GQLCampaign;
-  unbindLikerId: GQLUser;
+  toggleSubscribeArticle: GQLArticle
+  toggleUsersBadge: Array<Maybe<GQLUser>>
+  toggleWritingChallengeFeaturedArticles: GQLCampaign
+  unbindLikerId: GQLUser
   /** Reverse a spam ring freeze: unban only the members this ring banned. OSS. */
-  unfreezeSpamRing: GQLUnfreezeSpamRingResult;
-  unlikeCollection: GQLCollection;
-  unlikeMoment: GQLMoment;
+  unfreezeSpamRing: GQLUnfreezeSpamRingResult
+  unlikeCollection: GQLCollection
+  unlikeMoment: GQLMoment
   /** Unpin a comment. */
-  unpinComment: GQLComment;
+  unpinComment: GQLComment
   /** Unsubscribe a Circle. */
-  unsubscribeCircle: GQLCircle;
+  unsubscribeCircle: GQLCircle
   /** Unvote a comment. */
-  unvoteComment: GQLComment;
-  updateArticleSensitive: GQLArticle;
-  updateArticleState: GQLArticle;
-  updateCampaignApplicationState: GQLCampaign;
+  unvoteComment: GQLComment
+  updateArticleSensitive: GQLArticle
+  updateArticleState: GQLArticle
+  updateCampaignApplicationState: GQLCampaign
   /** Update a comments' state. */
-  updateCommentsState: Array<GQLComment>;
+  updateCommentsState: Array<GQLComment>
   /** Update Community Watch appeal, review, or reason as staff. */
-  updateCommunityWatchActionState: GQLCommunityWatchAction;
-  updateMomentFeedApplicationState: GQLUser;
+  updateCommunityWatchActionState: GQLCommunityWatchAction
+  updateModerationCase: GQLModerationCase
+  updateMomentFeedApplicationState: GQLUser
   /** Update user notification settings. */
-  updateNotificationSetting: GQLUser;
+  updateNotificationSetting: GQLUser
   /** Update referralCode of a user, used in OSS. */
-  updateUserExtra: GQLUser;
+  updateUserExtra: GQLUser
   /** Update user information. */
-  updateUserInfo: GQLUser;
+  updateUserInfo: GQLUser
   /** Update state of a user, used in OSS. */
-  updateUserRole: GQLUser;
+  updateUserRole: GQLUser
   /** Update state of a user, used in OSS. */
-  updateUserState?: Maybe<Array<GQLUser>>;
+  updateUserState?: Maybe<Array<GQLUser>>
   /** Upsert spam ring candidates from the detection job (admin service principal). OSS. */
-  upsertSpamRingCandidates: GQLUpsertSpamRingCandidatesResult;
+  upsertSpamRingCandidates: GQLUpsertSpamRingCandidatesResult
   /** Logout user. */
-  userLogout: Scalars['Boolean']['output'];
+  userLogout: Scalars['Boolean']['output']
   /** Verify user email. */
-  verifyEmail: GQLAuthResult;
+  verifyEmail: GQLAuthResult
   /** Upvote or downvote a comment. */
-  voteComment: GQLComment;
+  voteComment: GQLComment
   /** Login/Signup via a wallet. */
-  walletLogin: GQLAuthResult;
+  walletLogin: GQLAuthResult
   /** Withdraw locked ERC20/native token from donation vault */
-  withdrawLockedTokens: GQLWithdrawLockedTokensResult;
-};
-
+  withdrawLockedTokens: GQLWithdrawLockedTokensResult
+}
 
 export type GQLMutationAddBlockedSearchKeywordArgs = {
-  input: GQLKeywordInput;
-};
-
+  input: GQLKeywordInput
+}
 
 export type GQLMutationAddCollectionsArticlesArgs = {
-  input: GQLAddCollectionsArticlesInput;
-};
-
+  input: GQLAddCollectionsArticlesInput
+}
 
 export type GQLMutationAddCreditArgs = {
-  input: GQLAddCreditInput;
-};
-
+  input: GQLAddCreditInput
+}
 
 export type GQLMutationAddCurationChannelArticlesArgs = {
-  input: GQLAddCurationChannelArticlesInput;
-};
-
+  input: GQLAddCurationChannelArticlesInput
+}
 
 export type GQLMutationAddSocialLoginArgs = {
-  input: GQLSocialLoginInput;
-};
-
+  input: GQLSocialLoginInput
+}
 
 export type GQLMutationAddWalletLoginArgs = {
-  input: GQLWalletLoginInput;
-};
-
+  input: GQLWalletLoginInput
+}
 
 export type GQLMutationApplyCampaignArgs = {
-  input: GQLApplyCampaignInput;
-};
-
+  input: GQLApplyCampaignInput
+}
 
 export type GQLMutationAppreciateArticleArgs = {
-  input: GQLAppreciateArticleInput;
-};
-
+  input: GQLAppreciateArticleInput
+}
 
 export type GQLMutationArchiveUsersArgs = {
-  input: GQLArchiveUsersInput;
-};
-
+  input: GQLArchiveUsersInput
+}
 
 export type GQLMutationBanCampaignArticlesArgs = {
-  input: GQLBanCampaignArticlesInput;
-};
-
+  input: GQLBanCampaignArticlesInput
+}
 
 export type GQLMutationClaimLogbooksArgs = {
-  input: GQLClaimLogbooksInput;
-};
-
+  input: GQLClaimLogbooksInput
+}
 
 export type GQLMutationClaimPersonhoodBadgeArgs = {
-  input: GQLClaimPersonhoodBadgeInput;
-};
-
+  input: GQLClaimPersonhoodBadgeInput
+}
 
 export type GQLMutationClassifyArticlesChannelsArgs = {
-  input: GQLClassifyArticlesChannelsInput;
-};
-
+  input: GQLClassifyArticlesChannelsInput
+}
 
 export type GQLMutationClearCommunityWatchOriginalContentArgs = {
-  input: GQLClearCommunityWatchOriginalContentInput;
-};
-
+  input: GQLClearCommunityWatchOriginalContentInput
+}
 
 export type GQLMutationClearReadHistoryArgs = {
-  input: GQLClearReadHistoryInput;
-};
-
+  input: GQLClearReadHistoryInput
+}
 
 export type GQLMutationCommunityWatchRemoveCommentArgs = {
-  input: GQLCommunityWatchRemoveCommentInput;
-};
-
+  input: GQLCommunityWatchRemoveCommentInput
+}
 
 export type GQLMutationConfirmVerificationCodeArgs = {
-  input: GQLConfirmVerificationCodeInput;
-};
-
+  input: GQLConfirmVerificationCodeInput
+}
 
 export type GQLMutationConnectStripeAccountArgs = {
-  input: GQLConnectStripeAccountInput;
-};
-
+  input: GQLConnectStripeAccountInput
+}
 
 export type GQLMutationCreatePersonhoodHandoffArgs = {
-  input: GQLCreatePersonhoodHandoffInput;
-};
-
+  input: GQLCreatePersonhoodHandoffInput
+}
 
 export type GQLMutationDeleteAnnouncementsArgs = {
-  input: GQLDeleteAnnouncementsInput;
-};
-
+  input: GQLDeleteAnnouncementsInput
+}
 
 export type GQLMutationDeleteBlockedSearchKeywordsArgs = {
-  input: GQLKeywordsInput;
-};
-
+  input: GQLKeywordsInput
+}
 
 export type GQLMutationDeleteCollectionArticlesArgs = {
-  input: GQLDeleteCollectionArticlesInput;
-};
-
+  input: GQLDeleteCollectionArticlesInput
+}
 
 export type GQLMutationDeleteCollectionsArgs = {
-  input: GQLDeleteCollectionsInput;
-};
-
+  input: GQLDeleteCollectionsInput
+}
 
 export type GQLMutationDeleteCommentArgs = {
-  input: GQLDeleteCommentInput;
-};
-
+  input: GQLDeleteCommentInput
+}
 
 export type GQLMutationDeleteCurationChannelArticlesArgs = {
-  input: GQLDeleteCurationChannelArticlesInput;
-};
-
+  input: GQLDeleteCurationChannelArticlesInput
+}
 
 export type GQLMutationDeleteDraftArgs = {
-  input: GQLDeleteDraftInput;
-};
-
+  input: GQLDeleteDraftInput
+}
 
 export type GQLMutationDeleteMomentArgs = {
-  input: GQLDeleteMomentInput;
-};
-
+  input: GQLDeleteMomentInput
+}
 
 export type GQLMutationDeleteQuoteArgs = {
-  input: GQLDeleteQuoteInput;
-};
-
+  input: GQLDeleteQuoteInput
+}
 
 export type GQLMutationDeleteTagsArgs = {
-  input: GQLDeleteTagsInput;
-};
-
+  input: GQLDeleteTagsInput
+}
 
 export type GQLMutationDirectImageUploadArgs = {
-  input: GQLDirectImageUploadInput;
-};
-
+  input: GQLDirectImageUploadInput
+}
 
 export type GQLMutationDismissSpamRingArgs = {
-  input: GQLDismissSpamRingInput;
-};
-
+  input: GQLDismissSpamRingInput
+}
 
 export type GQLMutationEditArticleArgs = {
-  input: GQLEditArticleInput;
-};
-
+  input: GQLEditArticleInput
+}
 
 export type GQLMutationEmailLoginArgs = {
-  input: GQLEmailLoginInput;
-};
-
+  input: GQLEmailLoginInput
+}
 
 export type GQLMutationFreezeSpamRingArgs = {
-  input: GQLFreezeSpamRingInput;
-};
-
+  input: GQLFreezeSpamRingInput
+}
 
 export type GQLMutationGenerateSigningMessageArgs = {
-  input: GQLGenerateSigningMessageInput;
-};
-
+  input: GQLGenerateSigningMessageInput
+}
 
 export type GQLMutationInviteArgs = {
-  input: GQLInviteCircleInput;
-};
-
+  input: GQLInviteCircleInput
+}
 
 export type GQLMutationLikeCollectionArgs = {
-  input: GQLLikeCollectionInput;
-};
-
+  input: GQLLikeCollectionInput
+}
 
 export type GQLMutationLikeMomentArgs = {
-  input: GQLLikeMomentInput;
-};
-
+  input: GQLLikeMomentInput
+}
 
 export type GQLMutationLogRecordArgs = {
-  input: GQLLogRecordInput;
-};
-
+  input: GQLLogRecordInput
+}
 
 export type GQLMutationMergeTagsArgs = {
-  input: GQLMergeTagsInput;
-};
-
+  input: GQLMergeTagsInput
+}
 
 export type GQLMutationMigrationArgs = {
-  input: GQLMigrationInput;
-};
-
+  input: GQLMigrationInput
+}
 
 export type GQLMutationPayToArgs = {
-  input: GQLPayToInput;
-};
-
+  input: GQLPayToInput
+}
 
 export type GQLMutationPayoutArgs = {
-  input: GQLPayoutInput;
-};
-
+  input: GQLPayoutInput
+}
 
 export type GQLMutationPinCommentArgs = {
-  input: GQLPinCommentInput;
-};
-
+  input: GQLPinCommentInput
+}
 
 export type GQLMutationPublishArticleArgs = {
-  input: GQLPublishArticleInput;
-};
-
+  input: GQLPublishArticleInput
+}
 
 export type GQLMutationPutAnnouncementArgs = {
-  input: GQLPutAnnouncementInput;
-};
-
+  input: GQLPutAnnouncementInput
+}
 
 export type GQLMutationPutArticleFederationSettingArgs = {
-  input: GQLPutArticleFederationSettingInput;
-};
-
+  input: GQLPutArticleFederationSettingInput
+}
 
 export type GQLMutationPutCircleArgs = {
-  input: GQLPutCircleInput;
-};
-
+  input: GQLPutCircleInput
+}
 
 export type GQLMutationPutCircleArticlesArgs = {
-  input: GQLPutCircleArticlesInput;
-};
-
+  input: GQLPutCircleArticlesInput
+}
 
 export type GQLMutationPutCollectionArgs = {
-  input: GQLPutCollectionInput;
-};
-
+  input: GQLPutCollectionInput
+}
 
 export type GQLMutationPutCommentArgs = {
-  input: GQLPutCommentInput;
-};
-
+  input: GQLPutCommentInput
+}
 
 export type GQLMutationPutCurationChannelArgs = {
-  input: GQLPutCurationChannelInput;
-};
-
+  input: GQLPutCurationChannelInput
+}
 
 export type GQLMutationPutDraftArgs = {
-  input: GQLPutDraftInput;
-};
-
+  input: GQLPutDraftInput
+}
 
 export type GQLMutationPutFeaturedTagsArgs = {
-  input: GQLFeaturedTagsInput;
-};
-
+  input: GQLFeaturedTagsInput
+}
 
 export type GQLMutationPutIcymiTopicArgs = {
-  input: GQLPutIcymiTopicInput;
-};
-
+  input: GQLPutIcymiTopicInput
+}
 
 export type GQLMutationPutMomentArgs = {
-  input: GQLPutMomentInput;
-};
-
+  input: GQLPutMomentInput
+}
 
 export type GQLMutationPutOAuthClientArgs = {
-  input: GQLPutOAuthClientInput;
-};
-
+  input: GQLPutOAuthClientInput
+}
 
 export type GQLMutationPutQuoteArgs = {
-  input: GQLPutQuoteInput;
-};
-
+  input: GQLPutQuoteInput
+}
 
 export type GQLMutationPutRemarkArgs = {
-  input: GQLPutRemarkInput;
-};
-
+  input: GQLPutRemarkInput
+}
 
 export type GQLMutationPutRestrictedUsersArgs = {
-  input: GQLPutRestrictedUsersInput;
-};
-
+  input: GQLPutRestrictedUsersInput
+}
 
 export type GQLMutationPutSkippedListItemArgs = {
-  input: GQLPutSkippedListItemInput;
-};
-
+  input: GQLPutSkippedListItemInput
+}
 
 export type GQLMutationPutTagChannelArgs = {
-  input: GQLPutTagChannelInput;
-};
-
+  input: GQLPutTagChannelInput
+}
 
 export type GQLMutationPutTopicChannelArgs = {
-  input: GQLPutTopicChannelInput;
-};
-
+  input: GQLPutTopicChannelInput
+}
 
 export type GQLMutationPutUserFeatureFlagsArgs = {
-  input: GQLPutUserFeatureFlagsInput;
-};
-
+  input: GQLPutUserFeatureFlagsInput
+}
 
 export type GQLMutationPutUserFederationSettingArgs = {
-  input: GQLPutUserFederationSettingInput;
-};
-
+  input: GQLPutUserFederationSettingInput
+}
 
 export type GQLMutationPutWritingChallengeArgs = {
-  input: GQLPutWritingChallengeInput;
-};
-
+  input: GQLPutWritingChallengeInput
+}
 
 export type GQLMutationReadArticleArgs = {
-  input: GQLReadArticleInput;
-};
-
+  input: GQLReadArticleInput
+}
 
 export type GQLMutationRemoveSocialLoginArgs = {
-  input: GQLRemoveSocialLoginInput;
-};
-
+  input: GQLRemoveSocialLoginInput
+}
 
 export type GQLMutationRenameTagArgs = {
-  input: GQLRenameTagInput;
-};
-
+  input: GQLRenameTagInput
+}
 
 export type GQLMutationReorderChannelsArgs = {
-  input: GQLReorderChannelsInput;
-};
-
+  input: GQLReorderChannelsInput
+}
 
 export type GQLMutationReorderCollectionArticlesArgs = {
-  input: GQLReorderCollectionArticlesInput;
-};
-
+  input: GQLReorderCollectionArticlesInput
+}
 
 export type GQLMutationResetLikerIdArgs = {
-  input: GQLResetLikerIdInput;
-};
-
+  input: GQLResetLikerIdInput
+}
 
 export type GQLMutationResetPasswordArgs = {
-  input: GQLResetPasswordInput;
-};
-
+  input: GQLResetPasswordInput
+}
 
 export type GQLMutationRestoreCommunityWatchCommentArgs = {
-  input: GQLRestoreCommunityWatchCommentInput;
-};
-
+  input: GQLRestoreCommunityWatchCommentInput
+}
 
 export type GQLMutationReviewTopicChannelFeedbackArgs = {
-  input: GQLReviewTopicChannelFeedbackInput;
-};
-
+  input: GQLReviewTopicChannelFeedbackInput
+}
 
 export type GQLMutationSendCampaignAnnouncementArgs = {
-  input: GQLSendCampaignAnnouncementInput;
-};
-
+  input: GQLSendCampaignAnnouncementInput
+}
 
 export type GQLMutationSendVerificationCodeArgs = {
-  input: GQLSendVerificationCodeInput;
-};
-
+  input: GQLSendVerificationCodeInput
+}
 
 export type GQLMutationSetAdStatusArgs = {
-  input: GQLSetAdStatusInput;
-};
-
+  input: GQLSetAdStatusInput
+}
 
 export type GQLMutationSetArticleFederationSettingArgs = {
-  input: GQLSetArticleFederationSettingInput;
-};
-
+  input: GQLSetArticleFederationSettingInput
+}
 
 export type GQLMutationSetArticleTopicChannelsArgs = {
-  input: GQLSetArticleTopicChannelsInput;
-};
-
+  input: GQLSetArticleTopicChannelsInput
+}
 
 export type GQLMutationSetBoostArgs = {
-  input: GQLSetBoostInput;
-};
-
+  input: GQLSetBoostInput
+}
 
 export type GQLMutationSetCurrencyArgs = {
-  input: GQLSetCurrencyInput;
-};
-
+  input: GQLSetCurrencyInput
+}
 
 export type GQLMutationSetEmailArgs = {
-  input: GQLSetEmailInput;
-};
-
+  input: GQLSetEmailInput
+}
 
 export type GQLMutationSetFeatureArgs = {
-  input: GQLSetFeatureInput;
-};
-
+  input: GQLSetFeatureInput
+}
 
 export type GQLMutationSetPasswordArgs = {
-  input: GQLSetPasswordInput;
-};
-
+  input: GQLSetPasswordInput
+}
 
 export type GQLMutationSetSpamStatusArgs = {
-  input: GQLSetSpamStatusInput;
-};
-
+  input: GQLSetSpamStatusInput
+}
 
 export type GQLMutationSetUserNameArgs = {
-  input: GQLSetUserNameInput;
-};
-
+  input: GQLSetUserNameInput
+}
 
 export type GQLMutationSetViewerFederationSettingArgs = {
-  input: GQLSetViewerFederationSettingInput;
-};
-
+  input: GQLSetViewerFederationSettingInput
+}
 
 export type GQLMutationSetWritingAdStatusArgs = {
-  input: GQLSetAdStatusInput;
-};
-
+  input: GQLSetAdStatusInput
+}
 
 export type GQLMutationSingleFileUploadArgs = {
-  input: GQLSingleFileUploadInput;
-};
-
+  input: GQLSingleFileUploadInput
+}
 
 export type GQLMutationSocialLoginArgs = {
-  input: GQLSocialLoginInput;
-};
-
+  input: GQLSocialLoginInput
+}
 
 export type GQLMutationSubmitReportArgs = {
-  input: GQLSubmitReportInput;
-};
-
+  input: GQLSubmitReportInput
+}
 
 export type GQLMutationSubmitTopicChannelFeedbackArgs = {
-  input: GQLSubmitTopicChannelFeedbackInput;
-};
-
+  input: GQLSubmitTopicChannelFeedbackInput
+}
 
 export type GQLMutationSubscribeCircleArgs = {
-  input: GQLSubscribeCircleInput;
-};
-
+  input: GQLSubscribeCircleInput
+}
 
 export type GQLMutationToggleArticleRecommendArgs = {
-  input: GQLToggleRecommendInput;
-};
-
+  input: GQLToggleRecommendInput
+}
 
 export type GQLMutationToggleBlockUserArgs = {
-  input: GQLToggleItemInput;
-};
-
+  input: GQLToggleItemInput
+}
 
 export type GQLMutationToggleBookmarkArticleArgs = {
-  input: GQLToggleItemInput;
-};
-
+  input: GQLToggleItemInput
+}
 
 export type GQLMutationToggleBookmarkTagArgs = {
-  input: GQLToggleItemInput;
-};
-
+  input: GQLToggleItemInput
+}
 
 export type GQLMutationToggleFollowCircleArgs = {
-  input: GQLToggleItemInput;
-};
-
+  input: GQLToggleItemInput
+}
 
 export type GQLMutationToggleFollowTagArgs = {
-  input: GQLToggleItemInput;
-};
-
+  input: GQLToggleItemInput
+}
 
 export type GQLMutationToggleFollowUserArgs = {
-  input: GQLToggleItemInput;
-};
-
+  input: GQLToggleItemInput
+}
 
 export type GQLMutationTogglePinChannelArticlesArgs = {
-  input: GQLTogglePinChannelArticlesInput;
-};
-
+  input: GQLTogglePinChannelArticlesInput
+}
 
 export type GQLMutationTogglePinCommentArgs = {
-  input: GQLToggleItemInput;
-};
-
+  input: GQLToggleItemInput
+}
 
 export type GQLMutationToggleSeedingUsersArgs = {
-  input: GQLToggleSeedingUsersInput;
-};
-
+  input: GQLToggleSeedingUsersInput
+}
 
 export type GQLMutationToggleSubscribeArticleArgs = {
-  input: GQLToggleItemInput;
-};
-
+  input: GQLToggleItemInput
+}
 
 export type GQLMutationToggleUsersBadgeArgs = {
-  input: GQLToggleUsersBadgeInput;
-};
-
+  input: GQLToggleUsersBadgeInput
+}
 
 export type GQLMutationToggleWritingChallengeFeaturedArticlesArgs = {
-  input: GQLToggleWritingChallengeFeaturedArticlesInput;
-};
-
+  input: GQLToggleWritingChallengeFeaturedArticlesInput
+}
 
 export type GQLMutationUnbindLikerIdArgs = {
-  input: GQLUnbindLikerIdInput;
-};
-
+  input: GQLUnbindLikerIdInput
+}
 
 export type GQLMutationUnfreezeSpamRingArgs = {
-  input: GQLUnfreezeSpamRingInput;
-};
-
+  input: GQLUnfreezeSpamRingInput
+}
 
 export type GQLMutationUnlikeCollectionArgs = {
-  input: GQLUnlikeCollectionInput;
-};
-
+  input: GQLUnlikeCollectionInput
+}
 
 export type GQLMutationUnlikeMomentArgs = {
-  input: GQLUnlikeMomentInput;
-};
-
+  input: GQLUnlikeMomentInput
+}
 
 export type GQLMutationUnpinCommentArgs = {
-  input: GQLUnpinCommentInput;
-};
-
+  input: GQLUnpinCommentInput
+}
 
 export type GQLMutationUnsubscribeCircleArgs = {
-  input: GQLUnsubscribeCircleInput;
-};
-
+  input: GQLUnsubscribeCircleInput
+}
 
 export type GQLMutationUnvoteCommentArgs = {
-  input: GQLUnvoteCommentInput;
-};
-
+  input: GQLUnvoteCommentInput
+}
 
 export type GQLMutationUpdateArticleSensitiveArgs = {
-  input: GQLUpdateArticleSensitiveInput;
-};
-
+  input: GQLUpdateArticleSensitiveInput
+}
 
 export type GQLMutationUpdateArticleStateArgs = {
-  input: GQLUpdateArticleStateInput;
-};
-
+  input: GQLUpdateArticleStateInput
+}
 
 export type GQLMutationUpdateCampaignApplicationStateArgs = {
-  input: GQLUpdateCampaignApplicationStateInput;
-};
-
+  input: GQLUpdateCampaignApplicationStateInput
+}
 
 export type GQLMutationUpdateCommentsStateArgs = {
-  input: GQLUpdateCommentsStateInput;
-};
-
+  input: GQLUpdateCommentsStateInput
+}
 
 export type GQLMutationUpdateCommunityWatchActionStateArgs = {
-  input: GQLUpdateCommunityWatchActionStateInput;
-};
+  input: GQLUpdateCommunityWatchActionStateInput
+}
 
+export type GQLMutationUpdateModerationCaseArgs = {
+  input: GQLUpdateModerationCaseInput
+}
 
 export type GQLMutationUpdateMomentFeedApplicationStateArgs = {
-  input: GQLUpdateMomentFeedApplicationStateInput;
-};
-
+  input: GQLUpdateMomentFeedApplicationStateInput
+}
 
 export type GQLMutationUpdateNotificationSettingArgs = {
-  input: GQLUpdateNotificationSettingInput;
-};
-
+  input: GQLUpdateNotificationSettingInput
+}
 
 export type GQLMutationUpdateUserExtraArgs = {
-  input: GQLUpdateUserExtraInput;
-};
-
+  input: GQLUpdateUserExtraInput
+}
 
 export type GQLMutationUpdateUserInfoArgs = {
-  input: GQLUpdateUserInfoInput;
-};
-
+  input: GQLUpdateUserInfoInput
+}
 
 export type GQLMutationUpdateUserRoleArgs = {
-  input: GQLUpdateUserRoleInput;
-};
-
+  input: GQLUpdateUserRoleInput
+}
 
 export type GQLMutationUpdateUserStateArgs = {
-  input: GQLUpdateUserStateInput;
-};
-
+  input: GQLUpdateUserStateInput
+}
 
 export type GQLMutationUpsertSpamRingCandidatesArgs = {
-  input: GQLUpsertSpamRingCandidatesInput;
-};
-
+  input: GQLUpsertSpamRingCandidatesInput
+}
 
 export type GQLMutationVerifyEmailArgs = {
-  input: GQLVerifyEmailInput;
-};
-
+  input: GQLVerifyEmailInput
+}
 
 export type GQLMutationVoteCommentArgs = {
-  input: GQLVoteCommentInput;
-};
-
+  input: GQLVoteCommentInput
+}
 
 export type GQLMutationWalletLoginArgs = {
-  input: GQLWalletLoginInput;
-};
+  input: GQLWalletLoginInput
+}
 
 /**  NFT Asset  */
 export type GQLNftAsset = {
-  __typename?: 'NFTAsset';
-  collectionName: Scalars['String']['output'];
+  __typename?: 'NFTAsset'
+  collectionName: Scalars['String']['output']
   /** imageOriginalUrl: String! */
-  contractAddress: Scalars['String']['output'];
-  description?: Maybe<Scalars['String']['output']>;
-  id: Scalars['ID']['output'];
-  imagePreviewUrl?: Maybe<Scalars['String']['output']>;
-  imageUrl: Scalars['String']['output'];
-  name: Scalars['String']['output'];
-};
+  contractAddress: Scalars['String']['output']
+  description?: Maybe<Scalars['String']['output']>
+  id: Scalars['ID']['output']
+  imagePreviewUrl?: Maybe<Scalars['String']['output']>
+  imageUrl: Scalars['String']['output']
+  name: Scalars['String']['output']
+}
 
 export type GQLNode = {
-  id: Scalars['ID']['output'];
-};
+  id: Scalars['ID']['output']
+}
 
 export type GQLNodeInput = {
-  id: Scalars['ID']['input'];
-};
+  id: Scalars['ID']['input']
+}
 
 export type GQLNodesInput = {
-  ids: Array<Scalars['ID']['input']>;
-};
+  ids: Array<Scalars['ID']['input']>
+}
 
 /** This interface contains common fields of a notice. */
 export type GQLNotice = {
   /** Time of this notice was created. */
-  createdAt: Scalars['DateTime']['output'];
+  createdAt: Scalars['DateTime']['output']
   /** Unique ID of this notice. */
-  id: Scalars['ID']['output'];
+  id: Scalars['ID']['output']
   /** The value determines if the notice is unread or not. */
-  unread: Scalars['Boolean']['output'];
-};
+  unread: Scalars['Boolean']['output']
+}
 
 export type GQLNoticeConnection = GQLConnection & {
-  __typename?: 'NoticeConnection';
-  edges?: Maybe<Array<GQLNoticeEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'NoticeConnection'
+  edges?: Maybe<Array<GQLNoticeEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLNoticeEdge = {
-  __typename?: 'NoticeEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLNotice;
-};
+  __typename?: 'NoticeEdge'
+  cursor: Scalars['String']['output']
+  node: GQLNotice
+}
 
 export type GQLNotificationSetting = {
-  __typename?: 'NotificationSetting';
-  articleNewAppreciation: Scalars['Boolean']['output'];
-  articleNewCollected: Scalars['Boolean']['output'];
-  articleNewComment: Scalars['Boolean']['output'];
-  articleNewSubscription: Scalars['Boolean']['output'];
-  circleMemberNewBroadcastReply: Scalars['Boolean']['output'];
-  circleMemberNewDiscussion: Scalars['Boolean']['output'];
-  circleMemberNewDiscussionReply: Scalars['Boolean']['output'];
-  circleNewFollower: Scalars['Boolean']['output'];
+  __typename?: 'NotificationSetting'
+  articleNewAppreciation: Scalars['Boolean']['output']
+  articleNewCollected: Scalars['Boolean']['output']
+  articleNewComment: Scalars['Boolean']['output']
+  articleNewSubscription: Scalars['Boolean']['output']
+  circleMemberNewBroadcastReply: Scalars['Boolean']['output']
+  circleMemberNewDiscussion: Scalars['Boolean']['output']
+  circleMemberNewDiscussionReply: Scalars['Boolean']['output']
+  circleNewFollower: Scalars['Boolean']['output']
   /** for circle owners */
-  circleNewSubscriber: Scalars['Boolean']['output'];
-  circleNewUnsubscriber: Scalars['Boolean']['output'];
-  email: Scalars['Boolean']['output'];
+  circleNewSubscriber: Scalars['Boolean']['output']
+  circleNewUnsubscriber: Scalars['Boolean']['output']
+  email: Scalars['Boolean']['output']
   /** for circle members & followers */
-  inCircleNewArticle: Scalars['Boolean']['output'];
-  inCircleNewBroadcast: Scalars['Boolean']['output'];
-  inCircleNewBroadcastReply: Scalars['Boolean']['output'];
-  inCircleNewDiscussion: Scalars['Boolean']['output'];
-  inCircleNewDiscussionReply: Scalars['Boolean']['output'];
-  mention: Scalars['Boolean']['output'];
-  newComment: Scalars['Boolean']['output'];
-  newLike: Scalars['Boolean']['output'];
-  userNewFollower: Scalars['Boolean']['output'];
-};
+  inCircleNewArticle: Scalars['Boolean']['output']
+  inCircleNewBroadcast: Scalars['Boolean']['output']
+  inCircleNewBroadcastReply: Scalars['Boolean']['output']
+  inCircleNewDiscussion: Scalars['Boolean']['output']
+  inCircleNewDiscussionReply: Scalars['Boolean']['output']
+  mention: Scalars['Boolean']['output']
+  newComment: Scalars['Boolean']['output']
+  newLike: Scalars['Boolean']['output']
+  userNewFollower: Scalars['Boolean']['output']
+}
 
 export type GQLNotificationSettingType =
   | 'articleNewAppreciation'
@@ -3299,846 +3179,789 @@ export type GQLNotificationSettingType =
   | 'mention'
   | 'newComment'
   | 'newLike'
-  | 'userNewFollower';
+  | 'userNewFollower'
 
 export type GQLOAuthClient = {
-  __typename?: 'OAuthClient';
+  __typename?: 'OAuthClient'
   /** URL for oauth client's avatar. */
-  avatar?: Maybe<Scalars['String']['output']>;
+  avatar?: Maybe<Scalars['String']['output']>
   /** Creation Date */
-  createdAt: Scalars['DateTime']['output'];
+  createdAt: Scalars['DateTime']['output']
   /** App Description */
-  description?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>
   /** Grant Types */
-  grantTypes?: Maybe<Array<GQLGrantType>>;
+  grantTypes?: Maybe<Array<GQLGrantType>>
   /** Unique Client ID of this OAuth Client. */
-  id: Scalars['ID']['output'];
+  id: Scalars['ID']['output']
   /** App name */
-  name: Scalars['String']['output'];
+  name: Scalars['String']['output']
   /** Redirect URIs */
-  redirectURIs?: Maybe<Array<Scalars['String']['output']>>;
+  redirectURIs?: Maybe<Array<Scalars['String']['output']>>
   /** Scopes */
-  scope?: Maybe<Array<Scalars['String']['output']>>;
+  scope?: Maybe<Array<Scalars['String']['output']>>
   /** Client secret */
-  secret: Scalars['String']['output'];
+  secret: Scalars['String']['output']
   /** Linked Developer Account */
-  user?: Maybe<GQLUser>;
+  user?: Maybe<GQLUser>
   /** URL for oauth client's official website */
-  website?: Maybe<Scalars['String']['output']>;
-};
+  website?: Maybe<Scalars['String']['output']>
+}
 
 export type GQLOAuthClientConnection = GQLConnection & {
-  __typename?: 'OAuthClientConnection';
-  edges?: Maybe<Array<GQLOAuthClientEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'OAuthClientConnection'
+  edges?: Maybe<Array<GQLOAuthClientEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLOAuthClientEdge = {
-  __typename?: 'OAuthClientEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLOAuthClient;
-};
+  __typename?: 'OAuthClientEdge'
+  cursor: Scalars['String']['output']
+  node: GQLOAuthClient
+}
 
 export type GQLOAuthClientInput = {
-  id: Scalars['ID']['input'];
-};
+  id: Scalars['ID']['input']
+}
 
 export type GQLOss = {
-  __typename?: 'OSS';
-  articles: GQLArticleConnection;
-  badgedUsers: GQLUserConnection;
-  comments: GQLCommentConnection;
-  icymiTopics: GQLIcymiTopicConnection;
-  momentFeedUsers: GQLUserConnection;
-  moments: GQLMomentConnection;
-  oauthClients: GQLOAuthClientConnection;
-  reports: GQLReportConnection;
-  restrictedUsers: GQLUserConnection;
-  seedingUsers: GQLUserConnection;
-  skippedListItems: GQLSkippedListItemsConnection;
-  spamRings: GQLSpamRingConnection;
-  tags: GQLTagConnection;
-  topicChannelFeedbacks: GQLTopicChannelFeedbackConnection;
-  users: GQLUserConnection;
-};
-
+  __typename?: 'OSS'
+  articles: GQLArticleConnection
+  badgedUsers: GQLUserConnection
+  comments: GQLCommentConnection
+  icymiTopics: GQLIcymiTopicConnection
+  momentFeedUsers: GQLUserConnection
+  moments: GQLMomentConnection
+  oauthClients: GQLOAuthClientConnection
+  reports: GQLReportConnection
+  restrictedUsers: GQLUserConnection
+  seedingUsers: GQLUserConnection
+  skippedListItems: GQLSkippedListItemsConnection
+  spamRings: GQLSpamRingConnection
+  tags: GQLTagConnection
+  topicChannelFeedbacks: GQLTopicChannelFeedbackConnection
+  users: GQLUserConnection
+}
 
 export type GQLOssArticlesArgs = {
-  input: GQLOssArticlesInput;
-};
-
+  input: GQLOssArticlesInput
+}
 
 export type GQLOssBadgedUsersArgs = {
-  input: GQLBadgedUsersInput;
-};
-
+  input: GQLBadgedUsersInput
+}
 
 export type GQLOssCommentsArgs = {
-  input: GQLOssCommentsInput;
-};
-
+  input: GQLOssCommentsInput
+}
 
 export type GQLOssIcymiTopicsArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLOssMomentFeedUsersArgs = {
-  input: GQLMomentFeedUsersInput;
-};
-
+  input: GQLMomentFeedUsersInput
+}
 
 export type GQLOssMomentsArgs = {
-  input: GQLOssMomentsInput;
-};
-
+  input: GQLOssMomentsInput
+}
 
 export type GQLOssOauthClientsArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLOssReportsArgs = {
-  input: GQLOssReportsInput;
-};
-
+  input: GQLOssReportsInput
+}
 
 export type GQLOssRestrictedUsersArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLOssSeedingUsersArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLOssSkippedListItemsArgs = {
-  input: GQLSkippedListItemsInput;
-};
-
+  input: GQLSkippedListItemsInput
+}
 
 export type GQLOssSpamRingsArgs = {
-  input: GQLOssSpamRingsInput;
-};
-
+  input: GQLOssSpamRingsInput
+}
 
 export type GQLOssTagsArgs = {
-  input: GQLTagsInput;
-};
-
+  input: GQLTagsInput
+}
 
 export type GQLOssTopicChannelFeedbacksArgs = {
-  input: GQLTopicChannelFeedbacksInput;
-};
-
+  input: GQLTopicChannelFeedbacksInput
+}
 
 export type GQLOssUsersArgs = {
-  input: GQLConnectionArgs;
-};
+  input: GQLConnectionArgs
+}
 
 export type GQLOssArticlesFilterInput = {
-  datetimeRange?: InputMaybe<GQLDatetimeRangeInput>;
-  isSpam?: InputMaybe<Scalars['Boolean']['input']>;
-  searchKey?: InputMaybe<Scalars['String']['input']>;
-};
+  datetimeRange?: InputMaybe<GQLDatetimeRangeInput>
+  isSpam?: InputMaybe<Scalars['Boolean']['input']>
+  searchKey?: InputMaybe<Scalars['String']['input']>
+}
 
 export type GQLOssArticlesInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<GQLOssArticlesFilterInput>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  sort?: InputMaybe<GQLArticlesSort>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<GQLOssArticlesFilterInput>
+  first?: InputMaybe<Scalars['Int']['input']>
+  sort?: InputMaybe<GQLArticlesSort>
+}
 
 export type GQLOssCommentsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<GQLOssSpamDatetimeFilterInput>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  sort?: InputMaybe<GQLOssContentSpamSort>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<GQLOssSpamDatetimeFilterInput>
+  first?: InputMaybe<Scalars['Int']['input']>
+  sort?: InputMaybe<GQLOssContentSpamSort>
+}
 
 /** Sort options shared by OSS comment/moment lists for spam triage. */
 export type GQLOssContentSpamSort =
   /** Order by spam score from high to low (only scored items) */
-  | 'mostSpam'
-  | 'newest';
+  'mostSpam' | 'newest'
 
 export type GQLOssMomentsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<GQLOssSpamDatetimeFilterInput>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  sort?: InputMaybe<GQLOssContentSpamSort>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<GQLOssSpamDatetimeFilterInput>
+  first?: InputMaybe<Scalars['Int']['input']>
+  sort?: InputMaybe<GQLOssContentSpamSort>
+}
 
 export type GQLOssReportsFilter = {
-  source?: InputMaybe<GQLReportSource>;
-};
+  source?: InputMaybe<GQLReportSource>
+}
 
 export type GQLOssReportsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<GQLOssReportsFilter>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<GQLOssReportsFilter>
+  first?: InputMaybe<Scalars['Int']['input']>
+}
 
 export type GQLOssSpamDatetimeFilterInput = {
-  datetimeRange?: InputMaybe<GQLDatetimeRangeInput>;
-};
+  datetimeRange?: InputMaybe<GQLDatetimeRangeInput>
+}
 
 export type GQLOssSpamRingsFilter = {
-  status?: InputMaybe<GQLSpamRingStatus>;
-};
+  status?: InputMaybe<GQLSpamRingStatus>
+}
 
 export type GQLOssSpamRingsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<GQLOssSpamRingsFilter>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  sort?: InputMaybe<GQLSpamRingsSort>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<GQLOssSpamRingsFilter>
+  first?: InputMaybe<Scalars['Int']['input']>
+  sort?: InputMaybe<GQLSpamRingsSort>
+}
 
 export type GQLOauth1CredentialInput = {
-  oauthToken: Scalars['String']['input'];
-  oauthVerifier: Scalars['String']['input'];
-};
+  oauthToken: Scalars['String']['input']
+  oauthVerifier: Scalars['String']['input']
+}
 
 /** This type contains system-wise info and settings. */
 export type GQLOfficial = {
-  __typename?: 'Official';
+  __typename?: 'Official'
   /** Announcements */
-  announcements?: Maybe<Array<GQLAnnouncement>>;
+  announcements?: Maybe<Array<GQLAnnouncement>>
   /** Feature flag */
-  features: Array<GQLFeature>;
-};
-
+  features: Array<GQLFeature>
+}
 
 /** This type contains system-wise info and settings. */
 export type GQLOfficialAnnouncementsArgs = {
-  input: GQLAnnouncementsInput;
-};
+  input: GQLAnnouncementsInput
+}
 
 /** The notice type contains info about official announcement. */
 export type GQLOfficialAnnouncementNotice = GQLNotice & {
-  __typename?: 'OfficialAnnouncementNotice';
+  __typename?: 'OfficialAnnouncementNotice'
   /** Time of this notice was created. */
-  createdAt: Scalars['DateTime']['output'];
+  createdAt: Scalars['DateTime']['output']
   /** Unique ID of this notice. */
-  id: Scalars['ID']['output'];
+  id: Scalars['ID']['output']
   /** The link to a specific page if provided. */
-  link?: Maybe<Scalars['String']['output']>;
+  link?: Maybe<Scalars['String']['output']>
   /** The message content. */
-  message: Scalars['String']['output'];
+  message: Scalars['String']['output']
   /** The value determines if the notice is unread or not. */
-  unread: Scalars['Boolean']['output'];
-};
+  unread: Scalars['Boolean']['output']
+}
 
 export type GQLPageInfo = {
-  __typename?: 'PageInfo';
-  endCursor?: Maybe<Scalars['String']['output']>;
-  hasNextPage: Scalars['Boolean']['output'];
-  hasPreviousPage: Scalars['Boolean']['output'];
-  startCursor?: Maybe<Scalars['String']['output']>;
-};
+  __typename?: 'PageInfo'
+  endCursor?: Maybe<Scalars['String']['output']>
+  hasNextPage: Scalars['Boolean']['output']
+  hasPreviousPage: Scalars['Boolean']['output']
+  startCursor?: Maybe<Scalars['String']['output']>
+}
 
 export type GQLPayToInput = {
-  amount: Scalars['Float']['input'];
+  amount: Scalars['Float']['input']
   /** for ERC20/native token payment */
-  chain?: InputMaybe<GQLChain>;
-  currency: GQLTransactionCurrency;
-  id?: InputMaybe<Scalars['ID']['input']>;
+  chain?: InputMaybe<GQLChain>
+  currency: GQLTransactionCurrency
+  id?: InputMaybe<Scalars['ID']['input']>
   /** for HKD payment */
-  password?: InputMaybe<Scalars['String']['input']>;
-  purpose: GQLTransactionPurpose;
-  recipientId: Scalars['ID']['input'];
-  targetId?: InputMaybe<Scalars['ID']['input']>;
-  txHash?: InputMaybe<Scalars['String']['input']>;
-};
+  password?: InputMaybe<Scalars['String']['input']>
+  purpose: GQLTransactionPurpose
+  recipientId: Scalars['ID']['input']
+  targetId?: InputMaybe<Scalars['ID']['input']>
+  txHash?: InputMaybe<Scalars['String']['input']>
+}
 
 export type GQLPayToResult = {
-  __typename?: 'PayToResult';
+  __typename?: 'PayToResult'
   /** Only available when paying with LIKE. */
-  redirectUrl?: Maybe<Scalars['String']['output']>;
-  transaction: GQLTransaction;
-};
+  redirectUrl?: Maybe<Scalars['String']['output']>
+  transaction: GQLTransaction
+}
 
 export type GQLPayoutInput = {
-  amount: Scalars['Float']['input'];
-  password: Scalars['String']['input'];
-};
+  amount: Scalars['Float']['input']
+  password: Scalars['String']['input']
+}
 
 export type GQLPerson = {
-  __typename?: 'Person';
-  email: Scalars['String']['output'];
-};
+  __typename?: 'Person'
+  email: Scalars['String']['output']
+}
 
 export type GQLPersonhoodHandoff = {
-  __typename?: 'PersonhoodHandoff';
-  expiresAt: Scalars['DateTime']['output'];
-  token: Scalars['String']['output'];
-};
+  __typename?: 'PersonhoodHandoff'
+  expiresAt: Scalars['DateTime']['output']
+  token: Scalars['String']['output']
+}
 
 export type GQLPinCommentInput = {
-  id: Scalars['ID']['input'];
-};
+  id: Scalars['ID']['input']
+}
 
 export type GQLPinHistory = {
-  __typename?: 'PinHistory';
+  __typename?: 'PinHistory'
   /** Which feed (IcymiTopic / Channel) the article was pinned */
-  feed: GQLNode;
-  pinnedAt: Scalars['DateTime']['output'];
-};
+  feed: GQLNode
+  pinnedAt: Scalars['DateTime']['output']
+}
 
 export type GQLPinnableWork = {
-  cover?: Maybe<Scalars['String']['output']>;
-  id: Scalars['ID']['output'];
-  pinned: Scalars['Boolean']['output'];
-  title: Scalars['String']['output'];
-};
+  cover?: Maybe<Scalars['String']['output']>
+  id: Scalars['ID']['output']
+  pinned: Scalars['Boolean']['output']
+  title: Scalars['String']['output']
+}
 
 export type GQLPrice = {
-  __typename?: 'Price';
+  __typename?: 'Price'
   /** Amount of Price. */
-  amount: Scalars['Float']['output'];
+  amount: Scalars['Float']['output']
   /** Current Price belongs to whcih Circle. */
-  circle: GQLCircle;
+  circle: GQLCircle
   /**
    * Created time.
    * @deprecated No longer in use
    */
-  createdAt: Scalars['DateTime']['output'];
+  createdAt: Scalars['DateTime']['output']
   /** Currency of Price. */
-  currency: GQLTransactionCurrency;
+  currency: GQLTransactionCurrency
   /** Unique ID. */
-  id: Scalars['ID']['output'];
+  id: Scalars['ID']['output']
   /** State of Price. */
-  state: GQLPriceState;
+  state: GQLPriceState
   /**
    * Updated time.
    * @deprecated No longer in use
    */
-  updatedAt: Scalars['DateTime']['output'];
-};
+  updatedAt: Scalars['DateTime']['output']
+}
 
-export type GQLPriceState =
-  | 'active'
-  | 'archived';
+export type GQLPriceState = 'active' | 'archived'
 
 export type GQLPublishArticleInput = {
-  id: Scalars['ID']['input'];
+  id: Scalars['ID']['input']
   /** whether publish to ISCN */
-  iscnPublish?: InputMaybe<Scalars['Boolean']['input']>;
+  iscnPublish?: InputMaybe<Scalars['Boolean']['input']>
   /** Scheduled publish date of the article. */
-  publishAt?: InputMaybe<Scalars['DateTime']['input']>;
-};
+  publishAt?: InputMaybe<Scalars['DateTime']['input']>
+}
 
 /** Enums for publishing state. */
-export type GQLPublishState =
-  | 'error'
-  | 'pending'
-  | 'published'
-  | 'unpublished';
+export type GQLPublishState = 'error' | 'pending' | 'published' | 'unpublished'
 
 export type GQLPutAnnouncementInput = {
-  channels?: InputMaybe<Array<GQLAnnouncementChannelInput>>;
-  content?: InputMaybe<Array<GQLTranslationInput>>;
-  cover?: InputMaybe<Scalars['String']['input']>;
-  expiredAt?: InputMaybe<Scalars['DateTime']['input']>;
-  id?: InputMaybe<Scalars['ID']['input']>;
-  link?: InputMaybe<Array<GQLTranslationInput>>;
-  order?: InputMaybe<Scalars['Int']['input']>;
-  title?: InputMaybe<Array<GQLTranslationInput>>;
-  type?: InputMaybe<GQLAnnouncementType>;
-  visible?: InputMaybe<Scalars['Boolean']['input']>;
-};
+  channels?: InputMaybe<Array<GQLAnnouncementChannelInput>>
+  content?: InputMaybe<Array<GQLTranslationInput>>
+  cover?: InputMaybe<Scalars['String']['input']>
+  expiredAt?: InputMaybe<Scalars['DateTime']['input']>
+  id?: InputMaybe<Scalars['ID']['input']>
+  link?: InputMaybe<Array<GQLTranslationInput>>
+  order?: InputMaybe<Scalars['Int']['input']>
+  title?: InputMaybe<Array<GQLTranslationInput>>
+  type?: InputMaybe<GQLAnnouncementType>
+  visible?: InputMaybe<Scalars['Boolean']['input']>
+}
 
 export type GQLPutArticleFederationSettingInput = {
-  id: Scalars['ID']['input'];
-  state: GQLFederationArticleSettingState;
-};
+  id: Scalars['ID']['input']
+  state: GQLFederationArticleSettingState
+}
 
 export type GQLPutCircleArticlesInput = {
   /** Access Type, `public` or `paywall` only. */
-  accessType: GQLArticleAccessType;
+  accessType: GQLArticleAccessType
   /** Article Ids */
-  articles?: InputMaybe<Array<Scalars['ID']['input']>>;
+  articles?: InputMaybe<Array<Scalars['ID']['input']>>
   /** Circle ID */
-  id: Scalars['ID']['input'];
-  license?: InputMaybe<GQLArticleLicenseType>;
+  id: Scalars['ID']['input']
+  license?: InputMaybe<GQLArticleLicenseType>
   /** Action Type */
-  type: GQLPutCircleArticlesType;
-};
+  type: GQLPutCircleArticlesType
+}
 
-export type GQLPutCircleArticlesType =
-  | 'add'
-  | 'remove';
+export type GQLPutCircleArticlesType = 'add' | 'remove'
 
 export type GQLPutCircleInput = {
   /** Circle's subscription fee. */
-  amount?: InputMaybe<Scalars['Float']['input']>;
+  amount?: InputMaybe<Scalars['Float']['input']>
   /** Unique ID of a Circle's avatar. */
-  avatar?: InputMaybe<Scalars['ID']['input']>;
+  avatar?: InputMaybe<Scalars['ID']['input']>
   /** Unique ID of a Circle's cover. */
-  cover?: InputMaybe<Scalars['ID']['input']>;
+  cover?: InputMaybe<Scalars['ID']['input']>
   /** A short description of this Circle. */
-  description?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>
   /** Human readable name of this Circle. */
-  displayName?: InputMaybe<Scalars['String']['input']>;
+  displayName?: InputMaybe<Scalars['String']['input']>
   /** Unique ID. */
-  id?: InputMaybe<Scalars['ID']['input']>;
+  id?: InputMaybe<Scalars['ID']['input']>
   /** Slugified name of a Circle. */
-  name?: InputMaybe<Scalars['String']['input']>;
-};
+  name?: InputMaybe<Scalars['String']['input']>
+}
 
 export type GQLPutCollectionInput = {
-  cover?: InputMaybe<Scalars['ID']['input']>;
-  description?: InputMaybe<Scalars['String']['input']>;
-  id?: InputMaybe<Scalars['ID']['input']>;
-  pinned?: InputMaybe<Scalars['Boolean']['input']>;
-  title?: InputMaybe<Scalars['String']['input']>;
-};
+  cover?: InputMaybe<Scalars['ID']['input']>
+  description?: InputMaybe<Scalars['String']['input']>
+  id?: InputMaybe<Scalars['ID']['input']>
+  pinned?: InputMaybe<Scalars['Boolean']['input']>
+  title?: InputMaybe<Scalars['String']['input']>
+}
 
 export type GQLPutCommentInput = {
-  comment: GQLCommentInput;
-  id?: InputMaybe<Scalars['ID']['input']>;
-};
+  comment: GQLCommentInput
+  id?: InputMaybe<Scalars['ID']['input']>
+}
 
 export type GQLPutCurationChannelInput = {
-  activePeriod?: InputMaybe<GQLDatetimeRangeInput>;
-  color?: InputMaybe<GQLColor>;
-  id?: InputMaybe<Scalars['ID']['input']>;
-  name?: InputMaybe<Array<GQLTranslationInput>>;
-  navbarTitle?: InputMaybe<Array<GQLTranslationInput>>;
-  note?: InputMaybe<Array<GQLTranslationInput>>;
-  pinAmount?: InputMaybe<Scalars['Int']['input']>;
-  showRecommendation?: InputMaybe<Scalars['Boolean']['input']>;
-  state?: InputMaybe<GQLCurationChannelState>;
-};
+  activePeriod?: InputMaybe<GQLDatetimeRangeInput>
+  color?: InputMaybe<GQLColor>
+  id?: InputMaybe<Scalars['ID']['input']>
+  name?: InputMaybe<Array<GQLTranslationInput>>
+  navbarTitle?: InputMaybe<Array<GQLTranslationInput>>
+  note?: InputMaybe<Array<GQLTranslationInput>>
+  pinAmount?: InputMaybe<Scalars['Int']['input']>
+  showRecommendation?: InputMaybe<Scalars['Boolean']['input']>
+  state?: InputMaybe<GQLCurationChannelState>
+}
 
 export type GQLPutDraftInput = {
-  accessType?: InputMaybe<GQLArticleAccessType>;
+  accessType?: InputMaybe<GQLArticleAccessType>
   /** Which campaigns to attach */
-  campaigns?: InputMaybe<Array<GQLArticleCampaignInput>>;
+  campaigns?: InputMaybe<Array<GQLArticleCampaignInput>>
   /** Whether readers can comment */
-  canComment?: InputMaybe<Scalars['Boolean']['input']>;
-  circle?: InputMaybe<Scalars['ID']['input']>;
+  canComment?: InputMaybe<Scalars['Boolean']['input']>
+  circle?: InputMaybe<Scalars['ID']['input']>
   /** Deprecated, use connections instead */
-  collection?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  collection?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>
   /** Add article to these collections when published */
-  collections?: InputMaybe<Array<Scalars['ID']['input']>>;
-  connections?: InputMaybe<Array<Scalars['ID']['input']>>;
-  content?: InputMaybe<Scalars['String']['input']>;
-  cover?: InputMaybe<Scalars['ID']['input']>;
-  id?: InputMaybe<Scalars['ID']['input']>;
-  indentFirstLine?: InputMaybe<Scalars['Boolean']['input']>;
+  collections?: InputMaybe<Array<Scalars['ID']['input']>>
+  connections?: InputMaybe<Array<Scalars['ID']['input']>>
+  content?: InputMaybe<Scalars['String']['input']>
+  cover?: InputMaybe<Scalars['ID']['input']>
+  id?: InputMaybe<Scalars['ID']['input']>
+  indentFirstLine?: InputMaybe<Scalars['Boolean']['input']>
   /** Whether publish to ISCN */
-  iscnPublish?: InputMaybe<Scalars['Boolean']['input']>;
+  iscnPublish?: InputMaybe<Scalars['Boolean']['input']>
   /** Last known update timestamp for version conflict detection */
-  lastUpdatedAt?: InputMaybe<Scalars['DateTime']['input']>;
-  license?: InputMaybe<GQLArticleLicenseType>;
-  replyToDonator?: InputMaybe<Scalars['String']['input']>;
-  requestForDonation?: InputMaybe<Scalars['String']['input']>;
-  sensitive?: InputMaybe<Scalars['Boolean']['input']>;
-  summary?: InputMaybe<Scalars['String']['input']>;
-  tags?: InputMaybe<Array<Scalars['String']['input']>>;
-  title?: InputMaybe<Scalars['String']['input']>;
-};
+  lastUpdatedAt?: InputMaybe<Scalars['DateTime']['input']>
+  license?: InputMaybe<GQLArticleLicenseType>
+  replyToDonator?: InputMaybe<Scalars['String']['input']>
+  requestForDonation?: InputMaybe<Scalars['String']['input']>
+  sensitive?: InputMaybe<Scalars['Boolean']['input']>
+  summary?: InputMaybe<Scalars['String']['input']>
+  tags?: InputMaybe<Array<Scalars['String']['input']>>
+  title?: InputMaybe<Scalars['String']['input']>
+}
 
 export type GQLPutIcymiTopicInput = {
-  articles?: InputMaybe<Array<Scalars['ID']['input']>>;
-  id?: InputMaybe<Scalars['ID']['input']>;
-  note?: InputMaybe<Array<GQLTranslationInput>>;
-  pinAmount?: InputMaybe<Scalars['Int']['input']>;
-  state?: InputMaybe<GQLIcymiTopicState>;
-  title?: InputMaybe<Array<GQLTranslationInput>>;
-};
+  articles?: InputMaybe<Array<Scalars['ID']['input']>>
+  id?: InputMaybe<Scalars['ID']['input']>
+  note?: InputMaybe<Array<GQLTranslationInput>>
+  pinAmount?: InputMaybe<Scalars['Int']['input']>
+  state?: InputMaybe<GQLIcymiTopicState>
+  title?: InputMaybe<Array<GQLTranslationInput>>
+}
 
 export type GQLPutMomentInput = {
-  articles?: InputMaybe<Array<Scalars['ID']['input']>>;
-  assets?: InputMaybe<Array<Scalars['ID']['input']>>;
-  content: Scalars['String']['input'];
-  tags?: InputMaybe<Array<Scalars['String']['input']>>;
-};
+  articles?: InputMaybe<Array<Scalars['ID']['input']>>
+  assets?: InputMaybe<Array<Scalars['ID']['input']>>
+  content: Scalars['String']['input']
+  tags?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type GQLPutOAuthClientInput = {
-  avatar?: InputMaybe<Scalars['ID']['input']>;
-  description?: InputMaybe<Scalars['String']['input']>;
-  grantTypes?: InputMaybe<Array<GQLGrantType>>;
-  id?: InputMaybe<Scalars['ID']['input']>;
-  name?: InputMaybe<Scalars['String']['input']>;
-  redirectURIs?: InputMaybe<Array<Scalars['String']['input']>>;
-  scope?: InputMaybe<Array<Scalars['String']['input']>>;
-  secret?: InputMaybe<Scalars['String']['input']>;
-  user?: InputMaybe<Scalars['ID']['input']>;
-  website?: InputMaybe<Scalars['String']['input']>;
-};
+  avatar?: InputMaybe<Scalars['ID']['input']>
+  description?: InputMaybe<Scalars['String']['input']>
+  grantTypes?: InputMaybe<Array<GQLGrantType>>
+  id?: InputMaybe<Scalars['ID']['input']>
+  name?: InputMaybe<Scalars['String']['input']>
+  redirectURIs?: InputMaybe<Array<Scalars['String']['input']>>
+  scope?: InputMaybe<Array<Scalars['String']['input']>>
+  secret?: InputMaybe<Scalars['String']['input']>
+  user?: InputMaybe<Scalars['ID']['input']>
+  website?: InputMaybe<Scalars['String']['input']>
+}
 
 export type GQLPutQuoteInput = {
-  articleId: Scalars['ID']['input'];
-  content: Scalars['String']['input'];
-};
+  articleId: Scalars['ID']['input']
+  content: Scalars['String']['input']
+}
 
 export type GQLPutRemarkInput = {
-  id: Scalars['ID']['input'];
-  remark: Scalars['String']['input'];
-  type: GQLRemarkTypes;
-};
+  id: Scalars['ID']['input']
+  remark: Scalars['String']['input']
+  type: GQLRemarkTypes
+}
 
 export type GQLPutRestrictedUsersInput = {
-  ids: Array<Scalars['ID']['input']>;
-  restrictions: Array<GQLUserRestrictionType>;
-};
+  ids: Array<Scalars['ID']['input']>
+  restrictions: Array<GQLUserRestrictionType>
+}
 
 export type GQLPutSkippedListItemInput = {
-  archived?: InputMaybe<Scalars['Boolean']['input']>;
-  id?: InputMaybe<Scalars['ID']['input']>;
-  type?: InputMaybe<GQLSkippedListItemType>;
-  value?: InputMaybe<Scalars['String']['input']>;
-};
+  archived?: InputMaybe<Scalars['Boolean']['input']>
+  id?: InputMaybe<Scalars['ID']['input']>
+  type?: InputMaybe<GQLSkippedListItemType>
+  value?: InputMaybe<Scalars['String']['input']>
+}
 
 export type GQLPutTagChannelInput = {
-  enabled?: InputMaybe<Scalars['Boolean']['input']>;
-  id: Scalars['ID']['input'];
-  navbarTitle?: InputMaybe<Array<GQLTranslationInput>>;
-};
+  enabled?: InputMaybe<Scalars['Boolean']['input']>
+  id: Scalars['ID']['input']
+  navbarTitle?: InputMaybe<Array<GQLTranslationInput>>
+}
 
 export type GQLPutTopicChannelInput = {
-  enabled?: InputMaybe<Scalars['Boolean']['input']>;
-  id?: InputMaybe<Scalars['ID']['input']>;
-  name?: InputMaybe<Array<GQLTranslationInput>>;
-  navbarTitle?: InputMaybe<Array<GQLTranslationInput>>;
-  note?: InputMaybe<Array<GQLTranslationInput>>;
-  providerId?: InputMaybe<Scalars['String']['input']>;
-  subChannels?: InputMaybe<Array<Scalars['ID']['input']>>;
-};
+  enabled?: InputMaybe<Scalars['Boolean']['input']>
+  id?: InputMaybe<Scalars['ID']['input']>
+  name?: InputMaybe<Array<GQLTranslationInput>>
+  navbarTitle?: InputMaybe<Array<GQLTranslationInput>>
+  note?: InputMaybe<Array<GQLTranslationInput>>
+  providerId?: InputMaybe<Scalars['String']['input']>
+  subChannels?: InputMaybe<Array<Scalars['ID']['input']>>
+}
 
 export type GQLPutUserFeatureFlagsInput = {
-  flags: Array<GQLUserFeatureFlagType>;
-  ids: Array<Scalars['ID']['input']>;
-};
+  flags: Array<GQLUserFeatureFlagType>
+  ids: Array<Scalars['ID']['input']>
+}
 
 export type GQLPutUserFederationSettingInput = {
-  id: Scalars['ID']['input'];
-  state: GQLFederationAuthorSettingState;
-};
+  id: Scalars['ID']['input']
+  state: GQLFederationAuthorSettingState
+}
 
 export type GQLPutWritingChallengeInput = {
-  announcements?: InputMaybe<Array<Scalars['ID']['input']>>;
-  applicationPeriod?: InputMaybe<GQLDatetimeRangeInput>;
-  channelEnabled?: InputMaybe<Scalars['Boolean']['input']>;
-  cover?: InputMaybe<Scalars['ID']['input']>;
-  description?: InputMaybe<Array<GQLTranslationInput>>;
+  announcements?: InputMaybe<Array<Scalars['ID']['input']>>
+  applicationPeriod?: InputMaybe<GQLDatetimeRangeInput>
+  channelEnabled?: InputMaybe<Scalars['Boolean']['input']>
+  cover?: InputMaybe<Scalars['ID']['input']>
+  description?: InputMaybe<Array<GQLTranslationInput>>
   /** enable the quote wall (post-to-wall) for this campaign */
-  enableQuoteWall?: InputMaybe<Scalars['Boolean']['input']>;
+  enableQuoteWall?: InputMaybe<Scalars['Boolean']['input']>
   /** exclude articles of this campaign in topic channels and newest */
-  exclusive?: InputMaybe<Scalars['Boolean']['input']>;
-  featuredDescription?: InputMaybe<Array<GQLTranslationInput>>;
-  id?: InputMaybe<Scalars['ID']['input']>;
-  link?: InputMaybe<Scalars['String']['input']>;
-  managers?: InputMaybe<Array<Scalars['ID']['input']>>;
-  name?: InputMaybe<Array<GQLTranslationInput>>;
-  navbarTitle?: InputMaybe<Array<GQLTranslationInput>>;
-  newStages?: InputMaybe<Array<GQLCampaignStageInput>>;
-  organizers?: InputMaybe<Array<Scalars['ID']['input']>>;
-  showAd?: InputMaybe<Scalars['Boolean']['input']>;
-  showOther?: InputMaybe<Scalars['Boolean']['input']>;
-  stages?: InputMaybe<Array<GQLCampaignStageInput>>;
-  state?: InputMaybe<GQLCampaignState>;
-  writingPeriod?: InputMaybe<GQLDatetimeRangeInput>;
-};
+  exclusive?: InputMaybe<Scalars['Boolean']['input']>
+  featuredDescription?: InputMaybe<Array<GQLTranslationInput>>
+  id?: InputMaybe<Scalars['ID']['input']>
+  link?: InputMaybe<Scalars['String']['input']>
+  managers?: InputMaybe<Array<Scalars['ID']['input']>>
+  name?: InputMaybe<Array<GQLTranslationInput>>
+  navbarTitle?: InputMaybe<Array<GQLTranslationInput>>
+  newStages?: InputMaybe<Array<GQLCampaignStageInput>>
+  organizers?: InputMaybe<Array<Scalars['ID']['input']>>
+  showAd?: InputMaybe<Scalars['Boolean']['input']>
+  showOther?: InputMaybe<Scalars['Boolean']['input']>
+  stages?: InputMaybe<Array<GQLCampaignStageInput>>
+  state?: InputMaybe<GQLCampaignState>
+  writingPeriod?: InputMaybe<GQLDatetimeRangeInput>
+}
 
 export type GQLQuery = {
-  __typename?: 'Query';
-  article?: Maybe<GQLArticle>;
-  campaign?: Maybe<GQLCampaign>;
-  campaignOrganizers: GQLUserConnection;
-  campaigns: GQLCampaignConnection;
-  channel?: Maybe<GQLChannel>;
-  channels: Array<GQLChannel>;
-  circle?: Maybe<GQLCircle>;
+  __typename?: 'Query'
+  article?: Maybe<GQLArticle>
+  campaign?: Maybe<GQLCampaign>
+  campaignOrganizers: GQLUserConnection
+  campaigns: GQLCampaignConnection
+  channel?: Maybe<GQLChannel>
+  channels: Array<GQLChannel>
+  circle?: Maybe<GQLCircle>
   /** One public Community Watch audit record. */
-  communityWatchAction?: Maybe<GQLCommunityWatchAction>;
+  communityWatchAction?: Maybe<GQLCommunityWatchAction>
   /** Recent public Community Watch audit records. */
-  communityWatchActions: GQLCommunityWatchActionConnection;
-  exchangeRates?: Maybe<Array<GQLExchangeRate>>;
-  frequentSearch?: Maybe<Array<Scalars['String']['output']>>;
-  moment?: Maybe<GQLMoment>;
-  node?: Maybe<GQLNode>;
-  nodes?: Maybe<Array<GQLNode>>;
-  oauthClient?: Maybe<GQLOAuthClient>;
-  oauthRequestToken?: Maybe<Scalars['String']['output']>;
-  official: GQLOfficial;
-  oss: GQLOss;
-  search: GQLSearchResultConnection;
-  user?: Maybe<GQLUser>;
-  viewer?: Maybe<GQLUser>;
-};
-
+  communityWatchActions: GQLCommunityWatchActionConnection
+  exchangeRates?: Maybe<Array<GQLExchangeRate>>
+  frequentSearch?: Maybe<Array<Scalars['String']['output']>>
+  moment?: Maybe<GQLMoment>
+  node?: Maybe<GQLNode>
+  nodes?: Maybe<Array<GQLNode>>
+  oauthClient?: Maybe<GQLOAuthClient>
+  oauthRequestToken?: Maybe<Scalars['String']['output']>
+  official: GQLOfficial
+  oss: GQLOss
+  search: GQLSearchResultConnection
+  user?: Maybe<GQLUser>
+  viewer?: Maybe<GQLUser>
+}
 
 export type GQLQueryArticleArgs = {
-  input: GQLArticleInput;
-};
-
+  input: GQLArticleInput
+}
 
 export type GQLQueryCampaignArgs = {
-  input: GQLCampaignInput;
-};
-
+  input: GQLCampaignInput
+}
 
 export type GQLQueryCampaignOrganizersArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLQueryCampaignsArgs = {
-  input: GQLCampaignsInput;
-};
-
+  input: GQLCampaignsInput
+}
 
 export type GQLQueryChannelArgs = {
-  input: GQLChannelInput;
-};
-
+  input: GQLChannelInput
+}
 
 export type GQLQueryChannelsArgs = {
-  input?: InputMaybe<GQLChannelsInput>;
-};
-
+  input?: InputMaybe<GQLChannelsInput>
+}
 
 export type GQLQueryCircleArgs = {
-  input: GQLCircleInput;
-};
-
+  input: GQLCircleInput
+}
 
 export type GQLQueryCommunityWatchActionArgs = {
-  input: GQLCommunityWatchActionInput;
-};
-
+  input: GQLCommunityWatchActionInput
+}
 
 export type GQLQueryCommunityWatchActionsArgs = {
-  input: GQLCommunityWatchActionsInput;
-};
-
+  input: GQLCommunityWatchActionsInput
+}
 
 export type GQLQueryExchangeRatesArgs = {
-  input?: InputMaybe<GQLExchangeRatesInput>;
-};
-
+  input?: InputMaybe<GQLExchangeRatesInput>
+}
 
 export type GQLQueryFrequentSearchArgs = {
-  input: GQLFrequentSearchInput;
-};
-
+  input: GQLFrequentSearchInput
+}
 
 export type GQLQueryMomentArgs = {
-  input: GQLMomentInput;
-};
-
+  input: GQLMomentInput
+}
 
 export type GQLQueryNodeArgs = {
-  input: GQLNodeInput;
-};
-
+  input: GQLNodeInput
+}
 
 export type GQLQueryNodesArgs = {
-  input: GQLNodesInput;
-};
-
+  input: GQLNodesInput
+}
 
 export type GQLQueryOauthClientArgs = {
-  input: GQLOAuthClientInput;
-};
-
+  input: GQLOAuthClientInput
+}
 
 export type GQLQuerySearchArgs = {
-  input: GQLSearchInput;
-};
-
+  input: GQLSearchInput
+}
 
 export type GQLQueryUserArgs = {
-  input: GQLUserInput;
-};
+  input: GQLUserInput
+}
 
 export type GQLQuote = {
-  __typename?: 'Quote';
-  article: GQLArticle;
-  content: Scalars['String']['output'];
-  createdAt: Scalars['DateTime']['output'];
-  id: Scalars['ID']['output'];
+  __typename?: 'Quote'
+  article: GQLArticle
+  content: Scalars['String']['output']
+  createdAt: Scalars['DateTime']['output']
+  id: Scalars['ID']['output']
   /** the user who posted this quote onto the wall */
-  poster: GQLUser;
-};
+  poster: GQLUser
+}
 
 export type GQLQuoteConnection = GQLConnection & {
-  __typename?: 'QuoteConnection';
-  edges?: Maybe<Array<GQLQuoteEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'QuoteConnection'
+  edges?: Maybe<Array<GQLQuoteEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
-export type GQLQuoteCurrency =
-  | 'HKD'
-  | 'TWD'
-  | 'USD';
+export type GQLQuoteCurrency = 'HKD' | 'TWD' | 'USD'
 
 export type GQLQuoteEdge = {
-  __typename?: 'QuoteEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLQuote;
-};
+  __typename?: 'QuoteEdge'
+  cursor: Scalars['String']['output']
+  node: GQLQuote
+}
 
 export type GQLQuotesInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
+  after?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
   /** random sampling for wall display; refetch to shuffle. when true, after is ignored */
-  random?: InputMaybe<Scalars['Boolean']['input']>;
-};
+  random?: InputMaybe<Scalars['Boolean']['input']>
+}
 
 export type GQLReadArticleInput = {
-  id: Scalars['ID']['input'];
-};
+  id: Scalars['ID']['input']
+}
 
 export type GQLReadHistory = {
-  __typename?: 'ReadHistory';
-  article: GQLArticle;
-  readAt: Scalars['DateTime']['output'];
-};
+  __typename?: 'ReadHistory'
+  article: GQLArticle
+  readAt: Scalars['DateTime']['output']
+}
 
 export type GQLReadHistoryConnection = GQLConnection & {
-  __typename?: 'ReadHistoryConnection';
-  edges?: Maybe<Array<GQLReadHistoryEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'ReadHistoryConnection'
+  edges?: Maybe<Array<GQLReadHistoryEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLReadHistoryEdge = {
-  __typename?: 'ReadHistoryEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLReadHistory;
-};
+  __typename?: 'ReadHistoryEdge'
+  cursor: Scalars['String']['output']
+  node: GQLReadHistory
+}
 
 export type GQLRecentSearchConnection = GQLConnection & {
-  __typename?: 'RecentSearchConnection';
-  edges?: Maybe<Array<GQLRecentSearchEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'RecentSearchConnection'
+  edges?: Maybe<Array<GQLRecentSearchEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLRecentSearchEdge = {
-  __typename?: 'RecentSearchEdge';
-  cursor: Scalars['String']['output'];
-  node: Scalars['String']['output'];
-};
+  __typename?: 'RecentSearchEdge'
+  cursor: Scalars['String']['output']
+  node: Scalars['String']['output']
+}
 
 export type GQLRecommendFilterInput = {
-  channel?: InputMaybe<GQLIdentityInput>;
+  channel?: InputMaybe<GQLIdentityInput>
   /** filter out followed users */
-  followed?: InputMaybe<Scalars['Boolean']['input']>;
+  followed?: InputMaybe<Scalars['Boolean']['input']>
   /** index of list, min: 0, max: 49 */
-  random?: InputMaybe<Scalars['Int']['input']>;
-};
+  random?: InputMaybe<Scalars['Int']['input']>
+}
 
 export type GQLRecommendInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<GQLRecommendFilterInput>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  newAlgo?: InputMaybe<Scalars['Boolean']['input']>;
-  oss?: InputMaybe<Scalars['Boolean']['input']>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<GQLRecommendFilterInput>
+  first?: InputMaybe<Scalars['Int']['input']>
+  newAlgo?: InputMaybe<Scalars['Boolean']['input']>
+  oss?: InputMaybe<Scalars['Boolean']['input']>
+}
 
 /** Enums for types of recommend articles. */
-export type GQLRecommendTypes =
-  | 'hottest'
-  | 'icymi'
-  | 'newest'
-  | 'search';
+export type GQLRecommendTypes = 'hottest' | 'icymi' | 'newest' | 'search'
 
 export type GQLRecommendation = {
-  __typename?: 'Recommendation';
+  __typename?: 'Recommendation'
   /** Global user list, sort by activities in recent 6 month. */
-  authors: GQLUserConnection;
+  authors: GQLUserConnection
   /** Activities based on user's following, sort by creation time. */
-  following: GQLFollowingActivityConnection;
+  following: GQLFollowingActivityConnection
   /** Global articles sort by latest activity time. */
-  hottest: GQLArticleConnection;
-  hottestMoments: GQLMomentConnection;
+  hottest: GQLArticleConnection
+  hottestMoments: GQLMomentConnection
   /** 'In case you missed it' recommendation. */
-  icymi: GQLArticleConnection;
+  icymi: GQLArticleConnection
   /** 'In case you missed it' topic. */
-  icymiTopic?: Maybe<GQLIcymiTopic>;
+  icymiTopic?: Maybe<GQLIcymiTopic>
   /** Global articles sort by publish time. */
-  newest: GQLArticleConnection;
+  newest: GQLArticleConnection
   /** Global tag list, sort by activities in recent 14 days. */
-  tags: GQLTagConnection;
-};
-
+  tags: GQLTagConnection
+}
 
 export type GQLRecommendationAuthorsArgs = {
-  input: GQLRecommendInput;
-};
-
+  input: GQLRecommendInput
+}
 
 export type GQLRecommendationFollowingArgs = {
-  input: GQLRecommendationFollowingInput;
-};
-
+  input: GQLRecommendationFollowingInput
+}
 
 export type GQLRecommendationHottestArgs = {
-  input: GQLRecommendInput;
-};
-
+  input: GQLRecommendInput
+}
 
 export type GQLRecommendationHottestMomentsArgs = {
-  input: GQLRecommendInput;
-};
-
+  input: GQLRecommendInput
+}
 
 export type GQLRecommendationIcymiArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLRecommendationNewestArgs = {
-  input: GQLRecommendationNewestInput;
-};
-
+  input: GQLRecommendationNewestInput
+}
 
 export type GQLRecommendationTagsArgs = {
-  input: GQLRecommendInput;
-};
+  input: GQLRecommendInput
+}
 
 export type GQLRecommendationFollowingFilterInput = {
-  type?: InputMaybe<GQLRecommendationFollowingFilterType>;
-};
+  type?: InputMaybe<GQLRecommendationFollowingFilterType>
+}
 
-export type GQLRecommendationFollowingFilterType =
-  | 'article';
+export type GQLRecommendationFollowingFilterType = 'article'
 
 export type GQLRecommendationFollowingInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<GQLRecommendationFollowingFilterInput>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<GQLRecommendationFollowingFilterInput>
+  first?: InputMaybe<Scalars['Int']['input']>
+}
 
 export type GQLRecommendationNewestInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  excludeChannelArticles?: InputMaybe<Scalars['Boolean']['input']>;
-  filter?: InputMaybe<GQLFilterInput>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  oss?: InputMaybe<Scalars['Boolean']['input']>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  excludeChannelArticles?: InputMaybe<Scalars['Boolean']['input']>
+  filter?: InputMaybe<GQLFilterInput>
+  first?: InputMaybe<Scalars['Int']['input']>
+  oss?: InputMaybe<Scalars['Boolean']['input']>
+}
 
 export type GQLRefreshIpnsFeedInput = {
   /** refresh how many recent articles, default to 50 */
-  numArticles?: InputMaybe<Scalars['Int']['input']>;
-  userName: Scalars['String']['input'];
-};
+  numArticles?: InputMaybe<Scalars['Int']['input']>
+  userName: Scalars['String']['input']
+}
 
 export type GQLRelatedDonationArticlesInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  oss?: InputMaybe<Scalars['Boolean']['input']>;
+  after?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  oss?: InputMaybe<Scalars['Boolean']['input']>
   /** index of article list, min: 0, max: 49 */
-  random?: InputMaybe<Scalars['Int']['input']>;
-};
+  random?: InputMaybe<Scalars['Int']['input']>
+}
 
 export type GQLRemarkTypes =
   | 'Article'
@@ -4146,57 +3969,59 @@ export type GQLRemarkTypes =
   | 'Feedback'
   | 'Report'
   | 'Tag'
-  | 'User';
+  | 'User'
 
 export type GQLRemoveSocialLoginInput = {
-  type: GQLSocialAccountType;
-};
+  type: GQLSocialAccountType
+}
 
 export type GQLRenameTagInput = {
-  content: Scalars['String']['input'];
-  id: Scalars['ID']['input'];
-};
+  content: Scalars['String']['input']
+  id: Scalars['ID']['input']
+}
 
 export type GQLReorderChannelsInput = {
-  ids: Array<Scalars['ID']['input']>;
-};
+  ids: Array<Scalars['ID']['input']>
+}
 
 export type GQLReorderCollectionArticlesInput = {
-  collection: Scalars['ID']['input'];
-  moves: Array<GQLReorderMoveInput>;
-};
+  collection: Scalars['ID']['input']
+  moves: Array<GQLReorderMoveInput>
+}
 
 export type GQLReorderMoveInput = {
-  item: Scalars['ID']['input'];
+  item: Scalars['ID']['input']
   /** The new position move to. To move item to the beginning of the list, set to 0. To the end of the list, set to the length of the list - 1. */
-  newPosition: Scalars['Int']['input'];
-};
+  newPosition: Scalars['Int']['input']
+}
 
 export type GQLReport = GQLNode & {
-  __typename?: 'Report';
+  __typename?: 'Report'
   /** The audit record when this report originates from a community watch action. */
-  communityWatchAction?: Maybe<GQLCommunityWatchAction>;
-  createdAt: Scalars['DateTime']['output'];
-  id: Scalars['ID']['output'];
-  reason: GQLReportReason;
-  reporter: GQLUser;
+  communityWatchAction?: Maybe<GQLCommunityWatchAction>
+  createdAt: Scalars['DateTime']['output']
+  id: Scalars['ID']['output']
+  /** Structured moderation case summary for OSS review and transparency reporting. */
+  moderationCase?: Maybe<GQLModerationCase>
+  reason: GQLReportReason
+  reporter: GQLUser
   /** Whether this record originates from a direct in-site report or a community watch action. */
-  source: GQLReportSource;
-  target: GQLNode;
-};
+  source: GQLReportSource
+  target: GQLNode
+}
 
 export type GQLReportConnection = GQLConnection & {
-  __typename?: 'ReportConnection';
-  edges?: Maybe<Array<GQLReportEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'ReportConnection'
+  edges?: Maybe<Array<GQLReportEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLReportEdge = {
-  __typename?: 'ReportEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLReport;
-};
+  __typename?: 'ReportEdge'
+  cursor: Scalars['String']['output']
+  node: GQLReport
+}
 
 export type GQLReportReason =
   /** Pornographic/adult advertising flagged by a community watch member. */
@@ -4207,369 +4032,347 @@ export type GQLReportReason =
   | 'illegal_advertising'
   | 'other'
   | 'pornography_involving_minors'
-  | 'tort';
+  | 'tort'
 
 export type GQLReportSource =
   /** Created automatically when a community watch member removes a comment. */
   | 'community_watch'
   /** Submitted directly via the in-site report form. */
-  | 'direct';
+  | 'direct'
 
 export type GQLResetLikerIdInput = {
-  id: Scalars['ID']['input'];
-};
+  id: Scalars['ID']['input']
+}
 
 export type GQLResetPasswordInput = {
-  codeId: Scalars['ID']['input'];
-  password: Scalars['String']['input'];
-  type?: InputMaybe<GQLResetPasswordType>;
-};
+  codeId: Scalars['ID']['input']
+  password: Scalars['String']['input']
+  type?: InputMaybe<GQLResetPasswordType>
+}
 
-export type GQLResetPasswordType =
-  | 'account'
-  | 'payment';
+export type GQLResetPasswordType = 'account' | 'payment'
 
-export type GQLResponse = GQLArticle | GQLComment;
+export type GQLResponse = GQLArticle | GQLComment
 
 export type GQLResponseConnection = GQLConnection & {
-  __typename?: 'ResponseConnection';
-  edges?: Maybe<Array<GQLResponseEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'ResponseConnection'
+  edges?: Maybe<Array<GQLResponseEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLResponseEdge = {
-  __typename?: 'ResponseEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLResponse;
-};
+  __typename?: 'ResponseEdge'
+  cursor: Scalars['String']['output']
+  node: GQLResponse
+}
 
 /** Enums for sorting responses. */
-export type GQLResponseSort =
-  | 'newest'
-  | 'oldest';
+export type GQLResponseSort = 'newest' | 'oldest'
 
 export type GQLResponsesInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  articleOnly?: InputMaybe<Scalars['Boolean']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  includeAfter?: InputMaybe<Scalars['Boolean']['input']>;
-  includeBefore?: InputMaybe<Scalars['Boolean']['input']>;
-  sort?: InputMaybe<GQLResponseSort>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  articleOnly?: InputMaybe<Scalars['Boolean']['input']>
+  before?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  includeAfter?: InputMaybe<Scalars['Boolean']['input']>
+  includeBefore?: InputMaybe<Scalars['Boolean']['input']>
+  sort?: InputMaybe<GQLResponseSort>
+}
 
 export type GQLRestoreCommunityWatchCommentInput = {
-  note?: InputMaybe<Scalars['String']['input']>;
-  uuid: Scalars['ID']['input'];
-};
+  note?: InputMaybe<Scalars['String']['input']>
+  uuid: Scalars['ID']['input']
+}
 
 export type GQLReviewTopicChannelFeedbackInput = {
-  action: GQLTopicChannelFeedbackAction;
-  feedback: Scalars['ID']['input'];
-};
+  action: GQLTopicChannelFeedbackAction
+  feedback: Scalars['ID']['input']
+}
 
 /** Enums for user roles. */
-export type GQLRole =
-  | 'admin'
-  | 'user'
-  | 'vistor';
+export type GQLRole = 'admin' | 'user' | 'vistor'
 
-export type GQLSearchApiVersion =
-  | 'v20230301'
-  | 'v20230601';
+export type GQLSearchApiVersion = 'v20230301' | 'v20230601'
 
-export type GQLSearchExclude =
-  | 'blocked';
+export type GQLSearchExclude = 'blocked'
 
 export type GQLSearchFilter = {
-  authorId?: InputMaybe<Scalars['ID']['input']>;
-};
+  authorId?: InputMaybe<Scalars['ID']['input']>
+}
 
 export type GQLSearchInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
+  after?: InputMaybe<Scalars['String']['input']>
   /** specific condition for rule data out */
-  exclude?: InputMaybe<GQLSearchExclude>;
+  exclude?: InputMaybe<GQLSearchExclude>
   /** extra query filter for searching */
-  filter?: InputMaybe<GQLSearchFilter>;
-  first?: InputMaybe<Scalars['Int']['input']>;
+  filter?: InputMaybe<GQLSearchFilter>
+  first?: InputMaybe<Scalars['Int']['input']>
   /** should include tags used by author */
-  includeAuthorTags?: InputMaybe<Scalars['Boolean']['input']>;
+  includeAuthorTags?: InputMaybe<Scalars['Boolean']['input']>
   /** search keyword */
-  key: Scalars['String']['input'];
-  oss?: InputMaybe<Scalars['Boolean']['input']>;
-  quicksearch?: InputMaybe<Scalars['Boolean']['input']>;
+  key: Scalars['String']['input']
+  oss?: InputMaybe<Scalars['Boolean']['input']>
+  quicksearch?: InputMaybe<Scalars['Boolean']['input']>
   /** whether this search operation should be recorded in search history */
-  record?: InputMaybe<Scalars['Boolean']['input']>;
+  record?: InputMaybe<Scalars['Boolean']['input']>
   /** types of search target */
-  type: GQLSearchTypes;
-};
+  type: GQLSearchTypes
+}
 
 export type GQLSearchResultConnection = GQLConnection & {
-  __typename?: 'SearchResultConnection';
-  edges?: Maybe<Array<GQLSearchResultEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'SearchResultConnection'
+  edges?: Maybe<Array<GQLSearchResultEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLSearchResultEdge = {
-  __typename?: 'SearchResultEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLNode;
-};
+  __typename?: 'SearchResultEdge'
+  cursor: Scalars['String']['output']
+  node: GQLNode
+}
 
-export type GQLSearchTypes =
-  | 'Article'
-  | 'Tag'
-  | 'User';
+export type GQLSearchTypes = 'Article' | 'Tag' | 'User'
 
 export type GQLSendCampaignAnnouncementInput = {
-  announcement: Array<GQLTranslationInput>;
-  campaign: Scalars['ID']['input'];
-  link: Scalars['String']['input'];
-  password: Scalars['String']['input'];
-};
+  announcement: Array<GQLTranslationInput>
+  campaign: Scalars['ID']['input']
+  link: Scalars['String']['input']
+  password: Scalars['String']['input']
+}
 
 export type GQLSendVerificationCodeInput = {
-  email: Scalars['String']['input'];
+  email: Scalars['String']['input']
   /** email content language */
-  language?: InputMaybe<GQLUserLanguage>;
+  language?: InputMaybe<GQLUserLanguage>
   /**
    * Redirect URL embedded in the verification email,
    * use code instead if not provided.
    */
-  redirectUrl?: InputMaybe<Scalars['String']['input']>;
-  token?: InputMaybe<Scalars['String']['input']>;
-  type: GQLVerificationCodeType;
-};
+  redirectUrl?: InputMaybe<Scalars['String']['input']>
+  token?: InputMaybe<Scalars['String']['input']>
+  type: GQLVerificationCodeType
+}
 
 export type GQLSetAdStatusInput = {
-  id: Scalars['ID']['input'];
-  isAd: Scalars['Boolean']['input'];
-};
+  id: Scalars['ID']['input']
+  isAd: Scalars['Boolean']['input']
+}
 
 export type GQLSetArticleFederationSettingInput = {
-  id: Scalars['ID']['input'];
-  state: GQLFederationArticleSettingState;
-};
+  id: Scalars['ID']['input']
+  state: GQLFederationArticleSettingState
+}
 
 export type GQLSetArticleTopicChannelsInput = {
-  channels: Array<Scalars['ID']['input']>;
-  id: Scalars['ID']['input'];
-};
+  channels: Array<Scalars['ID']['input']>
+  id: Scalars['ID']['input']
+}
 
 export type GQLSetBoostInput = {
-  boost: Scalars['Float']['input'];
-  id: Scalars['ID']['input'];
-  type: GQLBoostTypes;
-};
+  boost: Scalars['Float']['input']
+  id: Scalars['ID']['input']
+  type: GQLBoostTypes
+}
 
 export type GQLSetCurrencyInput = {
-  currency?: InputMaybe<GQLQuoteCurrency>;
-};
+  currency?: InputMaybe<GQLQuoteCurrency>
+}
 
 export type GQLSetEmailInput = {
-  email: Scalars['String']['input'];
-};
+  email: Scalars['String']['input']
+}
 
 export type GQLSetFeatureInput = {
-  flag: GQLFeatureFlag;
-  name: GQLFeatureName;
-  value?: InputMaybe<Scalars['Float']['input']>;
-};
+  flag: GQLFeatureFlag
+  name: GQLFeatureName
+  value?: InputMaybe<Scalars['Float']['input']>
+}
 
 export type GQLSetPasswordInput = {
-  password: Scalars['String']['input'];
-};
+  password: Scalars['String']['input']
+}
 
 export type GQLSetSpamStatusInput = {
-  id: Scalars['ID']['input'];
-  isSpam: Scalars['Boolean']['input'];
-};
+  id: Scalars['ID']['input']
+  isSpam: Scalars['Boolean']['input']
+}
 
 export type GQLSetUserNameInput = {
-  userName: Scalars['String']['input'];
-};
+  userName: Scalars['String']['input']
+}
 
 export type GQLSetViewerFederationSettingInput = {
-  state: GQLFederationAuthorSettingState;
-};
+  state: GQLFederationAuthorSettingState
+}
 
 export type GQLSigningMessagePurpose =
   | 'airdrop'
   | 'claimLogbook'
   | 'connect'
   | 'login'
-  | 'signup';
+  | 'signup'
 
 export type GQLSigningMessageResult = {
-  __typename?: 'SigningMessageResult';
-  createdAt: Scalars['DateTime']['output'];
-  expiredAt: Scalars['DateTime']['output'];
-  nonce: Scalars['String']['output'];
-  purpose: GQLSigningMessagePurpose;
-  signingMessage: Scalars['String']['output'];
-};
+  __typename?: 'SigningMessageResult'
+  createdAt: Scalars['DateTime']['output']
+  expiredAt: Scalars['DateTime']['output']
+  nonce: Scalars['String']['output']
+  purpose: GQLSigningMessagePurpose
+  signingMessage: Scalars['String']['output']
+}
 
 export type GQLSingleFileUploadInput = {
-  draft?: InputMaybe<Scalars['Boolean']['input']>;
-  entityId?: InputMaybe<Scalars['ID']['input']>;
-  entityType: GQLEntityType;
-  file?: InputMaybe<Scalars['Upload']['input']>;
-  type: GQLAssetType;
-  url?: InputMaybe<Scalars['String']['input']>;
-};
+  draft?: InputMaybe<Scalars['Boolean']['input']>
+  entityId?: InputMaybe<Scalars['ID']['input']>
+  entityType: GQLEntityType
+  file?: InputMaybe<Scalars['Upload']['input']>
+  type: GQLAssetType
+  url?: InputMaybe<Scalars['String']['input']>
+}
 
 export type GQLSkippedListItem = {
-  __typename?: 'SkippedListItem';
-  archived: Scalars['Boolean']['output'];
-  createdAt: Scalars['DateTime']['output'];
-  id: Scalars['ID']['output'];
-  type: GQLSkippedListItemType;
-  updatedAt: Scalars['DateTime']['output'];
-  uuid: Scalars['ID']['output'];
-  value: Scalars['String']['output'];
-};
+  __typename?: 'SkippedListItem'
+  archived: Scalars['Boolean']['output']
+  createdAt: Scalars['DateTime']['output']
+  id: Scalars['ID']['output']
+  type: GQLSkippedListItemType
+  updatedAt: Scalars['DateTime']['output']
+  uuid: Scalars['ID']['output']
+  value: Scalars['String']['output']
+}
 
 export type GQLSkippedListItemEdge = {
-  __typename?: 'SkippedListItemEdge';
-  cursor: Scalars['String']['output'];
-  node?: Maybe<GQLSkippedListItem>;
-};
+  __typename?: 'SkippedListItemEdge'
+  cursor: Scalars['String']['output']
+  node?: Maybe<GQLSkippedListItem>
+}
 
-export type GQLSkippedListItemType =
-  | 'agent_hash'
-  | 'domain'
-  | 'email';
+export type GQLSkippedListItemType = 'agent_hash' | 'domain' | 'email'
 
 export type GQLSkippedListItemsConnection = GQLConnection & {
-  __typename?: 'SkippedListItemsConnection';
-  edges?: Maybe<Array<GQLSkippedListItemEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'SkippedListItemsConnection'
+  edges?: Maybe<Array<GQLSkippedListItemEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLSkippedListItemsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  type?: InputMaybe<GQLSkippedListItemType>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  type?: InputMaybe<GQLSkippedListItemType>
+}
 
 export type GQLSocialAccount = {
-  __typename?: 'SocialAccount';
-  email?: Maybe<Scalars['String']['output']>;
-  type: GQLSocialAccountType;
-  userName?: Maybe<Scalars['String']['output']>;
-};
+  __typename?: 'SocialAccount'
+  email?: Maybe<Scalars['String']['output']>
+  type: GQLSocialAccountType
+  userName?: Maybe<Scalars['String']['output']>
+}
 
-export type GQLSocialAccountType =
-  | 'Facebook'
-  | 'Google'
-  | 'Threads'
-  | 'Twitter';
+export type GQLSocialAccountType = 'Facebook' | 'Google' | 'Threads' | 'Twitter'
 
 export type GQLSocialLoginInput = {
-  authorizationCode?: InputMaybe<Scalars['String']['input']>;
+  authorizationCode?: InputMaybe<Scalars['String']['input']>
   /** OAuth2 PKCE code_verifier for Facebook and Twitter */
-  codeVerifier?: InputMaybe<Scalars['String']['input']>;
+  codeVerifier?: InputMaybe<Scalars['String']['input']>
   /** used in register */
-  language?: InputMaybe<GQLUserLanguage>;
+  language?: InputMaybe<GQLUserLanguage>
   /** OIDC nonce for Google */
-  nonce?: InputMaybe<Scalars['String']['input']>;
+  nonce?: InputMaybe<Scalars['String']['input']>
   /** oauth token/verifier in OAuth1.0a for Twitter */
-  oauth1Credential?: InputMaybe<GQLOauth1CredentialInput>;
+  oauth1Credential?: InputMaybe<GQLOauth1CredentialInput>
   /** Google OIDC redirect_uri for OSS SSO. When set, must be allowlisted; login is restricted to existing admin accounts and no new account is created. */
-  redirectUri?: InputMaybe<Scalars['String']['input']>;
-  referralCode?: InputMaybe<Scalars['String']['input']>;
-  type: GQLSocialAccountType;
-};
+  redirectUri?: InputMaybe<Scalars['String']['input']>
+  referralCode?: InputMaybe<Scalars['String']['input']>
+  type: GQLSocialAccountType
+}
 
 /**
  * A spam ring: a cluster of accounts posting the same templated abuse,
  * surfaced by the account-layer ring detector (軸一 D).
  */
 export type GQLSpamRing = GQLNode & {
-  __typename?: 'SpamRing';
-  detectedAt: Scalars['DateTime']['output'];
-  events: Array<GQLSpamRingEvent>;
+  __typename?: 'SpamRing'
+  detectedAt: Scalars['DateTime']['output']
+  events: Array<GQLSpamRingEvent>
   /** 模板/家族指紋（偵測 job 的歸群 key） */
-  fingerprint: Scalars['String']['output'];
-  firstSeenAt?: Maybe<Scalars['DateTime']['output']>;
-  frozenAt?: Maybe<Scalars['DateTime']['output']>;
-  frozenBy?: Maybe<GQLUser>;
-  id: Scalars['ID']['output'];
-  lastSeenAt?: Maybe<Scalars['DateTime']['output']>;
+  fingerprint: Scalars['String']['output']
+  firstSeenAt?: Maybe<Scalars['DateTime']['output']>
+  frozenAt?: Maybe<Scalars['DateTime']['output']>
+  frozenBy?: Maybe<GQLUser>
+  id: Scalars['ID']['output']
+  lastSeenAt?: Maybe<Scalars['DateTime']['output']>
   /** 列表渲染用的少量樣本，免分頁 */
-  memberSample: Array<GQLUser>;
+  memberSample: Array<GQLUser>
   /** 群內成員帳號（可分頁） */
-  members: GQLSpamRingMemberConnection;
-  nArticles: Scalars['Int']['output'];
-  nAuthors: Scalars['Int']['output'];
-  newAccountRatio?: Maybe<Scalars['Float']['output']>;
-  note?: Maybe<Scalars['String']['output']>;
-  score?: Maybe<Scalars['Float']['output']>;
-  severity?: Maybe<GQLSpamRingSeverity>;
-  signals: GQLSpamRingSignals;
-  status: GQLSpamRingStatus;
-};
-
+  members: GQLSpamRingMemberConnection
+  nArticles: Scalars['Int']['output']
+  nAuthors: Scalars['Int']['output']
+  newAccountRatio?: Maybe<Scalars['Float']['output']>
+  note?: Maybe<Scalars['String']['output']>
+  score?: Maybe<Scalars['Float']['output']>
+  severity?: Maybe<GQLSpamRingSeverity>
+  signals: GQLSpamRingSignals
+  status: GQLSpamRingStatus
+}
 
 /**
  * A spam ring: a cluster of accounts posting the same templated abuse,
  * surfaced by the account-layer ring detector (軸一 D).
  */
 export type GQLSpamRingMemberSampleArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-};
-
+  limit?: InputMaybe<Scalars['Int']['input']>
+}
 
 /**
  * A spam ring: a cluster of accounts posting the same templated abuse,
  * surfaced by the account-layer ring detector (軸一 D).
  */
 export type GQLSpamRingMembersArgs = {
-  input: GQLConnectionArgs;
-};
+  input: GQLConnectionArgs
+}
 
 export type GQLSpamRingCandidateInput = {
-  fingerprint: Scalars['String']['input'];
-  firstSeenAt?: InputMaybe<Scalars['DateTime']['input']>;
-  lastSeenAt?: InputMaybe<Scalars['DateTime']['input']>;
+  fingerprint: Scalars['String']['input']
+  firstSeenAt?: InputMaybe<Scalars['DateTime']['input']>
+  lastSeenAt?: InputMaybe<Scalars['DateTime']['input']>
   /** JSON string: map of user id -> evidence. */
-  memberEvidence?: InputMaybe<Scalars['String']['input']>;
+  memberEvidence?: InputMaybe<Scalars['String']['input']>
   /** Raw DB user ids (the detection job reads them from the replica). */
-  memberUserIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  memberUserNames?: InputMaybe<Array<Scalars['String']['input']>>;
-  nArticles: Scalars['Int']['input'];
-  nAuthors: Scalars['Int']['input'];
-  newAccountRatio?: InputMaybe<Scalars['Float']['input']>;
-  score?: InputMaybe<Scalars['Float']['input']>;
-  severity?: InputMaybe<GQLSpamRingSeverity>;
-  signals: GQLSpamRingSignalsInput;
-};
+  memberUserIds?: InputMaybe<Array<Scalars['String']['input']>>
+  memberUserNames?: InputMaybe<Array<Scalars['String']['input']>>
+  nArticles: Scalars['Int']['input']
+  nAuthors: Scalars['Int']['input']
+  newAccountRatio?: InputMaybe<Scalars['Float']['input']>
+  score?: InputMaybe<Scalars['Float']['input']>
+  severity?: InputMaybe<GQLSpamRingSeverity>
+  signals: GQLSpamRingSignalsInput
+}
 
 export type GQLSpamRingConnection = GQLConnection & {
-  __typename?: 'SpamRingConnection';
-  edges?: Maybe<Array<GQLSpamRingEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'SpamRingConnection'
+  edges?: Maybe<Array<GQLSpamRingEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLSpamRingEdge = {
-  __typename?: 'SpamRingEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLSpamRing;
-};
+  __typename?: 'SpamRingEdge'
+  cursor: Scalars['String']['output']
+  node: GQLSpamRing
+}
 
 export type GQLSpamRingEvent = {
-  __typename?: 'SpamRingEvent';
-  action: GQLSpamRingEventAction;
-  actor?: Maybe<GQLUser>;
-  createdAt: Scalars['DateTime']['output'];
+  __typename?: 'SpamRingEvent'
+  action: GQLSpamRingEventAction
+  actor?: Maybe<GQLUser>
+  createdAt: Scalars['DateTime']['output']
   /** JSON 字串 */
-  detail?: Maybe<Scalars['String']['output']>;
-  id: Scalars['ID']['output'];
-};
+  detail?: Maybe<Scalars['String']['output']>
+  id: Scalars['ID']['output']
+}
 
 export type GQLSpamRingEventAction =
   | 'detected'
@@ -4578,95 +4381,84 @@ export type GQLSpamRingEventAction =
   | 'member_banned'
   | 'member_restored'
   | 'member_skipped'
-  | 'unfrozen';
+  | 'unfrozen'
 
 export type GQLSpamRingMember = {
-  __typename?: 'SpamRingMember';
+  __typename?: 'SpamRingMember'
   /** 是否由本 ring 的凍結造成封禁（解凍時只還原此類） */
-  bannedByThisRing: Scalars['Boolean']['output'];
-  createdAt: Scalars['DateTime']['output'];
-  id: Scalars['ID']['output'];
-  skipReason?: Maybe<Scalars['String']['output']>;
-  status: GQLSpamRingMemberStatus;
-  user: GQLUser;
-};
+  bannedByThisRing: Scalars['Boolean']['output']
+  createdAt: Scalars['DateTime']['output']
+  id: Scalars['ID']['output']
+  skipReason?: Maybe<Scalars['String']['output']>
+  status: GQLSpamRingMemberStatus
+  user: GQLUser
+}
 
 export type GQLSpamRingMemberConnection = GQLConnection & {
-  __typename?: 'SpamRingMemberConnection';
-  edges?: Maybe<Array<GQLSpamRingMemberEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'SpamRingMemberConnection'
+  edges?: Maybe<Array<GQLSpamRingMemberEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLSpamRingMemberEdge = {
-  __typename?: 'SpamRingMemberEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLSpamRingMember;
-};
+  __typename?: 'SpamRingMemberEdge'
+  cursor: Scalars['String']['output']
+  node: GQLSpamRingMember
+}
 
 export type GQLSpamRingMemberStatus =
   | 'frozen'
   | 'pending'
   | 'restored'
-  | 'skipped';
+  | 'skipped'
 
-export type GQLSpamRingSeverity =
-  | 'critical'
-  | 'high'
-  | 'low'
-  | 'medium';
+export type GQLSpamRingSeverity = 'critical' | 'high' | 'low' | 'medium'
 
 export type GQLSpamRingSignals = {
-  __typename?: 'SpamRingSignals';
-  botUsernameRatio?: Maybe<Scalars['Float']['output']>;
-  contentModelMax?: Maybe<Scalars['Float']['output']>;
-  entityRingSize?: Maybe<Scalars['Int']['output']>;
-  nearDupRingSize?: Maybe<Scalars['Int']['output']>;
-  sampleBrands?: Maybe<Array<Scalars['String']['output']>>;
-  sampleCodes?: Maybe<Array<Scalars['String']['output']>>;
-  topEntity?: Maybe<Scalars['String']['output']>;
-};
+  __typename?: 'SpamRingSignals'
+  botUsernameRatio?: Maybe<Scalars['Float']['output']>
+  contentModelMax?: Maybe<Scalars['Float']['output']>
+  entityRingSize?: Maybe<Scalars['Int']['output']>
+  nearDupRingSize?: Maybe<Scalars['Int']['output']>
+  sampleBrands?: Maybe<Array<Scalars['String']['output']>>
+  sampleCodes?: Maybe<Array<Scalars['String']['output']>>
+  topEntity?: Maybe<Scalars['String']['output']>
+}
 
 export type GQLSpamRingSignalsInput = {
-  botUsernameRatio?: InputMaybe<Scalars['Float']['input']>;
-  contentModelMax?: InputMaybe<Scalars['Float']['input']>;
-  entityRingSize?: InputMaybe<Scalars['Int']['input']>;
-  nearDupRingSize?: InputMaybe<Scalars['Int']['input']>;
-  sampleBrands?: InputMaybe<Array<Scalars['String']['input']>>;
-  sampleCodes?: InputMaybe<Array<Scalars['String']['input']>>;
-  topEntity?: InputMaybe<Scalars['String']['input']>;
-};
+  botUsernameRatio?: InputMaybe<Scalars['Float']['input']>
+  contentModelMax?: InputMaybe<Scalars['Float']['input']>
+  entityRingSize?: InputMaybe<Scalars['Int']['input']>
+  nearDupRingSize?: InputMaybe<Scalars['Int']['input']>
+  sampleBrands?: InputMaybe<Array<Scalars['String']['input']>>
+  sampleCodes?: InputMaybe<Array<Scalars['String']['input']>>
+  topEntity?: InputMaybe<Scalars['String']['input']>
+}
 
 export type GQLSpamRingSkip = {
-  __typename?: 'SpamRingSkip';
-  reason: Scalars['String']['output'];
-  user: GQLUser;
-};
+  __typename?: 'SpamRingSkip'
+  reason: Scalars['String']['output']
+  user: GQLUser
+}
 
-export type GQLSpamRingStatus =
-  | 'dismissed'
-  | 'frozen'
-  | 'pending'
-  | 'restored';
+export type GQLSpamRingStatus = 'dismissed' | 'frozen' | 'pending' | 'restored'
 
-export type GQLSpamRingsSort =
-  | 'detectedAt'
-  | 'nAuthors'
-  | 'score';
+export type GQLSpamRingsSort = 'detectedAt' | 'nAuthors' | 'score'
 
 export type GQLSpamStatus = {
-  __typename?: 'SpamStatus';
+  __typename?: 'SpamStatus'
   /** Whether this work is labeled as spam by human, null for not labeled yet.  */
-  isSpam?: Maybe<Scalars['Boolean']['output']>;
+  isSpam?: Maybe<Scalars['Boolean']['output']>
   /** Spam confident score by machine, null for not checked yet.  */
-  score?: Maybe<Scalars['Float']['output']>;
-};
+  score?: Maybe<Scalars['Float']['output']>
+}
 
 export type GQLStripeAccount = {
-  __typename?: 'StripeAccount';
-  id: Scalars['ID']['output'];
-  loginUrl: Scalars['String']['output'];
-};
+  __typename?: 'StripeAccount'
+  id: Scalars['ID']['output']
+  loginUrl: Scalars['String']['output']
+}
 
 export type GQLStripeAccountCountry =
   | 'Australia'
@@ -4700,373 +4492,354 @@ export type GQLStripeAccountCountry =
   | 'Spain'
   | 'Sweden'
   | 'UnitedKingdom'
-  | 'UnitedStates';
+  | 'UnitedStates'
 
 export type GQLSubmitReportInput = {
-  reason: GQLReportReason;
-  targetId: Scalars['ID']['input'];
-};
+  reason: GQLReportReason
+  targetId: Scalars['ID']['input']
+}
 
 export type GQLSubmitTopicChannelFeedbackInput = {
-  article: Scalars['ID']['input'];
-  channels?: InputMaybe<Array<Scalars['ID']['input']>>;
-  type: GQLTopicChannelFeedbackType;
-};
+  article: Scalars['ID']['input']
+  channels?: InputMaybe<Array<Scalars['ID']['input']>>
+  type: GQLTopicChannelFeedbackType
+}
 
 export type GQLSubscribeCircleInput = {
   /** Unique ID. */
-  id: Scalars['ID']['input'];
+  id: Scalars['ID']['input']
   /** Wallet password. */
-  password?: InputMaybe<Scalars['String']['input']>;
-};
+  password?: InputMaybe<Scalars['String']['input']>
+}
 
 export type GQLSubscribeCircleResult = {
-  __typename?: 'SubscribeCircleResult';
-  circle: GQLCircle;
+  __typename?: 'SubscribeCircleResult'
+  circle: GQLCircle
   /** client secret for SetupIntent. */
-  client_secret?: Maybe<Scalars['String']['output']>;
-};
+  client_secret?: Maybe<Scalars['String']['output']>
+}
 
 /** This type contains content, count and related data of an article tag. */
-export type GQLTag = GQLChannel & GQLNode & {
-  __typename?: 'Tag';
-  /** List of articles were attached with this tag. */
-  articles: GQLChannelArticleConnection;
-  /** Whether this tag is enabled as a channel */
-  channelEnabled: Scalars['Boolean']['output'];
-  /** Content of this tag. */
-  content: Scalars['String']['output'];
-  /** Time of this tag was created. */
-  createdAt: Scalars['DateTime']['output'];
-  deleted: Scalars['Boolean']['output'];
-  /** Unique id of this tag. */
-  id: Scalars['ID']['output'];
-  /** This value determines if current viewer is following or not. */
-  isFollower?: Maybe<Scalars['Boolean']['output']>;
-  /** Navbar title for this tag channel */
-  navbarTitle: Scalars['String']['output'];
-  /** Counts of this tag. */
-  numArticles: Scalars['Int']['output'];
-  numAuthors: Scalars['Int']['output'];
-  numMoments: Scalars['Int']['output'];
-  oss: GQLTagOss;
-  /** Tags recommended based on relations to current tag. */
-  recommended: GQLTagConnection;
-  /** Authors recommended based on relations to current tag. */
-  recommendedAuthors: GQLUserConnection;
-  remark?: Maybe<Scalars['String']['output']>;
-  /** Short hash for shorter url addressing */
-  shortHash: Scalars['String']['output'];
-  /** Articles and moments were attached with this tag. */
-  writings: GQLTagWritingConnection;
-};
-
+export type GQLTag = GQLChannel &
+  GQLNode & {
+    __typename?: 'Tag'
+    /** List of articles were attached with this tag. */
+    articles: GQLChannelArticleConnection
+    /** Whether this tag is enabled as a channel */
+    channelEnabled: Scalars['Boolean']['output']
+    /** Content of this tag. */
+    content: Scalars['String']['output']
+    /** Time of this tag was created. */
+    createdAt: Scalars['DateTime']['output']
+    deleted: Scalars['Boolean']['output']
+    /** Unique id of this tag. */
+    id: Scalars['ID']['output']
+    /** This value determines if current viewer is following or not. */
+    isFollower?: Maybe<Scalars['Boolean']['output']>
+    /** Navbar title for this tag channel */
+    navbarTitle: Scalars['String']['output']
+    /** Counts of this tag. */
+    numArticles: Scalars['Int']['output']
+    numAuthors: Scalars['Int']['output']
+    numMoments: Scalars['Int']['output']
+    oss: GQLTagOss
+    /** Tags recommended based on relations to current tag. */
+    recommended: GQLTagConnection
+    /** Authors recommended based on relations to current tag. */
+    recommendedAuthors: GQLUserConnection
+    remark?: Maybe<Scalars['String']['output']>
+    /** Short hash for shorter url addressing */
+    shortHash: Scalars['String']['output']
+    /** Articles and moments were attached with this tag. */
+    writings: GQLTagWritingConnection
+  }
 
 /** This type contains content, count and related data of an article tag. */
 export type GQLTagArticlesArgs = {
-  input: GQLTagArticlesInput;
-};
-
+  input: GQLTagArticlesInput
+}
 
 /** This type contains content, count and related data of an article tag. */
 export type GQLTagNavbarTitleArgs = {
-  input?: InputMaybe<GQLTranslationArgs>;
-};
-
+  input?: InputMaybe<GQLTranslationArgs>
+}
 
 /** This type contains content, count and related data of an article tag. */
 export type GQLTagRecommendedArgs = {
-  input: GQLRecommendInput;
-};
-
+  input: GQLRecommendInput
+}
 
 /** This type contains content, count and related data of an article tag. */
 export type GQLTagRecommendedAuthorsArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 /** This type contains content, count and related data of an article tag. */
 export type GQLTagWritingsArgs = {
-  input: GQLWritingInput;
-};
+  input: GQLWritingInput
+}
 
 export type GQLTagArticlesInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  oss?: InputMaybe<Scalars['Boolean']['input']>;
-  sortBy?: InputMaybe<GQLTagArticlesSortBy>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  oss?: InputMaybe<Scalars['Boolean']['input']>
+  sortBy?: InputMaybe<GQLTagArticlesSortBy>
+}
 
-export type GQLTagArticlesSortBy =
-  | 'byCreatedAtDesc'
-  | 'byHottestDesc';
+export type GQLTagArticlesSortBy = 'byCreatedAtDesc' | 'byHottestDesc'
 
 export type GQLTagConnection = GQLConnection & {
-  __typename?: 'TagConnection';
-  edges?: Maybe<Array<GQLTagEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'TagConnection'
+  edges?: Maybe<Array<GQLTagEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLTagEdge = {
-  __typename?: 'TagEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLTag;
-};
+  __typename?: 'TagEdge'
+  cursor: Scalars['String']['output']
+  node: GQLTag
+}
 
 export type GQLTagOss = {
-  __typename?: 'TagOSS';
-  boost: Scalars['Float']['output'];
-  score: Scalars['Float']['output'];
-};
+  __typename?: 'TagOSS'
+  boost: Scalars['Float']['output']
+  score: Scalars['Float']['output']
+}
 
 export type GQLTagWritingConnection = GQLConnection & {
-  __typename?: 'TagWritingConnection';
-  edges?: Maybe<Array<GQLTagWritingEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'TagWritingConnection'
+  edges?: Maybe<Array<GQLTagWritingEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLTagWritingEdge = {
-  __typename?: 'TagWritingEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLWriting;
-  pinned: Scalars['Boolean']['output'];
-};
+  __typename?: 'TagWritingEdge'
+  cursor: Scalars['String']['output']
+  node: GQLWriting
+  pinned: Scalars['Boolean']['output']
+}
 
 export type GQLTagsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  sort?: InputMaybe<GQLTagsSort>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  sort?: InputMaybe<GQLTagsSort>
+}
 
 /** Enums for sorting tags. */
-export type GQLTagsSort =
-  | 'hottest'
-  | 'newest'
-  | 'oldest';
+export type GQLTagsSort = 'hottest' | 'newest' | 'oldest'
 
 export type GQLToggleCircleMemberInput = {
   /** Toggle value. */
-  enabled: Scalars['Boolean']['input'];
+  enabled: Scalars['Boolean']['input']
   /** Unique ID. */
-  id: Scalars['ID']['input'];
+  id: Scalars['ID']['input']
   /** Unique ID of target user. */
-  targetId: Scalars['ID']['input'];
-};
+  targetId: Scalars['ID']['input']
+}
 
 /** Common input to toggle single item for `toggleXXX` mutations */
 export type GQLToggleItemInput = {
-  enabled?: InputMaybe<Scalars['Boolean']['input']>;
-  id: Scalars['ID']['input'];
-};
+  enabled?: InputMaybe<Scalars['Boolean']['input']>
+  id: Scalars['ID']['input']
+}
 
 export type GQLTogglePinChannelArticlesInput = {
-  articles: Array<Scalars['ID']['input']>;
+  articles: Array<Scalars['ID']['input']>
   /** id of TopicChannel or CurationChannel */
-  channels: Array<Scalars['ID']['input']>;
-  pinned: Scalars['Boolean']['input'];
-};
+  channels: Array<Scalars['ID']['input']>
+  pinned: Scalars['Boolean']['input']
+}
 
 export type GQLToggleRecommendInput = {
-  enabled: Scalars['Boolean']['input'];
-  id: Scalars['ID']['input'];
-  type?: InputMaybe<GQLRecommendTypes>;
-};
+  enabled: Scalars['Boolean']['input']
+  id: Scalars['ID']['input']
+  type?: InputMaybe<GQLRecommendTypes>
+}
 
 export type GQLToggleSeedingUsersInput = {
-  enabled: Scalars['Boolean']['input'];
-  ids?: InputMaybe<Array<Scalars['ID']['input']>>;
-};
+  enabled: Scalars['Boolean']['input']
+  ids?: InputMaybe<Array<Scalars['ID']['input']>>
+}
 
 export type GQLToggleUsersBadgeInput = {
-  enabled: Scalars['Boolean']['input'];
-  ids: Array<Scalars['ID']['input']>;
-  type: GQLBadgeType;
-};
+  enabled: Scalars['Boolean']['input']
+  ids: Array<Scalars['ID']['input']>
+  type: GQLBadgeType
+}
 
 export type GQLToggleWritingChallengeFeaturedArticlesInput = {
-  articles: Array<Scalars['ID']['input']>;
-  campaign: Scalars['ID']['input'];
-  enabled: Scalars['Boolean']['input'];
-};
+  articles: Array<Scalars['ID']['input']>
+  campaign: Scalars['ID']['input']
+  enabled: Scalars['Boolean']['input']
+}
 
 export type GQLTopDonatorConnection = GQLConnection & {
-  __typename?: 'TopDonatorConnection';
-  edges?: Maybe<Array<GQLTopDonatorEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'TopDonatorConnection'
+  edges?: Maybe<Array<GQLTopDonatorEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLTopDonatorEdge = {
-  __typename?: 'TopDonatorEdge';
-  cursor: Scalars['String']['output'];
-  donationCount: Scalars['Int']['output'];
-  node: GQLDonator;
-};
+  __typename?: 'TopDonatorEdge'
+  cursor: Scalars['String']['output']
+  donationCount: Scalars['Int']['output']
+  node: GQLDonator
+}
 
 export type GQLTopDonatorFilter = {
-  inRangeEnd?: InputMaybe<Scalars['DateTime']['input']>;
-  inRangeStart?: InputMaybe<Scalars['DateTime']['input']>;
-};
+  inRangeEnd?: InputMaybe<Scalars['DateTime']['input']>
+  inRangeStart?: InputMaybe<Scalars['DateTime']['input']>
+}
 
 export type GQLTopDonatorInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<GQLTopDonatorFilter>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<GQLTopDonatorFilter>
+  first?: InputMaybe<Scalars['Int']['input']>
+}
 
-export type GQLTopicChannel = GQLChannel & GQLNode & {
-  __typename?: 'TopicChannel';
-  articles: GQLChannelArticleConnection;
-  enabled: Scalars['Boolean']['output'];
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
-  navbarTitle: Scalars['String']['output'];
-  note?: Maybe<Scalars['String']['output']>;
-  parent?: Maybe<GQLTopicChannel>;
-  providerId?: Maybe<Scalars['String']['output']>;
-  shortHash: Scalars['String']['output'];
-};
-
+export type GQLTopicChannel = GQLChannel &
+  GQLNode & {
+    __typename?: 'TopicChannel'
+    articles: GQLChannelArticleConnection
+    enabled: Scalars['Boolean']['output']
+    id: Scalars['ID']['output']
+    name: Scalars['String']['output']
+    navbarTitle: Scalars['String']['output']
+    note?: Maybe<Scalars['String']['output']>
+    parent?: Maybe<GQLTopicChannel>
+    providerId?: Maybe<Scalars['String']['output']>
+    shortHash: Scalars['String']['output']
+  }
 
 export type GQLTopicChannelArticlesArgs = {
-  input: GQLChannelArticlesInput;
-};
-
+  input: GQLChannelArticlesInput
+}
 
 export type GQLTopicChannelNameArgs = {
-  input?: InputMaybe<GQLTranslationArgs>;
-};
-
+  input?: InputMaybe<GQLTranslationArgs>
+}
 
 export type GQLTopicChannelNavbarTitleArgs = {
-  input?: InputMaybe<GQLTranslationArgs>;
-};
-
+  input?: InputMaybe<GQLTranslationArgs>
+}
 
 export type GQLTopicChannelNoteArgs = {
-  input?: InputMaybe<GQLTranslationArgs>;
-};
+  input?: InputMaybe<GQLTranslationArgs>
+}
 
 export type GQLTopicChannelClassification = {
-  __typename?: 'TopicChannelClassification';
+  __typename?: 'TopicChannelClassification'
   /** Which channels this article is in, null for not classified, empty for not in any channel */
-  channels?: Maybe<Array<GQLArticleTopicChannel>>;
+  channels?: Maybe<Array<GQLArticleTopicChannel>>
   /** whether user enable channel classification */
-  enabled: Scalars['Boolean']['output'];
+  enabled: Scalars['Boolean']['output']
   /** Feedback from author */
-  feedback?: Maybe<GQLTopicChannelFeedback>;
-};
+  feedback?: Maybe<GQLTopicChannelFeedback>
+}
 
 export type GQLTopicChannelFeedback = {
-  __typename?: 'TopicChannelFeedback';
-  article: GQLArticle;
+  __typename?: 'TopicChannelFeedback'
+  article: GQLArticle
   /** Which channels author want to be in, empty for no channels */
-  channels?: Maybe<Array<GQLTopicChannel>>;
-  createdAt: Scalars['DateTime']['output'];
-  id: Scalars['ID']['output'];
-  state?: Maybe<GQLTopicChannelFeedbackState>;
-  type: GQLTopicChannelFeedbackType;
-};
+  channels?: Maybe<Array<GQLTopicChannel>>
+  createdAt: Scalars['DateTime']['output']
+  id: Scalars['ID']['output']
+  state?: Maybe<GQLTopicChannelFeedbackState>
+  type: GQLTopicChannelFeedbackType
+}
 
-export type GQLTopicChannelFeedbackAction =
-  | 'accept'
-  | 'reject';
+export type GQLTopicChannelFeedbackAction = 'accept' | 'reject'
 
 export type GQLTopicChannelFeedbackConnection = GQLConnection & {
-  __typename?: 'TopicChannelFeedbackConnection';
-  edges: Array<GQLTopicChannelFeedbackEdge>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'TopicChannelFeedbackConnection'
+  edges: Array<GQLTopicChannelFeedbackEdge>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLTopicChannelFeedbackEdge = {
-  __typename?: 'TopicChannelFeedbackEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLTopicChannelFeedback;
-};
+  __typename?: 'TopicChannelFeedbackEdge'
+  cursor: Scalars['String']['output']
+  node: GQLTopicChannelFeedback
+}
 
 export type GQLTopicChannelFeedbackState =
   | 'accepted'
   | 'pending'
   | 'rejected'
-  | 'resolved';
+  | 'resolved'
 
-export type GQLTopicChannelFeedbackType =
-  | 'negative'
-  | 'positive';
+export type GQLTopicChannelFeedbackType = 'negative' | 'positive'
 
 export type GQLTopicChannelFeedbacksFilterInput = {
-  spam?: InputMaybe<Scalars['Boolean']['input']>;
-  state?: InputMaybe<GQLTopicChannelFeedbackState>;
-  type?: InputMaybe<GQLTopicChannelFeedbackType>;
-};
+  spam?: InputMaybe<Scalars['Boolean']['input']>
+  state?: InputMaybe<GQLTopicChannelFeedbackState>
+  type?: InputMaybe<GQLTopicChannelFeedbackType>
+}
 
 export type GQLTopicChannelFeedbacksInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<GQLTopicChannelFeedbacksFilterInput>;
-  first: Scalars['Int']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<GQLTopicChannelFeedbacksFilterInput>
+  first: Scalars['Int']['input']
+}
 
 export type GQLTransaction = {
-  __typename?: 'Transaction';
-  amount: Scalars['Float']['output'];
+  __typename?: 'Transaction'
+  amount: Scalars['Float']['output']
   /** blockchain transaction info of ERC20/native token payment transaction */
-  blockchainTx?: Maybe<GQLBlockchainTransaction>;
+  blockchainTx?: Maybe<GQLBlockchainTransaction>
   /** Timestamp of transaction. */
-  createdAt: Scalars['DateTime']['output'];
-  currency: GQLTransactionCurrency;
-  fee: Scalars['Float']['output'];
-  id: Scalars['ID']['output'];
+  createdAt: Scalars['DateTime']['output']
+  currency: GQLTransactionCurrency
+  fee: Scalars['Float']['output']
+  id: Scalars['ID']['output']
   /** Message for end user, including reason of failure. */
-  message?: Maybe<Scalars['String']['output']>;
-  purpose: GQLTransactionPurpose;
+  message?: Maybe<Scalars['String']['output']>
+  purpose: GQLTransactionPurpose
   /** Recipient of transaction. */
-  recipient?: Maybe<GQLUser>;
+  recipient?: Maybe<GQLUser>
   /** Sender of transaction. */
-  sender?: Maybe<GQLUser>;
-  state: GQLTransactionState;
+  sender?: Maybe<GQLUser>
+  state: GQLTransactionState
   /** Related target article or transaction. */
-  target?: Maybe<GQLTransactionTarget>;
-};
+  target?: Maybe<GQLTransactionTarget>
+}
 
 export type GQLTransactionConnection = GQLConnection & {
-  __typename?: 'TransactionConnection';
-  edges?: Maybe<Array<GQLTransactionEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'TransactionConnection'
+  edges?: Maybe<Array<GQLTransactionEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
-export type GQLTransactionCurrency =
-  | 'HKD'
-  | 'LIKE'
-  | 'USDT';
+export type GQLTransactionCurrency = 'HKD' | 'LIKE' | 'USDT'
 
 export type GQLTransactionEdge = {
-  __typename?: 'TransactionEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLTransaction;
-};
+  __typename?: 'TransactionEdge'
+  cursor: Scalars['String']['output']
+  node: GQLTransaction
+}
 
 export type GQLTransactionNotice = GQLNotice & {
-  __typename?: 'TransactionNotice';
+  __typename?: 'TransactionNotice'
   /** List of notice actors. */
-  actors?: Maybe<Array<GQLUser>>;
+  actors?: Maybe<Array<GQLUser>>
   /** Time of this notice was created. */
-  createdAt: Scalars['DateTime']['output'];
+  createdAt: Scalars['DateTime']['output']
   /** Unique ID of this notice. */
-  id: Scalars['ID']['output'];
-  target: GQLTransaction;
-  type: GQLTransactionNoticeType;
+  id: Scalars['ID']['output']
+  target: GQLTransaction
+  type: GQLTransactionNoticeType
   /** The value determines if the notice is unread or not. */
-  unread: Scalars['Boolean']['output'];
-};
+  unread: Scalars['Boolean']['output']
+}
 
 export type GQLTransactionNoticeType =
   | 'PaymentReceivedDonation'
-  | 'WithdrewLockedTokens';
+  | 'WithdrewLockedTokens'
 
 export type GQLTransactionPurpose =
   | 'addCredit'
@@ -5076,4112 +4849,8381 @@ export type GQLTransactionPurpose =
   | 'payout'
   | 'payoutReversal'
   | 'refund'
-  | 'subscriptionSplit';
+  | 'subscriptionSplit'
 
 export type GQLTransactionState =
   | 'canceled'
   | 'failed'
   | 'pending'
-  | 'succeeded';
+  | 'succeeded'
 
-export type GQLTransactionTarget = GQLArticle | GQLCircle | GQLTransaction;
+export type GQLTransactionTarget = GQLArticle | GQLCircle | GQLTransaction
 
 export type GQLTransactionsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<GQLTransactionsFilter>;
-  first?: InputMaybe<Scalars['Int']['input']>;
+  after?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<GQLTransactionsFilter>
+  first?: InputMaybe<Scalars['Int']['input']>
   /** deprecated, use TransactionsFilter.id instead. */
-  id?: InputMaybe<Scalars['ID']['input']>;
+  id?: InputMaybe<Scalars['ID']['input']>
   /** deprecated, use TransactionsFilter.states instead. */
-  states?: InputMaybe<Array<GQLTransactionState>>;
-};
+  states?: InputMaybe<Array<GQLTransactionState>>
+}
 
 export type GQLTransactionsFilter = {
-  currency?: InputMaybe<GQLTransactionCurrency>;
-  id?: InputMaybe<Scalars['ID']['input']>;
-  purpose?: InputMaybe<GQLTransactionPurpose>;
-  states?: InputMaybe<Array<GQLTransactionState>>;
-};
+  currency?: InputMaybe<GQLTransactionCurrency>
+  id?: InputMaybe<Scalars['ID']['input']>
+  purpose?: InputMaybe<GQLTransactionPurpose>
+  states?: InputMaybe<Array<GQLTransactionState>>
+}
 
 export type GQLTransactionsReceivedByArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  purpose: GQLTransactionPurpose;
-  senderId?: InputMaybe<Scalars['ID']['input']>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  purpose: GQLTransactionPurpose
+  senderId?: InputMaybe<Scalars['ID']['input']>
+}
 
 export type GQLTranslatedAnnouncement = {
-  __typename?: 'TranslatedAnnouncement';
-  content?: Maybe<Scalars['String']['output']>;
-  cover?: Maybe<Scalars['String']['output']>;
-  language: GQLUserLanguage;
-  link?: Maybe<Scalars['String']['output']>;
-  title?: Maybe<Scalars['String']['output']>;
-};
+  __typename?: 'TranslatedAnnouncement'
+  content?: Maybe<Scalars['String']['output']>
+  cover?: Maybe<Scalars['String']['output']>
+  language: GQLUserLanguage
+  link?: Maybe<Scalars['String']['output']>
+  title?: Maybe<Scalars['String']['output']>
+}
 
 export type GQLTranslationArgs = {
-  language: GQLUserLanguage;
-};
+  language: GQLUserLanguage
+}
 
 export type GQLTranslationInput = {
-  language: GQLUserLanguage;
-  text: Scalars['String']['input'];
-};
+  language: GQLUserLanguage
+  text: Scalars['String']['input']
+}
 
 export type GQLTranslationModel =
   | 'google_gemini_2_0_flash'
   | 'google_gemini_2_5_flash'
   | 'google_translation_v2'
-  | 'opencc';
+  | 'opencc'
 
 export type GQLUnbindLikerIdInput = {
-  id: Scalars['ID']['input'];
-  likerId: Scalars['String']['input'];
-};
+  id: Scalars['ID']['input']
+  likerId: Scalars['String']['input']
+}
 
 export type GQLUnfreezeSpamRingInput = {
-  id: Scalars['ID']['input'];
-};
+  id: Scalars['ID']['input']
+}
 
 export type GQLUnfreezeSpamRingResult = {
-  __typename?: 'UnfreezeSpamRingResult';
-  ring: GQLSpamRing;
-  skipped: Array<GQLSpamRingSkip>;
-  unbanned: Array<GQLUser>;
-};
+  __typename?: 'UnfreezeSpamRingResult'
+  ring: GQLSpamRing
+  skipped: Array<GQLSpamRingSkip>
+  unbanned: Array<GQLUser>
+}
 
 export type GQLUnlikeCollectionInput = {
-  id: Scalars['ID']['input'];
-};
+  id: Scalars['ID']['input']
+}
 
 export type GQLUnlikeMomentInput = {
-  id: Scalars['ID']['input'];
-};
+  id: Scalars['ID']['input']
+}
 
 export type GQLUnpinCommentInput = {
-  id: Scalars['ID']['input'];
-};
+  id: Scalars['ID']['input']
+}
 
 export type GQLUnsubscribeCircleInput = {
   /** Unique ID. */
-  id: Scalars['ID']['input'];
-};
+  id: Scalars['ID']['input']
+}
 
 export type GQLUnvoteCommentInput = {
-  id: Scalars['ID']['input'];
-};
+  id: Scalars['ID']['input']
+}
 
 export type GQLUpdateArticleSensitiveInput = {
-  id: Scalars['ID']['input'];
-  sensitive: Scalars['Boolean']['input'];
-};
+  id: Scalars['ID']['input']
+  sensitive: Scalars['Boolean']['input']
+}
 
 export type GQLUpdateArticleStateInput = {
-  id: Scalars['ID']['input'];
-  state: GQLArticleState;
-};
+  id: Scalars['ID']['input']
+  state: GQLArticleState
+}
 
 export type GQLUpdateCampaignApplicationStateInput = {
-  campaign: Scalars['ID']['input'];
-  state: GQLCampaignApplicationState;
-  user: Scalars['ID']['input'];
-};
+  campaign: Scalars['ID']['input']
+  state: GQLCampaignApplicationState
+  user: Scalars['ID']['input']
+}
 
 export type GQLUpdateCommentsStateInput = {
-  ids: Array<Scalars['ID']['input']>;
-  state: GQLCommentState;
-};
+  ids: Array<Scalars['ID']['input']>
+  state: GQLCommentState
+}
 
 export type GQLUpdateCommunityWatchActionStateInput = {
-  appealState?: InputMaybe<GQLCommunityWatchAppealState>;
-  note?: InputMaybe<Scalars['String']['input']>;
-  reason?: InputMaybe<GQLCommunityWatchRemoveCommentReason>;
-  reviewState?: InputMaybe<GQLCommunityWatchReviewState>;
-  uuid: Scalars['ID']['input'];
-};
+  appealState?: InputMaybe<GQLCommunityWatchAppealState>
+  note?: InputMaybe<Scalars['String']['input']>
+  reason?: InputMaybe<GQLCommunityWatchRemoveCommentReason>
+  reviewState?: InputMaybe<GQLCommunityWatchReviewState>
+  uuid: Scalars['ID']['input']
+}
+
+export type GQLUpdateModerationCaseInput = {
+  id: Scalars['ID']['input']
+  internalNote?: InputMaybe<Scalars['String']['input']>
+  noticeState?: InputMaybe<GQLModerationNoticeState>
+  outcome?: InputMaybe<GQLModerationCaseOutcome>
+  publicReason?: InputMaybe<Scalars['String']['input']>
+  status?: InputMaybe<GQLModerationCaseStatus>
+}
 
 export type GQLUpdateMomentFeedApplicationStateInput = {
-  id: Scalars['ID']['input'];
-  state: GQLMomentFeedUserState;
-};
+  id: Scalars['ID']['input']
+  state: GQLMomentFeedUserState
+}
 
 export type GQLUpdateNotificationSettingInput = {
-  enabled: Scalars['Boolean']['input'];
-  type: GQLNotificationSettingType;
-};
+  enabled: Scalars['Boolean']['input']
+  type: GQLNotificationSettingType
+}
 
 export type GQLUpdateUserExtraInput = {
-  id: Scalars['ID']['input'];
-  referralCode?: InputMaybe<Scalars['String']['input']>;
-};
+  id: Scalars['ID']['input']
+  referralCode?: InputMaybe<Scalars['String']['input']>
+}
 
 export type GQLUpdateUserInfoInput = {
-  agreeOn?: InputMaybe<Scalars['Boolean']['input']>;
-  avatar?: InputMaybe<Scalars['ID']['input']>;
-  description?: InputMaybe<Scalars['String']['input']>;
-  displayName?: InputMaybe<Scalars['String']['input']>;
-  language?: InputMaybe<GQLUserLanguage>;
-  paymentPassword?: InputMaybe<Scalars['String']['input']>;
-  paymentPointer?: InputMaybe<Scalars['String']['input']>;
-  profileCover?: InputMaybe<Scalars['ID']['input']>;
-  referralCode?: InputMaybe<Scalars['String']['input']>;
-};
+  agreeOn?: InputMaybe<Scalars['Boolean']['input']>
+  avatar?: InputMaybe<Scalars['ID']['input']>
+  description?: InputMaybe<Scalars['String']['input']>
+  displayName?: InputMaybe<Scalars['String']['input']>
+  language?: InputMaybe<GQLUserLanguage>
+  paymentPassword?: InputMaybe<Scalars['String']['input']>
+  paymentPointer?: InputMaybe<Scalars['String']['input']>
+  profileCover?: InputMaybe<Scalars['ID']['input']>
+  referralCode?: InputMaybe<Scalars['String']['input']>
+}
 
 export type GQLUpdateUserRoleInput = {
-  id: Scalars['ID']['input'];
-  role: GQLUserRole;
-};
+  id: Scalars['ID']['input']
+  role: GQLUserRole
+}
 
 export type GQLUpdateUserStateInput = {
-  banDays?: InputMaybe<Scalars['Int']['input']>;
-  emails?: InputMaybe<Array<Scalars['String']['input']>>;
-  id?: InputMaybe<Scalars['ID']['input']>;
-  password?: InputMaybe<Scalars['String']['input']>;
-  state: GQLUserState;
-};
+  banDays?: InputMaybe<Scalars['Int']['input']>
+  emails?: InputMaybe<Array<Scalars['String']['input']>>
+  id?: InputMaybe<Scalars['ID']['input']>
+  password?: InputMaybe<Scalars['String']['input']>
+  state: GQLUserState
+}
 
 export type GQLUpsertSpamRingCandidatesInput = {
-  candidates: Array<GQLSpamRingCandidateInput>;
-};
+  candidates: Array<GQLSpamRingCandidateInput>
+}
 
 export type GQLUpsertSpamRingCandidatesResult = {
-  __typename?: 'UpsertSpamRingCandidatesResult';
-  created: Scalars['Int']['output'];
-  rings: Array<GQLSpamRing>;
-  skipped: Scalars['Int']['output'];
-  updated: Scalars['Int']['output'];
-};
+  __typename?: 'UpsertSpamRingCandidatesResult'
+  created: Scalars['Int']['output']
+  rings: Array<GQLSpamRing>
+  skipped: Scalars['Int']['output']
+  updated: Scalars['Int']['output']
+}
 
 export type GQLUser = GQLNode & {
-  __typename?: 'User';
+  __typename?: 'User'
   /** Record of user activity, only accessable by current user. */
-  activity: GQLUserActivity;
+  activity: GQLUserActivity
   /** user data analytics, only accessable by current user. */
-  analytics: GQLUserAnalytics;
+  analytics: GQLUserAnalytics
   /** Articles authored by current user. */
-  articles: GQLArticleConnection;
+  articles: GQLArticleConnection
   /** URL for user avatar. */
-  avatar?: Maybe<Scalars['String']['output']>;
+  avatar?: Maybe<Scalars['String']['output']>
   /** Users that blocked by current user. */
-  blockList: GQLUserConnection;
+  blockList: GQLUserConnection
   /** Artilces current user bookmarked. */
-  bookmarkedArticles: GQLArticleConnection;
+  bookmarkedArticles: GQLArticleConnection
   /** Tags current user bookmarked. */
-  bookmarkedTags: GQLTagConnection;
+  bookmarkedTags: GQLTagConnection
   /** active applied campaigns */
-  campaigns: GQLCampaignConnection;
+  campaigns: GQLCampaignConnection
   /** collections authored by current user. */
-  collections: GQLCollectionConnection;
+  collections: GQLCollectionConnection
   /** Articles current user commented on */
-  commentedArticles: GQLArticleConnection;
+  commentedArticles: GQLArticleConnection
   /** Display name on user profile, can be duplicated. */
-  displayName?: Maybe<Scalars['String']['output']>;
+  displayName?: Maybe<Scalars['String']['output']>
   /** Drafts authored by current user. */
-  drafts: GQLDraftConnection;
+  drafts: GQLDraftConnection
   /** Public-safe feature eligibility for current viewer. */
-  features: GQLUserFeatures;
+  features: GQLUserFeatures
   /** User-level federation opt-in setting. */
-  federationSetting?: Maybe<GQLUserFederationSetting>;
+  federationSetting?: Maybe<GQLUserFederationSetting>
   /** Followers of this user. */
-  followers: GQLUserConnection;
+  followers: GQLUserConnection
   /** Following contents of this user. */
-  following: GQLFollowing;
+  following: GQLFollowing
   /** Global id of an user. */
-  id: Scalars['ID']['output'];
+  id: Scalars['ID']['output']
   /** User information. */
-  info: GQLUserInfo;
+  info: GQLUserInfo
   /** Whether current user is blocked by viewer. */
-  isBlocked: Scalars['Boolean']['output'];
+  isBlocked: Scalars['Boolean']['output']
   /** Whether current user is blocking viewer. */
-  isBlocking: Scalars['Boolean']['output'];
+  isBlocking: Scalars['Boolean']['output']
   /** Whether viewer is following current user. */
-  isFollowee: Scalars['Boolean']['output'];
+  isFollowee: Scalars['Boolean']['output']
   /** Whether current user is following viewer. */
-  isFollower: Scalars['Boolean']['output'];
-  isMomentFeedApplied: Scalars['Boolean']['output'];
+  isFollower: Scalars['Boolean']['output']
+  isMomentFeedApplied: Scalars['Boolean']['output']
   /** user latest articles or collections */
-  latestWorks: Array<GQLPinnableWork>;
+  latestWorks: Array<GQLPinnableWork>
   /** Liker info of current user */
-  liker: GQLLiker;
+  liker: GQLLiker
   /** LikerID of LikeCoin, being used by LikeCoin OAuth */
-  likerId?: Maybe<Scalars['String']['output']>;
-  notices: GQLNoticeConnection;
-  oss: GQLUserOss;
+  likerId?: Maybe<Scalars['String']['output']>
+  notices: GQLNoticeConnection
+  oss: GQLUserOss
   /** Circles belong to current user. */
-  ownCircles?: Maybe<Array<GQLCircle>>;
+  ownCircles?: Maybe<Array<GQLCircle>>
   /** Payment pointer that resolves to Open Payments endpoints */
-  paymentPointer?: Maybe<Scalars['String']['output']>;
+  paymentPointer?: Maybe<Scalars['String']['output']>
   /** user pinned articles or collections */
-  pinnedWorks: Array<GQLPinnableWork>;
+  pinnedWorks: Array<GQLPinnableWork>
   /** Recommendations for current user. */
-  recommendation: GQLRecommendation;
-  remark?: Maybe<Scalars['String']['output']>;
+  recommendation: GQLRecommendation
+  remark?: Maybe<Scalars['String']['output']>
   /** User settings. */
-  settings: GQLUserSettings;
+  settings: GQLUserSettings
   /** Status of current user. */
-  status?: Maybe<GQLUserStatus>;
+  status?: Maybe<GQLUserStatus>
   /** Circles whiches user has subscribed. */
-  subscribedCircles: GQLCircleConnection;
+  subscribedCircles: GQLCircleConnection
   /** Tags by usage order of current user. */
-  tags: GQLTagConnection;
+  tags: GQLTagConnection
   /** Global unique user name of a user. */
-  userName?: Maybe<Scalars['String']['output']>;
+  userName?: Maybe<Scalars['String']['output']>
   /** User Wallet */
-  wallet: GQLWallet;
+  wallet: GQLWallet
   /** Articles and moments authored by current user. */
-  writings: GQLWritingConnection;
-};
-
+  writings: GQLWritingConnection
+}
 
 export type GQLUserArticlesArgs = {
-  input: GQLUserArticlesInput;
-};
-
+  input: GQLUserArticlesInput
+}
 
 export type GQLUserBlockListArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLUserBookmarkedArticlesArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLUserBookmarkedTagsArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLUserCampaignsArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLUserCollectionsArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLUserCommentedArticlesArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLUserDraftsArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLUserFollowersArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLUserNoticesArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLUserSubscribedCirclesArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLUserTagsArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLUserWritingsArgs = {
-  input: GQLWritingInput;
-};
+  input: GQLWritingInput
+}
 
 export type GQLUserActivity = {
-  __typename?: 'UserActivity';
+  __typename?: 'UserActivity'
   /** Appreciations current user received. */
-  appreciationsReceived: GQLAppreciationConnection;
+  appreciationsReceived: GQLAppreciationConnection
   /** Total number of appreciation current user received. */
-  appreciationsReceivedTotal: Scalars['Int']['output'];
+  appreciationsReceivedTotal: Scalars['Int']['output']
   /** Appreciations current user gave. */
-  appreciationsSent: GQLAppreciationConnection;
+  appreciationsSent: GQLAppreciationConnection
   /** Total number of appreciation current user gave. */
-  appreciationsSentTotal: Scalars['Int']['output'];
+  appreciationsSentTotal: Scalars['Int']['output']
   /** User reading history. */
-  history: GQLReadHistoryConnection;
+  history: GQLReadHistoryConnection
   /** User search history. */
-  recentSearches: GQLRecentSearchConnection;
-};
-
+  recentSearches: GQLRecentSearchConnection
+}
 
 export type GQLUserActivityAppreciationsReceivedArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLUserActivityAppreciationsSentArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLUserActivityHistoryArgs = {
-  input: GQLConnectionArgs;
-};
-
+  input: GQLConnectionArgs
+}
 
 export type GQLUserActivityRecentSearchesArgs = {
-  input: GQLConnectionArgs;
-};
+  input: GQLConnectionArgs
+}
 
 export type GQLUserAddArticleTagActivity = {
-  __typename?: 'UserAddArticleTagActivity';
-  actor: GQLUser;
-  createdAt: Scalars['DateTime']['output'];
+  __typename?: 'UserAddArticleTagActivity'
+  actor: GQLUser
+  createdAt: Scalars['DateTime']['output']
   /** Article added to tag */
-  node: GQLArticle;
+  node: GQLArticle
   /** Tag added by article */
-  target: GQLTag;
-};
+  target: GQLTag
+}
 
 export type GQLUserAnalytics = {
-  __typename?: 'UserAnalytics';
+  __typename?: 'UserAnalytics'
   /** Top donators of current user. */
-  topDonators: GQLTopDonatorConnection;
-};
-
+  topDonators: GQLTopDonatorConnection
+}
 
 export type GQLUserAnalyticsTopDonatorsArgs = {
-  input: GQLTopDonatorInput;
-};
+  input: GQLTopDonatorInput
+}
 
 export type GQLUserArticlesFilter = {
-  state?: InputMaybe<GQLArticleState>;
-};
+  state?: InputMaybe<GQLArticleState>
+}
 
 export type GQLUserArticlesInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<GQLUserArticlesFilter>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  sort?: InputMaybe<GQLUserArticlesSort>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<GQLUserArticlesFilter>
+  first?: InputMaybe<Scalars['Int']['input']>
+  sort?: InputMaybe<GQLUserArticlesSort>
+}
 
 export type GQLUserArticlesSort =
   | 'mostAppreciations'
   | 'mostComments'
   | 'mostDonations'
   | 'mostReaders'
-  | 'newest';
+  | 'newest'
 
 export type GQLUserBroadcastCircleActivity = {
-  __typename?: 'UserBroadcastCircleActivity';
-  actor: GQLUser;
-  createdAt: Scalars['DateTime']['output'];
+  __typename?: 'UserBroadcastCircleActivity'
+  actor: GQLUser
+  createdAt: Scalars['DateTime']['output']
   /** Comment broadcast by actor */
-  node: GQLComment;
+  node: GQLComment
   /** Circle that comment belongs to */
-  target: GQLCircle;
-};
+  target: GQLCircle
+}
 
 export type GQLUserConnection = GQLConnection & {
-  __typename?: 'UserConnection';
-  edges?: Maybe<Array<GQLUserEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'UserConnection'
+  edges?: Maybe<Array<GQLUserEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLUserCreateCircleActivity = {
-  __typename?: 'UserCreateCircleActivity';
-  actor: GQLUser;
-  createdAt: Scalars['DateTime']['output'];
+  __typename?: 'UserCreateCircleActivity'
+  actor: GQLUser
+  createdAt: Scalars['DateTime']['output']
   /** Circle created by actor */
-  node: GQLCircle;
-};
+  node: GQLCircle
+}
 
 export type GQLUserEdge = {
-  __typename?: 'UserEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLUser;
-};
+  __typename?: 'UserEdge'
+  cursor: Scalars['String']['output']
+  node: GQLUser
+}
 
 export type GQLUserFeatureFlag = {
-  __typename?: 'UserFeatureFlag';
-  createdAt: Scalars['DateTime']['output'];
-  type: GQLUserFeatureFlagType;
-};
+  __typename?: 'UserFeatureFlag'
+  createdAt: Scalars['DateTime']['output']
+  type: GQLUserFeatureFlagType
+}
 
 export type GQLUserFeatureFlagType =
   | 'bypassSpamDetection'
   | 'communityWatch'
   | 'fediverseBeta'
   | 'readSpamStatus'
-  | 'unlimitedArticleFetch';
+  | 'unlimitedArticleFetch'
 
 export type GQLUserFeatures = {
-  __typename?: 'UserFeatures';
+  __typename?: 'UserFeatures'
   /** Whether current viewer can use Community Watch controls. */
-  communityWatch: Scalars['Boolean']['output'];
+  communityWatch: Scalars['Boolean']['output']
   /** Whether current viewer can access Fediverse beta controls. */
-  fediverseBeta: Scalars['Boolean']['output'];
-};
+  fediverseBeta: Scalars['Boolean']['output']
+}
 
 export type GQLUserFederationSetting = {
-  __typename?: 'UserFederationSetting';
-  state: GQLFederationAuthorSettingState;
-  updatedBy?: Maybe<Scalars['ID']['output']>;
-  userId: Scalars['ID']['output'];
-};
+  __typename?: 'UserFederationSetting'
+  state: GQLFederationAuthorSettingState
+  updatedBy?: Maybe<Scalars['ID']['output']>
+  userId: Scalars['ID']['output']
+}
 
-export type GQLUserGroup =
-  | 'a'
-  | 'b';
+export type GQLUserGroup = 'a' | 'b'
 
 export type GQLUserInfo = {
-  __typename?: 'UserInfo';
+  __typename?: 'UserInfo'
   /** Timestamp of user agreement. */
-  agreeOn?: Maybe<Scalars['DateTime']['output']>;
+  agreeOn?: Maybe<Scalars['DateTime']['output']>
   /** User badges. */
-  badges?: Maybe<Array<GQLBadge>>;
+  badges?: Maybe<Array<GQLBadge>>
   /** Timestamp of registration. */
-  createdAt?: Maybe<Scalars['DateTime']['output']>;
+  createdAt?: Maybe<Scalars['DateTime']['output']>
   /** Connected wallet. */
-  cryptoWallet?: Maybe<GQLCryptoWallet>;
+  cryptoWallet?: Maybe<GQLCryptoWallet>
   /** User desciption. */
-  description?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>
   /** User email. */
-  email?: Maybe<Scalars['String']['output']>;
+  email?: Maybe<Scalars['String']['output']>
   /** Weather user email is verified. */
-  emailVerified: Scalars['Boolean']['output'];
+  emailVerified: Scalars['Boolean']['output']
   /** Login address */
-  ethAddress?: Maybe<Scalars['String']['output']>;
+  ethAddress?: Maybe<Scalars['String']['output']>
   /** saved tags for showing on profile page, API allows up to 100, front-end lock'ed at lower limit */
-  featuredTags?: Maybe<Array<GQLTag>>;
+  featuredTags?: Maybe<Array<GQLTag>>
   /** Type of group. */
-  group: GQLUserGroup;
+  group: GQLUserGroup
   /** the ipnsKey (`ipfs.io/ipns/<ipnsKey>/...`) for feed.json / rss.xml / index */
-  ipnsKey?: Maybe<Scalars['String']['output']>;
-  isWalletAuth: Scalars['Boolean']['output'];
+  ipnsKey?: Maybe<Scalars['String']['output']>
+  isWalletAuth: Scalars['Boolean']['output']
   /** Cover of profile page. */
-  profileCover?: Maybe<Scalars['String']['output']>;
+  profileCover?: Maybe<Scalars['String']['output']>
   /** User connected social accounts. */
-  socialAccounts: Array<GQLSocialAccount>;
+  socialAccounts: Array<GQLSocialAccount>
   /** Is user name editable. */
-  userNameEditable: Scalars['Boolean']['output'];
-};
+  userNameEditable: Scalars['Boolean']['output']
+}
 
 export type GQLUserInfoFields =
   | 'agreeOn'
   | 'avatar'
   | 'description'
   | 'displayName'
-  | 'email';
+  | 'email'
 
 export type GQLUserInput = {
-  ethAddress?: InputMaybe<Scalars['String']['input']>;
-  userName?: InputMaybe<Scalars['String']['input']>;
+  ethAddress?: InputMaybe<Scalars['String']['input']>
+  userName?: InputMaybe<Scalars['String']['input']>
   /** used for case insensitive username search  */
-  userNameCaseIgnore?: InputMaybe<Scalars['Boolean']['input']>;
-};
+  userNameCaseIgnore?: InputMaybe<Scalars['Boolean']['input']>
+}
 
-export type GQLUserLanguage =
-  | 'en'
-  | 'zh_hans'
-  | 'zh_hant';
+export type GQLUserLanguage = 'en' | 'zh_hans' | 'zh_hant'
 
 export type GQLUserNotice = GQLNotice & {
-  __typename?: 'UserNotice';
+  __typename?: 'UserNotice'
   /** List of notice actors. */
-  actors?: Maybe<Array<GQLUser>>;
+  actors?: Maybe<Array<GQLUser>>
   /** Time of this notice was created. */
-  createdAt: Scalars['DateTime']['output'];
+  createdAt: Scalars['DateTime']['output']
   /** Unique ID of this notice. */
-  id: Scalars['ID']['output'];
-  target: GQLUser;
-  type: GQLUserNoticeType;
+  id: Scalars['ID']['output']
+  target: GQLUser
+  type: GQLUserNoticeType
   /** The value determines if the notice is unread or not. */
-  unread: Scalars['Boolean']['output'];
-};
+  unread: Scalars['Boolean']['output']
+}
 
-export type GQLUserNoticeType =
-  | 'MomentFeedApproved'
-  | 'UserNewFollower';
+export type GQLUserNoticeType = 'MomentFeedApproved' | 'UserNewFollower'
 
 export type GQLUserOss = {
-  __typename?: 'UserOSS';
-  boost: Scalars['Float']['output'];
-  featureFlags: Array<GQLUserFeatureFlag>;
-  momentFeedApplication?: Maybe<GQLMomentFeedApplication>;
-  restrictions: Array<GQLUserRestriction>;
-  score: Scalars['Float']['output'];
-};
+  __typename?: 'UserOSS'
+  boost: Scalars['Float']['output']
+  featureFlags: Array<GQLUserFeatureFlag>
+  momentFeedApplication?: Maybe<GQLMomentFeedApplication>
+  restrictions: Array<GQLUserRestriction>
+  score: Scalars['Float']['output']
+}
 
 export type GQLUserPostMomentActivity = {
-  __typename?: 'UserPostMomentActivity';
-  actor: GQLUser;
-  createdAt: Scalars['DateTime']['output'];
+  __typename?: 'UserPostMomentActivity'
+  actor: GQLUser
+  createdAt: Scalars['DateTime']['output']
   /** Another 3 moments posted by actor */
-  more: Array<GQLMoment>;
+  more: Array<GQLMoment>
   /** Moment posted by actor */
-  node: GQLMoment;
-};
+  node: GQLMoment
+}
 
 export type GQLUserPublishArticleActivity = {
-  __typename?: 'UserPublishArticleActivity';
-  actor: GQLUser;
-  createdAt: Scalars['DateTime']['output'];
+  __typename?: 'UserPublishArticleActivity'
+  actor: GQLUser
+  createdAt: Scalars['DateTime']['output']
   /** Article published by actor */
-  node: GQLArticle;
-};
+  node: GQLArticle
+}
 
 export type GQLUserRecommendationActivity = {
-  __typename?: 'UserRecommendationActivity';
+  __typename?: 'UserRecommendationActivity'
   /** Recommended users */
-  nodes?: Maybe<Array<GQLUser>>;
+  nodes?: Maybe<Array<GQLUser>>
   /** The source type of recommendation */
-  source?: Maybe<GQLUserRecommendationActivitySource>;
-};
+  source?: Maybe<GQLUserRecommendationActivitySource>
+}
 
-export type GQLUserRecommendationActivitySource =
-  | 'UserFollowing';
+export type GQLUserRecommendationActivitySource = 'UserFollowing'
 
 export type GQLUserRestriction = {
-  __typename?: 'UserRestriction';
-  createdAt: Scalars['DateTime']['output'];
-  type: GQLUserRestrictionType;
-};
+  __typename?: 'UserRestriction'
+  createdAt: Scalars['DateTime']['output']
+  type: GQLUserRestrictionType
+}
 
-export type GQLUserRestrictionType =
-  | 'articleHottest'
-  | 'articleNewest';
+export type GQLUserRestrictionType = 'articleHottest' | 'articleNewest'
 
-export type GQLUserRole =
-  | 'admin'
-  | 'user';
+export type GQLUserRole = 'admin' | 'user'
 
 export type GQLUserSettings = {
-  __typename?: 'UserSettings';
+  __typename?: 'UserSettings'
   /** User currency preference. */
-  currency: GQLQuoteCurrency;
+  currency: GQLQuoteCurrency
   /** User language setting. */
-  language: GQLUserLanguage;
+  language: GQLUserLanguage
   /** Notification settings. */
-  notification?: Maybe<GQLNotificationSetting>;
-};
+  notification?: Maybe<GQLNotificationSetting>
+}
 
-export type GQLUserState =
-  | 'active'
-  | 'archived'
-  | 'banned'
-  | 'frozen';
+export type GQLUserState = 'active' | 'archived' | 'banned' | 'frozen'
 
 export type GQLUserStatus = {
-  __typename?: 'UserStatus';
+  __typename?: 'UserStatus'
   /** Number of articles published by user */
-  articleCount: Scalars['Int']['output'];
+  articleCount: Scalars['Int']['output']
   /** Number of chances for the user to change email in a nature day. Reset in UTC+8 0:00 */
-  changeEmailTimesLeft: Scalars['Int']['output'];
+  changeEmailTimesLeft: Scalars['Int']['output']
   /** Number of comments posted by user. */
-  commentCount: Scalars['Int']['output'];
+  commentCount: Scalars['Int']['output']
   /** Number of articles donated by user */
-  donatedArticleCount: Scalars['Int']['output'];
+  donatedArticleCount: Scalars['Int']['output']
   /** Weather login password is set for email login. */
-  hasEmailLoginPassword: Scalars['Boolean']['output'];
+  hasEmailLoginPassword: Scalars['Boolean']['output']
   /** Whether user already set payment password. */
-  hasPaymentPassword: Scalars['Boolean']['output'];
+  hasPaymentPassword: Scalars['Boolean']['output']
   /** Number of moments posted by user */
-  momentCount: Scalars['Int']['output'];
+  momentCount: Scalars['Int']['output']
   /** Number of times of donations received by user */
-  receivedDonationCount: Scalars['Int']['output'];
+  receivedDonationCount: Scalars['Int']['output']
   /** User role and access level. */
-  role: GQLUserRole;
+  role: GQLUserRole
   /** User state. */
-  state: GQLUserState;
+  state: GQLUserState
   /** Number of referred user registration count (in Digital Nomad Campaign). */
-  totalReferredCount: Scalars['Int']['output'];
+  totalReferredCount: Scalars['Int']['output']
   /** Number of total written words. */
-  totalWordCount: Scalars['Int']['output'];
+  totalWordCount: Scalars['Int']['output']
   /** Whether there are unread activities from following. */
-  unreadFollowing: Scalars['Boolean']['output'];
+  unreadFollowing: Scalars['Boolean']['output']
   /** Number of unread notices. */
-  unreadNoticeCount: Scalars['Int']['output'];
-};
+  unreadNoticeCount: Scalars['Int']['output']
+}
 
 export type GQLVerificationCodeType =
   | 'email_otp'
   | 'email_verify'
   | 'payment_password_reset'
-  | 'register';
+  | 'register'
 
 export type GQLVerifyEmailInput = {
-  code: Scalars['String']['input'];
-  email: Scalars['String']['input'];
-};
+  code: Scalars['String']['input']
+  email: Scalars['String']['input']
+}
 
 /** Enums for vote types. */
-export type GQLVote =
-  | 'down'
-  | 'up';
+export type GQLVote = 'down' | 'up'
 
 export type GQLVoteCommentInput = {
-  id: Scalars['ID']['input'];
-  vote: GQLVote;
-};
+  id: Scalars['ID']['input']
+  vote: GQLVote
+}
 
 export type GQLWallet = {
-  __typename?: 'Wallet';
-  balance: GQLBalance;
+  __typename?: 'Wallet'
+  balance: GQLBalance
   /** The last four digits of the card. */
-  cardLast4?: Maybe<Scalars['String']['output']>;
+  cardLast4?: Maybe<Scalars['String']['output']>
   /** URL of Stripe Dashboard to manage subscription invoice and payment method */
-  customerPortal?: Maybe<Scalars['String']['output']>;
+  customerPortal?: Maybe<Scalars['String']['output']>
   /** Account of Stripe Connect to manage payout */
-  stripeAccount?: Maybe<GQLStripeAccount>;
-  transactions: GQLTransactionConnection;
-};
-
+  stripeAccount?: Maybe<GQLStripeAccount>
+  transactions: GQLTransactionConnection
+}
 
 export type GQLWalletTransactionsArgs = {
-  input: GQLTransactionsArgs;
-};
+  input: GQLTransactionsArgs
+}
 
 export type GQLWalletLoginInput = {
-  ethAddress: Scalars['String']['input'];
+  ethAddress: Scalars['String']['input']
   /** used in register */
-  language?: InputMaybe<GQLUserLanguage>;
+  language?: InputMaybe<GQLUserLanguage>
   /** nonce from generateSigningMessage */
-  nonce: Scalars['String']['input'];
-  referralCode?: InputMaybe<Scalars['String']['input']>;
+  nonce: Scalars['String']['input']
+  referralCode?: InputMaybe<Scalars['String']['input']>
   /** sign'ed by wallet */
-  signature: Scalars['String']['input'];
+  signature: Scalars['String']['input']
   /** the message being sign'ed, including nonce */
-  signedMessage: Scalars['String']['input'];
-};
+  signedMessage: Scalars['String']['input']
+}
 
 export type GQLWithdrawLockedTokensResult = {
-  __typename?: 'WithdrawLockedTokensResult';
-  transaction: GQLTransaction;
-};
+  __typename?: 'WithdrawLockedTokensResult'
+  transaction: GQLTransaction
+}
 
-export type GQLWriting = GQLArticle | GQLComment | GQLMoment;
+export type GQLWriting = GQLArticle | GQLComment | GQLMoment
 
-export type GQLWritingChallenge = GQLCampaign & GQLChannel & GQLNode & {
-  __typename?: 'WritingChallenge';
-  announcements: Array<GQLArticle>;
-  application?: Maybe<GQLCampaignApplication>;
-  applicationPeriod?: Maybe<GQLDatetimeRange>;
-  articles: GQLCampaignArticleConnection;
-  channelEnabled: Scalars['Boolean']['output'];
-  cover?: Maybe<Scalars['String']['output']>;
-  description?: Maybe<Scalars['String']['output']>;
-  /** Comments made by campaign participants (public to read). */
-  discussion: GQLCommentConnection;
-  /** Discussion (include replies) count of this campaign. */
-  discussionCount: Scalars['Int']['output'];
-  /** whether this campaign exposes a quote wall (post-to-wall affordance) */
-  enableQuoteWall: Scalars['Boolean']['output'];
-  featuredDescription: Scalars['String']['output'];
-  id: Scalars['ID']['output'];
-  isManager: Scalars['Boolean']['output'];
-  link: Scalars['String']['output'];
-  name: Scalars['String']['output'];
-  navbarTitle: Scalars['String']['output'];
-  organizers: Array<GQLUser>;
-  oss: GQLCampaignOss;
-  participants: GQLCampaignParticipantConnection;
-  /** Quote count of this campaign's quote wall. */
-  quoteCount: Scalars['Int']['output'];
-  /** Quotes on this campaign's quote wall (public). */
-  quotes: GQLQuoteConnection;
-  shortHash: Scalars['String']['output'];
-  showAd: Scalars['Boolean']['output'];
-  showOther: Scalars['Boolean']['output'];
-  stages: Array<GQLCampaignStage>;
-  state: GQLCampaignState;
-  writingPeriod?: Maybe<GQLDatetimeRange>;
-};
-
+export type GQLWritingChallenge = GQLCampaign &
+  GQLChannel &
+  GQLNode & {
+    __typename?: 'WritingChallenge'
+    announcements: Array<GQLArticle>
+    application?: Maybe<GQLCampaignApplication>
+    applicationPeriod?: Maybe<GQLDatetimeRange>
+    articles: GQLCampaignArticleConnection
+    channelEnabled: Scalars['Boolean']['output']
+    cover?: Maybe<Scalars['String']['output']>
+    description?: Maybe<Scalars['String']['output']>
+    /** Comments made by campaign participants (public to read). */
+    discussion: GQLCommentConnection
+    /** Discussion (include replies) count of this campaign. */
+    discussionCount: Scalars['Int']['output']
+    /** whether this campaign exposes a quote wall (post-to-wall affordance) */
+    enableQuoteWall: Scalars['Boolean']['output']
+    featuredDescription: Scalars['String']['output']
+    id: Scalars['ID']['output']
+    isManager: Scalars['Boolean']['output']
+    link: Scalars['String']['output']
+    name: Scalars['String']['output']
+    navbarTitle: Scalars['String']['output']
+    organizers: Array<GQLUser>
+    oss: GQLCampaignOss
+    participants: GQLCampaignParticipantConnection
+    /** Quote count of this campaign's quote wall. */
+    quoteCount: Scalars['Int']['output']
+    /** Quotes on this campaign's quote wall (public). */
+    quotes: GQLQuoteConnection
+    shortHash: Scalars['String']['output']
+    showAd: Scalars['Boolean']['output']
+    showOther: Scalars['Boolean']['output']
+    stages: Array<GQLCampaignStage>
+    state: GQLCampaignState
+    writingPeriod?: Maybe<GQLDatetimeRange>
+  }
 
 export type GQLWritingChallengeArticlesArgs = {
-  input: GQLCampaignArticlesInput;
-};
-
+  input: GQLCampaignArticlesInput
+}
 
 export type GQLWritingChallengeDescriptionArgs = {
-  input?: InputMaybe<GQLTranslationArgs>;
-};
-
+  input?: InputMaybe<GQLTranslationArgs>
+}
 
 export type GQLWritingChallengeDiscussionArgs = {
-  input: GQLCommentsInput;
-};
-
+  input: GQLCommentsInput
+}
 
 export type GQLWritingChallengeFeaturedDescriptionArgs = {
-  input?: InputMaybe<GQLTranslationArgs>;
-};
-
+  input?: InputMaybe<GQLTranslationArgs>
+}
 
 export type GQLWritingChallengeNameArgs = {
-  input?: InputMaybe<GQLTranslationArgs>;
-};
-
+  input?: InputMaybe<GQLTranslationArgs>
+}
 
 export type GQLWritingChallengeNavbarTitleArgs = {
-  input?: InputMaybe<GQLTranslationArgs>;
-};
-
+  input?: InputMaybe<GQLTranslationArgs>
+}
 
 export type GQLWritingChallengeParticipantsArgs = {
-  input: GQLCampaignParticipantsInput;
-};
-
+  input: GQLCampaignParticipantsInput
+}
 
 export type GQLWritingChallengeQuotesArgs = {
-  input: GQLQuotesInput;
-};
+  input: GQLQuotesInput
+}
 
 export type GQLWritingConnection = GQLConnection & {
-  __typename?: 'WritingConnection';
-  edges?: Maybe<Array<GQLWritingEdge>>;
-  pageInfo: GQLPageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename?: 'WritingConnection'
+  edges?: Maybe<Array<GQLWritingEdge>>
+  pageInfo: GQLPageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type GQLWritingEdge = {
-  __typename?: 'WritingEdge';
-  cursor: Scalars['String']['output'];
-  node: GQLWriting;
-};
+  __typename?: 'WritingEdge'
+  cursor: Scalars['String']['output']
+  node: GQLWriting
+}
 
 export type GQLWritingInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+}
 
-export type WithIndex<TObject> = TObject & Record<string, any>;
-export type ResolversObject<TObject> = WithIndex<TObject>;
+export type WithIndex<TObject> = TObject & Record<string, any>
+export type ResolversObject<TObject> = WithIndex<TObject>
 
-export type ResolverTypeWrapper<T> = Promise<T> | T;
+export type ResolverTypeWrapper<T> = Promise<T> | T
 
-export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> = ResolverFn<TResult, TParent, TContext, TArgs>;
+export type Resolver<
+  TResult,
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> = ResolverFn<TResult, TParent, TContext, TArgs>
 
 export type ResolverFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => Promise<TResult> | TResult;
+) => Promise<TResult> | TResult
 
 export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => AsyncIterable<TResult> | Promise<AsyncIterable<TResult>>;
+) => AsyncIterable<TResult> | Promise<AsyncIterable<TResult>>
 
 export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => TResult | Promise<TResult>;
+) => TResult | Promise<TResult>
 
-export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
-  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
-  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
+export interface SubscriptionSubscriberObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> {
+  subscribe: SubscriptionSubscribeFn<
+    { [key in TKey]: TResult },
+    TParent,
+    TContext,
+    TArgs
+  >
+  resolve?: SubscriptionResolveFn<
+    TResult,
+    { [key in TKey]: TResult },
+    TContext,
+    TArgs
+  >
 }
 
 export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
-  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
-  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>
 }
 
-export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+export type SubscriptionObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> =
   | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
-  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>
 
-export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
-  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
-  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
+export type SubscriptionResolver<
+  TResult,
+  TKey extends string,
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> =
+  | ((
+      ...args: any[]
+    ) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>
 
 export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
   parent: TParent,
   context: TContext,
   info: GraphQLResolveInfo
-) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
+) => Maybe<TTypes> | Promise<Maybe<TTypes>>
 
-export type IsTypeOfResolverFn<T = {}, TContext = {}> = (obj: T, context: TContext, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
+export type IsTypeOfResolverFn<T = {}, TContext = {}> = (
+  obj: T,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => boolean | Promise<boolean>
 
-export type NextResolverFn<T> = () => Promise<T>;
+export type NextResolverFn<T> = () => Promise<T>
 
-export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
+export type DirectiveResolverFn<
+  TResult = {},
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> = (
   next: NextResolverFn<TResult>,
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => TResult | Promise<TResult>;
+) => TResult | Promise<TResult>
 
 /** Mapping of union types */
-export type GQLResolversUnionTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
-  Donator: ( ETHWalletModel ) | ( UserModel );
-  FollowingActivity: ( Omit<GQLArticleRecommendationActivity, 'nodes'> & { nodes?: Maybe<Array<_RefType['Article']>> } ) | ( Omit<GQLCircleRecommendationActivity, 'nodes'> & { nodes?: Maybe<Array<_RefType['Circle']>> } ) | ( Omit<GQLUserAddArticleTagActivity, 'actor' | 'node' | 'target'> & { actor: _RefType['User'], node: _RefType['Article'], target: _RefType['Tag'] } ) | ( Omit<GQLUserBroadcastCircleActivity, 'actor' | 'node' | 'target'> & { actor: _RefType['User'], node: _RefType['Comment'], target: _RefType['Circle'] } ) | ( Omit<GQLUserCreateCircleActivity, 'actor' | 'node'> & { actor: _RefType['User'], node: _RefType['Circle'] } ) | ( Omit<GQLUserPostMomentActivity, 'actor' | 'more' | 'node'> & { actor: _RefType['User'], more: Array<_RefType['Moment']>, node: _RefType['Moment'] } ) | ( Omit<GQLUserPublishArticleActivity, 'actor' | 'node'> & { actor: _RefType['User'], node: _RefType['Article'] } ) | ( Omit<GQLUserRecommendationActivity, 'nodes'> & { nodes?: Maybe<Array<_RefType['User']>> } );
-  Invitee: ( GQLPerson ) | ( UserModel );
-  Response: ( ArticleModel ) | ( CommentModel );
-  TransactionTarget: ( ArticleModel ) | ( CircleModel ) | ( TransactionModel );
-  Writing: ( ArticleModel ) | ( CommentModel ) | ( MomentModel );
-}>;
+export type GQLResolversUnionTypes<_RefType extends Record<string, unknown>> =
+  ResolversObject<{
+    Donator: ETHWalletModel | UserModel
+    FollowingActivity:
+      | (Omit<GQLArticleRecommendationActivity, 'nodes'> & {
+          nodes?: Maybe<Array<_RefType['Article']>>
+        })
+      | (Omit<GQLCircleRecommendationActivity, 'nodes'> & {
+          nodes?: Maybe<Array<_RefType['Circle']>>
+        })
+      | (Omit<GQLUserAddArticleTagActivity, 'actor' | 'node' | 'target'> & {
+          actor: _RefType['User']
+          node: _RefType['Article']
+          target: _RefType['Tag']
+        })
+      | (Omit<GQLUserBroadcastCircleActivity, 'actor' | 'node' | 'target'> & {
+          actor: _RefType['User']
+          node: _RefType['Comment']
+          target: _RefType['Circle']
+        })
+      | (Omit<GQLUserCreateCircleActivity, 'actor' | 'node'> & {
+          actor: _RefType['User']
+          node: _RefType['Circle']
+        })
+      | (Omit<GQLUserPostMomentActivity, 'actor' | 'more' | 'node'> & {
+          actor: _RefType['User']
+          more: Array<_RefType['Moment']>
+          node: _RefType['Moment']
+        })
+      | (Omit<GQLUserPublishArticleActivity, 'actor' | 'node'> & {
+          actor: _RefType['User']
+          node: _RefType['Article']
+        })
+      | (Omit<GQLUserRecommendationActivity, 'nodes'> & {
+          nodes?: Maybe<Array<_RefType['User']>>
+        })
+    Invitee: GQLPerson | UserModel
+    Response: ArticleModel | CommentModel
+    TransactionTarget: ArticleModel | CircleModel | TransactionModel
+    Writing: ArticleModel | CommentModel | MomentModel
+  }>
 
 /** Mapping of interface types */
-export type GQLResolversInterfaceTypes<_RefType extends Record<string, unknown>> = ResolversObject<{
-  Campaign: ( CampaignModel );
-  Channel: ( CurationChannelModel ) | ( TagModel ) | ( TopicChannelModel ) | ( CampaignModel );
-  Connection: ( Omit<GQLAppreciationConnection, 'edges'> & { edges?: Maybe<Array<_RefType['AppreciationEdge']>> } ) | ( Omit<GQLArticleConnection, 'edges'> & { edges?: Maybe<Array<_RefType['ArticleEdge']>> } ) | ( Omit<GQLArticleVersionsConnection, 'edges'> & { edges: Array<Maybe<_RefType['ArticleVersionEdge']>> } ) | ( Omit<GQLCampaignArticleConnection, 'edges'> & { edges: Array<_RefType['CampaignArticleEdge']> } ) | ( Omit<GQLCampaignConnection, 'edges'> & { edges?: Maybe<Array<_RefType['CampaignEdge']>> } ) | ( Omit<GQLCampaignParticipantConnection, 'edges'> & { edges?: Maybe<Array<_RefType['CampaignParticipantEdge']>> } ) | ( Omit<GQLChannelArticleConnection, 'edges'> & { edges?: Maybe<Array<_RefType['ChannelArticleEdge']>> } ) | ( Omit<GQLCircleConnection, 'edges'> & { edges?: Maybe<Array<_RefType['CircleEdge']>> } ) | ( Omit<GQLCollectionConnection, 'edges'> & { edges?: Maybe<Array<_RefType['CollectionEdge']>> } ) | ( Omit<GQLCommentConnection, 'edges'> & { edges?: Maybe<Array<_RefType['CommentEdge']>> } ) | ( Omit<GQLCommunityWatchActionConnection, 'edges'> & { edges?: Maybe<Array<_RefType['CommunityWatchActionEdge']>> } ) | ( Omit<GQLDraftConnection, 'edges'> & { edges?: Maybe<Array<_RefType['DraftEdge']>> } ) | ( Omit<GQLFollowingActivityConnection, 'edges'> & { edges?: Maybe<Array<_RefType['FollowingActivityEdge']>> } ) | ( Omit<GQLIcymiTopicConnection, 'edges'> & { edges: Array<_RefType['IcymiTopicEdge']> } ) | ( Omit<GQLInvitationConnection, 'edges'> & { edges?: Maybe<Array<_RefType['InvitationEdge']>> } ) | ( Omit<GQLMemberConnection, 'edges'> & { edges?: Maybe<Array<_RefType['MemberEdge']>> } ) | ( Omit<GQLMomentConnection, 'edges'> & { edges?: Maybe<Array<_RefType['MomentEdge']>> } ) | ( Omit<GQLNoticeConnection, 'edges'> & { edges?: Maybe<Array<_RefType['NoticeEdge']>> } ) | ( Omit<GQLOAuthClientConnection, 'edges'> & { edges?: Maybe<Array<_RefType['OAuthClientEdge']>> } ) | ( Omit<GQLQuoteConnection, 'edges'> & { edges?: Maybe<Array<_RefType['QuoteEdge']>> } ) | ( Omit<GQLReadHistoryConnection, 'edges'> & { edges?: Maybe<Array<_RefType['ReadHistoryEdge']>> } ) | ( GQLRecentSearchConnection ) | ( Omit<GQLReportConnection, 'edges'> & { edges?: Maybe<Array<_RefType['ReportEdge']>> } ) | ( Omit<GQLResponseConnection, 'edges'> & { edges?: Maybe<Array<_RefType['ResponseEdge']>> } ) | ( Omit<GQLSearchResultConnection, 'edges'> & { edges?: Maybe<Array<_RefType['SearchResultEdge']>> } ) | ( GQLSkippedListItemsConnection ) | ( Omit<GQLSpamRingConnection, 'edges'> & { edges?: Maybe<Array<_RefType['SpamRingEdge']>> } ) | ( Omit<GQLSpamRingMemberConnection, 'edges'> & { edges?: Maybe<Array<_RefType['SpamRingMemberEdge']>> } ) | ( Omit<GQLTagConnection, 'edges'> & { edges?: Maybe<Array<_RefType['TagEdge']>> } ) | ( Omit<GQLTagWritingConnection, 'edges'> & { edges?: Maybe<Array<_RefType['TagWritingEdge']>> } ) | ( Omit<GQLTopDonatorConnection, 'edges'> & { edges?: Maybe<Array<_RefType['TopDonatorEdge']>> } ) | ( Omit<GQLTopicChannelFeedbackConnection, 'edges'> & { edges: Array<_RefType['TopicChannelFeedbackEdge']> } ) | ( Omit<GQLTransactionConnection, 'edges'> & { edges?: Maybe<Array<_RefType['TransactionEdge']>> } ) | ( Omit<GQLUserConnection, 'edges'> & { edges?: Maybe<Array<_RefType['UserEdge']>> } ) | ( Omit<GQLWritingConnection, 'edges'> & { edges?: Maybe<Array<_RefType['WritingEdge']>> } );
-  Node: ( ArticleModel ) | ( ArticleVersionModel ) | ( CircleModel ) | ( CollectionModel ) | ( CommentModel ) | ( CurationChannelModel ) | ( DraftModel ) | ( MattersChoiceTopicModel ) | ( MomentModel ) | ( ReportModel ) | ( SpamRingModel ) | ( TagModel ) | ( TopicChannelModel ) | ( UserModel ) | ( CampaignModel );
-  Notice: ( NoticeItemModel ) | ( NoticeItemModel ) | ( NoticeItemModel ) | ( NoticeItemModel ) | ( NoticeItemModel ) | ( NoticeItemModel ) | ( NoticeItemModel ) | ( NoticeItemModel ) | ( NoticeItemModel ) | ( NoticeItemModel ) | ( NoticeItemModel );
-  PinnableWork: ( ArticleModel ) | ( CollectionModel );
-}>;
+export type GQLResolversInterfaceTypes<
+  _RefType extends Record<string, unknown>
+> = ResolversObject<{
+  Campaign: CampaignModel
+  Channel: CurationChannelModel | TagModel | TopicChannelModel | CampaignModel
+  Connection:
+    | (Omit<GQLAppreciationConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['AppreciationEdge']>>
+      })
+    | (Omit<GQLArticleConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['ArticleEdge']>>
+      })
+    | (Omit<GQLArticleVersionsConnection, 'edges'> & {
+        edges: Array<Maybe<_RefType['ArticleVersionEdge']>>
+      })
+    | (Omit<GQLCampaignArticleConnection, 'edges'> & {
+        edges: Array<_RefType['CampaignArticleEdge']>
+      })
+    | (Omit<GQLCampaignConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['CampaignEdge']>>
+      })
+    | (Omit<GQLCampaignParticipantConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['CampaignParticipantEdge']>>
+      })
+    | (Omit<GQLChannelArticleConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['ChannelArticleEdge']>>
+      })
+    | (Omit<GQLCircleConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['CircleEdge']>>
+      })
+    | (Omit<GQLCollectionConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['CollectionEdge']>>
+      })
+    | (Omit<GQLCommentConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['CommentEdge']>>
+      })
+    | (Omit<GQLCommunityWatchActionConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['CommunityWatchActionEdge']>>
+      })
+    | (Omit<GQLDraftConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['DraftEdge']>>
+      })
+    | (Omit<GQLFollowingActivityConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['FollowingActivityEdge']>>
+      })
+    | (Omit<GQLIcymiTopicConnection, 'edges'> & {
+        edges: Array<_RefType['IcymiTopicEdge']>
+      })
+    | (Omit<GQLInvitationConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['InvitationEdge']>>
+      })
+    | (Omit<GQLMemberConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['MemberEdge']>>
+      })
+    | (Omit<GQLMomentConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['MomentEdge']>>
+      })
+    | (Omit<GQLNoticeConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['NoticeEdge']>>
+      })
+    | (Omit<GQLOAuthClientConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['OAuthClientEdge']>>
+      })
+    | (Omit<GQLQuoteConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['QuoteEdge']>>
+      })
+    | (Omit<GQLReadHistoryConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['ReadHistoryEdge']>>
+      })
+    | GQLRecentSearchConnection
+    | (Omit<GQLReportConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['ReportEdge']>>
+      })
+    | (Omit<GQLResponseConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['ResponseEdge']>>
+      })
+    | (Omit<GQLSearchResultConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['SearchResultEdge']>>
+      })
+    | GQLSkippedListItemsConnection
+    | (Omit<GQLSpamRingConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['SpamRingEdge']>>
+      })
+    | (Omit<GQLSpamRingMemberConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['SpamRingMemberEdge']>>
+      })
+    | (Omit<GQLTagConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['TagEdge']>>
+      })
+    | (Omit<GQLTagWritingConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['TagWritingEdge']>>
+      })
+    | (Omit<GQLTopDonatorConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['TopDonatorEdge']>>
+      })
+    | (Omit<GQLTopicChannelFeedbackConnection, 'edges'> & {
+        edges: Array<_RefType['TopicChannelFeedbackEdge']>
+      })
+    | (Omit<GQLTransactionConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['TransactionEdge']>>
+      })
+    | (Omit<GQLUserConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['UserEdge']>>
+      })
+    | (Omit<GQLWritingConnection, 'edges'> & {
+        edges?: Maybe<Array<_RefType['WritingEdge']>>
+      })
+  Node:
+    | ArticleModel
+    | ArticleVersionModel
+    | CircleModel
+    | CollectionModel
+    | CommentModel
+    | CurationChannelModel
+    | DraftModel
+    | MattersChoiceTopicModel
+    | MomentModel
+    | ReportModel
+    | SpamRingModel
+    | TagModel
+    | TopicChannelModel
+    | UserModel
+    | CampaignModel
+  Notice:
+    | NoticeItemModel
+    | NoticeItemModel
+    | NoticeItemModel
+    | NoticeItemModel
+    | NoticeItemModel
+    | NoticeItemModel
+    | NoticeItemModel
+    | NoticeItemModel
+    | NoticeItemModel
+    | NoticeItemModel
+    | NoticeItemModel
+  PinnableWork: ArticleModel | CollectionModel
+}>
 
 /** Mapping between all available schema types and the resolvers types */
 export type GQLResolversTypes = ResolversObject<{
-  AdStatus: ResolverTypeWrapper<GQLAdStatus>;
-  AddCollectionsArticlesInput: GQLAddCollectionsArticlesInput;
-  AddCreditInput: GQLAddCreditInput;
-  AddCreditResult: ResolverTypeWrapper<Omit<GQLAddCreditResult, 'transaction'> & { transaction: GQLResolversTypes['Transaction'] }>;
-  AddCurationChannelArticlesInput: GQLAddCurationChannelArticlesInput;
-  Announcement: ResolverTypeWrapper<AnnouncementModel>;
-  AnnouncementChannel: ResolverTypeWrapper<Omit<GQLAnnouncementChannel, 'channel'> & { channel: GQLResolversTypes['Channel'] }>;
-  AnnouncementChannelInput: GQLAnnouncementChannelInput;
-  AnnouncementType: GQLAnnouncementType;
-  AnnouncementsInput: GQLAnnouncementsInput;
-  ApplyCampaignInput: GQLApplyCampaignInput;
-  AppreciateArticleInput: GQLAppreciateArticleInput;
-  Appreciation: ResolverTypeWrapper<AppreciationModel>;
-  AppreciationConnection: ResolverTypeWrapper<Omit<GQLAppreciationConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['AppreciationEdge']>> }>;
-  AppreciationEdge: ResolverTypeWrapper<Omit<GQLAppreciationEdge, 'node'> & { node: GQLResolversTypes['Appreciation'] }>;
-  AppreciationPurpose: GQLAppreciationPurpose;
-  ArchiveUserFailure: ResolverTypeWrapper<GQLArchiveUserFailure>;
-  ArchiveUsersInput: GQLArchiveUsersInput;
-  ArchiveUsersResult: ResolverTypeWrapper<Omit<GQLArchiveUsersResult, 'archived'> & { archived: Array<GQLResolversTypes['User']> }>;
-  Article: ResolverTypeWrapper<ArticleModel>;
-  ArticleAccess: ResolverTypeWrapper<ArticleModel>;
-  ArticleAccessType: GQLArticleAccessType;
-  ArticleArticleNotice: ResolverTypeWrapper<NoticeItemModel>;
-  ArticleArticleNoticeType: GQLArticleArticleNoticeType;
-  ArticleCampaign: ResolverTypeWrapper<Omit<GQLArticleCampaign, 'campaign' | 'stage'> & { campaign: GQLResolversTypes['Campaign'], stage?: Maybe<GQLResolversTypes['CampaignStage']> }>;
-  ArticleCampaignInput: GQLArticleCampaignInput;
-  ArticleClassification: ResolverTypeWrapper<ArticleModel>;
-  ArticleConnection: ResolverTypeWrapper<Omit<GQLArticleConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['ArticleEdge']>> }>;
-  ArticleContents: ResolverTypeWrapper<ArticleVersionModel>;
-  ArticleDonation: ResolverTypeWrapper<Omit<GQLArticleDonation, 'sender'> & { sender?: Maybe<GQLResolversTypes['User']> }>;
-  ArticleDonationConnection: ResolverTypeWrapper<Omit<GQLArticleDonationConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['ArticleDonationEdge']>> }>;
-  ArticleDonationEdge: ResolverTypeWrapper<Omit<GQLArticleDonationEdge, 'node'> & { node: GQLResolversTypes['ArticleDonation'] }>;
-  ArticleEdge: ResolverTypeWrapper<Omit<GQLArticleEdge, 'node'> & { node: GQLResolversTypes['Article'] }>;
-  ArticleFederationEligibility: ResolverTypeWrapper<GQLArticleFederationEligibility>;
-  ArticleFederationSetting: ResolverTypeWrapper<GQLArticleFederationSetting>;
-  ArticleInput: GQLArticleInput;
-  ArticleLicenseType: GQLArticleLicenseType;
-  ArticleNotice: ResolverTypeWrapper<NoticeItemModel>;
-  ArticleNoticeType: GQLArticleNoticeType;
-  ArticleOSS: ResolverTypeWrapper<ArticleModel>;
-  ArticleRecommendationActivity: ResolverTypeWrapper<Omit<GQLArticleRecommendationActivity, 'nodes'> & { nodes?: Maybe<Array<GQLResolversTypes['Article']>> }>;
-  ArticleRecommendationActivitySource: GQLArticleRecommendationActivitySource;
-  ArticleState: GQLArticleState;
-  ArticleTopicChannel: ResolverTypeWrapper<Omit<GQLArticleTopicChannel, 'channel'> & { channel: GQLResolversTypes['TopicChannel'] }>;
-  ArticleTranslation: ResolverTypeWrapper<GQLArticleTranslation>;
-  ArticleTranslationInput: GQLArticleTranslationInput;
-  ArticleVersion: ResolverTypeWrapper<ArticleVersionModel>;
-  ArticleVersionEdge: ResolverTypeWrapper<Omit<GQLArticleVersionEdge, 'node'> & { node: GQLResolversTypes['ArticleVersion'] }>;
-  ArticleVersionsConnection: ResolverTypeWrapper<Omit<GQLArticleVersionsConnection, 'edges'> & { edges: Array<Maybe<GQLResolversTypes['ArticleVersionEdge']>> }>;
-  ArticleVersionsInput: GQLArticleVersionsInput;
-  ArticlesSort: GQLArticlesSort;
-  Asset: ResolverTypeWrapper<AssetModel>;
-  AssetType: GQLAssetType;
-  AuthResult: ResolverTypeWrapper<Omit<GQLAuthResult, 'user'> & { user?: Maybe<GQLResolversTypes['User']> }>;
-  AuthResultType: GQLAuthResultType;
-  AuthorsType: GQLAuthorsType;
-  Badge: ResolverTypeWrapper<GQLBadge>;
-  BadgeType: GQLBadgeType;
-  BadgedUsersInput: GQLBadgedUsersInput;
-  Balance: ResolverTypeWrapper<GQLBalance>;
-  BanCampaignArticlesInput: GQLBanCampaignArticlesInput;
-  BlockchainTransaction: ResolverTypeWrapper<GQLBlockchainTransaction>;
-  BlockedSearchKeyword: ResolverTypeWrapper<GQLBlockedSearchKeyword>;
-  Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
-  BoostTypes: GQLBoostTypes;
-  CacheControlScope: GQLCacheControlScope;
-  Campaign: ResolverTypeWrapper<CampaignModel>;
-  CampaignApplication: ResolverTypeWrapper<GQLCampaignApplication>;
-  CampaignApplicationState: GQLCampaignApplicationState;
-  CampaignArticleConnection: ResolverTypeWrapper<Omit<GQLCampaignArticleConnection, 'edges'> & { edges: Array<GQLResolversTypes['CampaignArticleEdge']> }>;
-  CampaignArticleEdge: ResolverTypeWrapper<Omit<GQLCampaignArticleEdge, 'node'> & { node: GQLResolversTypes['Article'] }>;
-  CampaignArticleNotice: ResolverTypeWrapper<NoticeItemModel>;
-  CampaignArticleNoticeType: GQLCampaignArticleNoticeType;
-  CampaignArticlesFilter: GQLCampaignArticlesFilter;
-  CampaignArticlesInput: GQLCampaignArticlesInput;
-  CampaignConnection: ResolverTypeWrapper<Omit<GQLCampaignConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['CampaignEdge']>> }>;
-  CampaignEdge: ResolverTypeWrapper<Omit<GQLCampaignEdge, 'node'> & { node: GQLResolversTypes['Campaign'] }>;
-  CampaignInput: GQLCampaignInput;
-  CampaignOSS: ResolverTypeWrapper<CampaignModel>;
-  CampaignParticipantConnection: ResolverTypeWrapper<Omit<GQLCampaignParticipantConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['CampaignParticipantEdge']>> }>;
-  CampaignParticipantEdge: ResolverTypeWrapper<Omit<GQLCampaignParticipantEdge, 'application' | 'node'> & { application?: Maybe<GQLResolversTypes['CampaignApplication']>, node: GQLResolversTypes['User'] }>;
-  CampaignParticipantsInput: GQLCampaignParticipantsInput;
-  CampaignStage: ResolverTypeWrapper<CampaignStageModel>;
-  CampaignStageInput: GQLCampaignStageInput;
-  CampaignState: GQLCampaignState;
-  CampaignsFilter: GQLCampaignsFilter;
-  CampaignsFilterSort: GQLCampaignsFilterSort;
-  CampaignsFilterState: GQLCampaignsFilterState;
-  CampaignsInput: GQLCampaignsInput;
-  Chain: GQLChain;
-  Channel: ResolverTypeWrapper<GQLResolversInterfaceTypes<GQLResolversTypes>['Channel']>;
-  ChannelArticleConnection: ResolverTypeWrapper<Omit<GQLChannelArticleConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['ChannelArticleEdge']>> }>;
-  ChannelArticleEdge: ResolverTypeWrapper<Omit<GQLChannelArticleEdge, 'node'> & { node: GQLResolversTypes['Article'] }>;
-  ChannelArticlesFilter: GQLChannelArticlesFilter;
-  ChannelArticlesInput: GQLChannelArticlesInput;
-  ChannelInput: GQLChannelInput;
-  ChannelsInput: GQLChannelsInput;
-  Circle: ResolverTypeWrapper<CircleModel>;
-  CircleAnalytics: ResolverTypeWrapper<CircleModel>;
-  CircleConnection: ResolverTypeWrapper<Omit<GQLCircleConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['CircleEdge']>> }>;
-  CircleContentAnalytics: ResolverTypeWrapper<CircleModel>;
-  CircleContentAnalyticsDatum: ResolverTypeWrapper<Omit<GQLCircleContentAnalyticsDatum, 'node'> & { node: GQLResolversTypes['Article'] }>;
-  CircleEdge: ResolverTypeWrapper<Omit<GQLCircleEdge, 'node'> & { node: GQLResolversTypes['Circle'] }>;
-  CircleFollowerAnalytics: ResolverTypeWrapper<CircleModel>;
-  CircleIncomeAnalytics: ResolverTypeWrapper<CircleModel>;
-  CircleInput: GQLCircleInput;
-  CircleNotice: ResolverTypeWrapper<NoticeItemModel>;
-  CircleNoticeType: GQLCircleNoticeType;
-  CircleRecommendationActivity: ResolverTypeWrapper<Omit<GQLCircleRecommendationActivity, 'nodes'> & { nodes?: Maybe<Array<GQLResolversTypes['Circle']>> }>;
-  CircleRecommendationActivitySource: GQLCircleRecommendationActivitySource;
-  CircleState: GQLCircleState;
-  CircleSubscriberAnalytics: ResolverTypeWrapper<CircleModel>;
-  ClaimLogbooksInput: GQLClaimLogbooksInput;
-  ClaimLogbooksResult: ResolverTypeWrapper<GQLClaimLogbooksResult>;
-  ClaimPersonhoodBadgeInput: GQLClaimPersonhoodBadgeInput;
-  ClassifyArticlesChannelsInput: GQLClassifyArticlesChannelsInput;
-  ClearCommunityWatchOriginalContentInput: GQLClearCommunityWatchOriginalContentInput;
-  ClearReadHistoryInput: GQLClearReadHistoryInput;
-  Collection: ResolverTypeWrapper<CollectionModel>;
-  CollectionArticlesInput: GQLCollectionArticlesInput;
-  CollectionConnection: ResolverTypeWrapper<Omit<GQLCollectionConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['CollectionEdge']>> }>;
-  CollectionEdge: ResolverTypeWrapper<Omit<GQLCollectionEdge, 'node'> & { node: GQLResolversTypes['Collection'] }>;
-  CollectionNotice: ResolverTypeWrapper<NoticeItemModel>;
-  Color: GQLColor;
-  Comment: ResolverTypeWrapper<CommentModel>;
-  CommentCommentNotice: ResolverTypeWrapper<NoticeItemModel>;
-  CommentCommentNoticeType: GQLCommentCommentNoticeType;
-  CommentCommentsInput: GQLCommentCommentsInput;
-  CommentConnection: ResolverTypeWrapper<Omit<GQLCommentConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['CommentEdge']>> }>;
-  CommentEdge: ResolverTypeWrapper<Omit<GQLCommentEdge, 'node'> & { node: GQLResolversTypes['Comment'] }>;
-  CommentInput: GQLCommentInput;
-  CommentNotice: ResolverTypeWrapper<NoticeItemModel>;
-  CommentNoticeType: GQLCommentNoticeType;
-  CommentSort: GQLCommentSort;
-  CommentState: GQLCommentState;
-  CommentType: GQLCommentType;
-  CommentsFilter: GQLCommentsFilter;
-  CommentsInput: GQLCommentsInput;
-  CommunityWatchAction: ResolverTypeWrapper<CommunityWatchActionModel>;
-  CommunityWatchActionConnection: ResolverTypeWrapper<Omit<GQLCommunityWatchActionConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['CommunityWatchActionEdge']>> }>;
-  CommunityWatchActionEdge: ResolverTypeWrapper<Omit<GQLCommunityWatchActionEdge, 'node'> & { node: GQLResolversTypes['CommunityWatchAction'] }>;
-  CommunityWatchActionInput: GQLCommunityWatchActionInput;
-  CommunityWatchActionSourceType: GQLCommunityWatchActionSourceType;
-  CommunityWatchActionState: GQLCommunityWatchActionState;
-  CommunityWatchActionsInput: GQLCommunityWatchActionsInput;
-  CommunityWatchAppealState: GQLCommunityWatchAppealState;
-  CommunityWatchRemoveCommentInput: GQLCommunityWatchRemoveCommentInput;
-  CommunityWatchRemoveCommentReason: GQLCommunityWatchRemoveCommentReason;
-  CommunityWatchReviewState: GQLCommunityWatchReviewState;
-  ConfirmVerificationCodeInput: GQLConfirmVerificationCodeInput;
-  ConnectStripeAccountInput: GQLConnectStripeAccountInput;
-  ConnectStripeAccountResult: ResolverTypeWrapper<GQLConnectStripeAccountResult>;
-  Connection: ResolverTypeWrapper<GQLResolversInterfaceTypes<GQLResolversTypes>['Connection']>;
-  ConnectionArgs: GQLConnectionArgs;
-  CreatePersonhoodHandoffInput: GQLCreatePersonhoodHandoffInput;
-  CryptoWallet: ResolverTypeWrapper<ETHWalletModel>;
-  CryptoWalletSignaturePurpose: GQLCryptoWalletSignaturePurpose;
-  CurationChannel: ResolverTypeWrapper<CurationChannelModel>;
-  CurationChannelState: GQLCurationChannelState;
-  DateTime: ResolverTypeWrapper<Scalars['DateTime']['output']>;
-  DatetimeRange: ResolverTypeWrapper<GQLDatetimeRange>;
-  DatetimeRangeInput: GQLDatetimeRangeInput;
-  DeleteAnnouncementsInput: GQLDeleteAnnouncementsInput;
-  DeleteCollectionArticlesInput: GQLDeleteCollectionArticlesInput;
-  DeleteCollectionsInput: GQLDeleteCollectionsInput;
-  DeleteCommentInput: GQLDeleteCommentInput;
-  DeleteCurationChannelArticlesInput: GQLDeleteCurationChannelArticlesInput;
-  DeleteDraftInput: GQLDeleteDraftInput;
-  DeleteMomentInput: GQLDeleteMomentInput;
-  DeleteQuoteInput: GQLDeleteQuoteInput;
-  DeleteTagsInput: GQLDeleteTagsInput;
-  DirectImageUploadInput: GQLDirectImageUploadInput;
-  DismissSpamRingInput: GQLDismissSpamRingInput;
-  Donator: ResolverTypeWrapper<GQLResolversUnionTypes<GQLResolversTypes>['Donator']>;
-  Draft: ResolverTypeWrapper<DraftModel>;
-  DraftAccess: ResolverTypeWrapper<DraftModel>;
-  DraftConnection: ResolverTypeWrapper<Omit<GQLDraftConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['DraftEdge']>> }>;
-  DraftEdge: ResolverTypeWrapper<Omit<GQLDraftEdge, 'node'> & { node: GQLResolversTypes['Draft'] }>;
-  EditArticleInput: GQLEditArticleInput;
-  EmailLoginInput: GQLEmailLoginInput;
-  EntityType: GQLEntityType;
-  ExchangeRate: ResolverTypeWrapper<GQLExchangeRate>;
-  ExchangeRatesInput: GQLExchangeRatesInput;
-  Feature: ResolverTypeWrapper<GQLFeature>;
-  FeatureFlag: GQLFeatureFlag;
-  FeatureName: GQLFeatureName;
-  FeaturedCommentsInput: GQLFeaturedCommentsInput;
-  FeaturedTagsInput: GQLFeaturedTagsInput;
-  FederationArticleSettingState: GQLFederationArticleSettingState;
-  FederationAuthorSettingState: GQLFederationAuthorSettingState;
-  FederationExportDecisionReason: GQLFederationExportDecisionReason;
-  FilterInput: GQLFilterInput;
-  Float: ResolverTypeWrapper<Scalars['Float']['output']>;
-  Following: ResolverTypeWrapper<UserModel>;
-  FollowingActivity: ResolverTypeWrapper<GQLResolversUnionTypes<GQLResolversTypes>['FollowingActivity']>;
-  FollowingActivityConnection: ResolverTypeWrapper<Omit<GQLFollowingActivityConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['FollowingActivityEdge']>> }>;
-  FollowingActivityEdge: ResolverTypeWrapper<Omit<GQLFollowingActivityEdge, 'node'> & { node: GQLResolversTypes['FollowingActivity'] }>;
-  FreezeSpamRingInput: GQLFreezeSpamRingInput;
-  FreezeSpamRingResult: ResolverTypeWrapper<Omit<GQLFreezeSpamRingResult, 'frozen' | 'ring' | 'skipped'> & { frozen: Array<GQLResolversTypes['User']>, ring: GQLResolversTypes['SpamRing'], skipped: Array<GQLResolversTypes['SpamRingSkip']> }>;
-  FrequentSearchInput: GQLFrequentSearchInput;
-  GenerateSigningMessageInput: GQLGenerateSigningMessageInput;
-  GrantType: GQLGrantType;
-  ID: ResolverTypeWrapper<Scalars['ID']['output']>;
-  IcymiTopic: ResolverTypeWrapper<MattersChoiceTopicModel>;
-  IcymiTopicConnection: ResolverTypeWrapper<Omit<GQLIcymiTopicConnection, 'edges'> & { edges: Array<GQLResolversTypes['IcymiTopicEdge']> }>;
-  IcymiTopicEdge: ResolverTypeWrapper<Omit<GQLIcymiTopicEdge, 'node'> & { node: GQLResolversTypes['IcymiTopic'] }>;
-  IcymiTopicState: GQLIcymiTopicState;
-  IdentityInput: GQLIdentityInput;
-  Int: ResolverTypeWrapper<Scalars['Int']['output']>;
-  Invitation: ResolverTypeWrapper<CircleInvitationModel>;
-  InvitationConnection: ResolverTypeWrapper<Omit<GQLInvitationConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['InvitationEdge']>> }>;
-  InvitationEdge: ResolverTypeWrapper<Omit<GQLInvitationEdge, 'node'> & { node: GQLResolversTypes['Invitation'] }>;
-  InvitationState: GQLInvitationState;
-  InviteCircleInput: GQLInviteCircleInput;
-  InviteCircleInvitee: GQLInviteCircleInvitee;
-  Invitee: ResolverTypeWrapper<GQLResolversUnionTypes<GQLResolversTypes>['Invitee']>;
-  Invites: ResolverTypeWrapper<CircleModel>;
-  KeywordInput: GQLKeywordInput;
-  KeywordsInput: GQLKeywordsInput;
-  LikeCollectionInput: GQLLikeCollectionInput;
-  LikeMomentInput: GQLLikeMomentInput;
-  Liker: ResolverTypeWrapper<UserModel>;
-  LogRecordInput: GQLLogRecordInput;
-  LogRecordTypes: GQLLogRecordTypes;
-  Member: ResolverTypeWrapper<CircleMemberModel>;
-  MemberConnection: ResolverTypeWrapper<Omit<GQLMemberConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['MemberEdge']>> }>;
-  MemberEdge: ResolverTypeWrapper<Omit<GQLMemberEdge, 'node'> & { node: GQLResolversTypes['Member'] }>;
-  MergeTagsInput: GQLMergeTagsInput;
-  MigrationInput: GQLMigrationInput;
-  MigrationType: GQLMigrationType;
-  Moment: ResolverTypeWrapper<MomentModel>;
-  MomentConnection: ResolverTypeWrapper<Omit<GQLMomentConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['MomentEdge']>> }>;
-  MomentEdge: ResolverTypeWrapper<Omit<GQLMomentEdge, 'node'> & { node: GQLResolversTypes['Moment'] }>;
-  MomentFeedApplication: ResolverTypeWrapper<MomentFeedUserModel>;
-  MomentFeedUserReviewedBy: GQLMomentFeedUserReviewedBy;
-  MomentFeedUserState: GQLMomentFeedUserState;
-  MomentFeedUsersInput: GQLMomentFeedUsersInput;
-  MomentInput: GQLMomentInput;
-  MomentNotice: ResolverTypeWrapper<NoticeItemModel>;
-  MomentNoticeType: GQLMomentNoticeType;
-  MomentState: GQLMomentState;
-  MonthlyDatum: ResolverTypeWrapper<GQLMonthlyDatum>;
-  Mutation: ResolverTypeWrapper<{}>;
-  NFTAsset: ResolverTypeWrapper<GQLNftAsset>;
-  Node: ResolverTypeWrapper<GQLResolversInterfaceTypes<GQLResolversTypes>['Node']>;
-  NodeInput: GQLNodeInput;
-  NodesInput: GQLNodesInput;
-  Notice: ResolverTypeWrapper<NoticeItemModel>;
-  NoticeConnection: ResolverTypeWrapper<Omit<GQLNoticeConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['NoticeEdge']>> }>;
-  NoticeEdge: ResolverTypeWrapper<Omit<GQLNoticeEdge, 'node'> & { node: GQLResolversTypes['Notice'] }>;
-  NotificationSetting: ResolverTypeWrapper<GQLNotificationSetting>;
-  NotificationSettingType: GQLNotificationSettingType;
-  OAuthClient: ResolverTypeWrapper<OAuthClientDBModel>;
-  OAuthClientConnection: ResolverTypeWrapper<Omit<GQLOAuthClientConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['OAuthClientEdge']>> }>;
-  OAuthClientEdge: ResolverTypeWrapper<Omit<GQLOAuthClientEdge, 'node'> & { node: GQLResolversTypes['OAuthClient'] }>;
-  OAuthClientInput: GQLOAuthClientInput;
-  OSS: ResolverTypeWrapper<Omit<GQLOss, 'articles' | 'badgedUsers' | 'comments' | 'icymiTopics' | 'momentFeedUsers' | 'moments' | 'oauthClients' | 'reports' | 'restrictedUsers' | 'seedingUsers' | 'spamRings' | 'tags' | 'topicChannelFeedbacks' | 'users'> & { articles: GQLResolversTypes['ArticleConnection'], badgedUsers: GQLResolversTypes['UserConnection'], comments: GQLResolversTypes['CommentConnection'], icymiTopics: GQLResolversTypes['IcymiTopicConnection'], momentFeedUsers: GQLResolversTypes['UserConnection'], moments: GQLResolversTypes['MomentConnection'], oauthClients: GQLResolversTypes['OAuthClientConnection'], reports: GQLResolversTypes['ReportConnection'], restrictedUsers: GQLResolversTypes['UserConnection'], seedingUsers: GQLResolversTypes['UserConnection'], spamRings: GQLResolversTypes['SpamRingConnection'], tags: GQLResolversTypes['TagConnection'], topicChannelFeedbacks: GQLResolversTypes['TopicChannelFeedbackConnection'], users: GQLResolversTypes['UserConnection'] }>;
-  OSSArticlesFilterInput: GQLOssArticlesFilterInput;
-  OSSArticlesInput: GQLOssArticlesInput;
-  OSSCommentsInput: GQLOssCommentsInput;
-  OSSContentSpamSort: GQLOssContentSpamSort;
-  OSSMomentsInput: GQLOssMomentsInput;
-  OSSReportsFilter: GQLOssReportsFilter;
-  OSSReportsInput: GQLOssReportsInput;
-  OSSSpamDatetimeFilterInput: GQLOssSpamDatetimeFilterInput;
-  OSSSpamRingsFilter: GQLOssSpamRingsFilter;
-  OSSSpamRingsInput: GQLOssSpamRingsInput;
-  Oauth1CredentialInput: GQLOauth1CredentialInput;
-  Official: ResolverTypeWrapper<Omit<GQLOfficial, 'announcements'> & { announcements?: Maybe<Array<GQLResolversTypes['Announcement']>> }>;
-  OfficialAnnouncementNotice: ResolverTypeWrapper<NoticeItemModel>;
-  PageInfo: ResolverTypeWrapper<GQLPageInfo>;
-  PayToInput: GQLPayToInput;
-  PayToResult: ResolverTypeWrapper<Omit<GQLPayToResult, 'transaction'> & { transaction: GQLResolversTypes['Transaction'] }>;
-  PayoutInput: GQLPayoutInput;
-  Person: ResolverTypeWrapper<GQLPerson>;
-  PersonhoodHandoff: ResolverTypeWrapper<GQLPersonhoodHandoff>;
-  PinCommentInput: GQLPinCommentInput;
-  PinHistory: ResolverTypeWrapper<Omit<GQLPinHistory, 'feed'> & { feed: GQLResolversTypes['Node'] }>;
-  PinnableWork: ResolverTypeWrapper<GQLResolversInterfaceTypes<GQLResolversTypes>['PinnableWork']>;
-  Price: ResolverTypeWrapper<CirclePriceModel>;
-  PriceState: GQLPriceState;
-  PublishArticleInput: GQLPublishArticleInput;
-  PublishState: GQLPublishState;
-  PutAnnouncementInput: GQLPutAnnouncementInput;
-  PutArticleFederationSettingInput: GQLPutArticleFederationSettingInput;
-  PutCircleArticlesInput: GQLPutCircleArticlesInput;
-  PutCircleArticlesType: GQLPutCircleArticlesType;
-  PutCircleInput: GQLPutCircleInput;
-  PutCollectionInput: GQLPutCollectionInput;
-  PutCommentInput: GQLPutCommentInput;
-  PutCurationChannelInput: GQLPutCurationChannelInput;
-  PutDraftInput: GQLPutDraftInput;
-  PutIcymiTopicInput: GQLPutIcymiTopicInput;
-  PutMomentInput: GQLPutMomentInput;
-  PutOAuthClientInput: GQLPutOAuthClientInput;
-  PutQuoteInput: GQLPutQuoteInput;
-  PutRemarkInput: GQLPutRemarkInput;
-  PutRestrictedUsersInput: GQLPutRestrictedUsersInput;
-  PutSkippedListItemInput: GQLPutSkippedListItemInput;
-  PutTagChannelInput: GQLPutTagChannelInput;
-  PutTopicChannelInput: GQLPutTopicChannelInput;
-  PutUserFeatureFlagsInput: GQLPutUserFeatureFlagsInput;
-  PutUserFederationSettingInput: GQLPutUserFederationSettingInput;
-  PutWritingChallengeInput: GQLPutWritingChallengeInput;
-  Query: ResolverTypeWrapper<{}>;
-  Quote: ResolverTypeWrapper<QuoteModel>;
-  QuoteConnection: ResolverTypeWrapper<Omit<GQLQuoteConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['QuoteEdge']>> }>;
-  QuoteCurrency: GQLQuoteCurrency;
-  QuoteEdge: ResolverTypeWrapper<Omit<GQLQuoteEdge, 'node'> & { node: GQLResolversTypes['Quote'] }>;
-  QuotesInput: GQLQuotesInput;
-  ReadArticleInput: GQLReadArticleInput;
-  ReadHistory: ResolverTypeWrapper<Omit<GQLReadHistory, 'article'> & { article: GQLResolversTypes['Article'] }>;
-  ReadHistoryConnection: ResolverTypeWrapper<Omit<GQLReadHistoryConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['ReadHistoryEdge']>> }>;
-  ReadHistoryEdge: ResolverTypeWrapper<Omit<GQLReadHistoryEdge, 'node'> & { node: GQLResolversTypes['ReadHistory'] }>;
-  RecentSearchConnection: ResolverTypeWrapper<GQLRecentSearchConnection>;
-  RecentSearchEdge: ResolverTypeWrapper<GQLRecentSearchEdge>;
-  RecommendFilterInput: GQLRecommendFilterInput;
-  RecommendInput: GQLRecommendInput;
-  RecommendTypes: GQLRecommendTypes;
-  Recommendation: ResolverTypeWrapper<UserModel>;
-  RecommendationFollowingFilterInput: GQLRecommendationFollowingFilterInput;
-  RecommendationFollowingFilterType: GQLRecommendationFollowingFilterType;
-  RecommendationFollowingInput: GQLRecommendationFollowingInput;
-  RecommendationNewestInput: GQLRecommendationNewestInput;
-  RefreshIPNSFeedInput: GQLRefreshIpnsFeedInput;
-  RelatedDonationArticlesInput: GQLRelatedDonationArticlesInput;
-  RemarkTypes: GQLRemarkTypes;
-  RemoveSocialLoginInput: GQLRemoveSocialLoginInput;
-  RenameTagInput: GQLRenameTagInput;
-  ReorderChannelsInput: GQLReorderChannelsInput;
-  ReorderCollectionArticlesInput: GQLReorderCollectionArticlesInput;
-  ReorderMoveInput: GQLReorderMoveInput;
-  Report: ResolverTypeWrapper<ReportModel>;
-  ReportConnection: ResolverTypeWrapper<Omit<GQLReportConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['ReportEdge']>> }>;
-  ReportEdge: ResolverTypeWrapper<Omit<GQLReportEdge, 'node'> & { node: GQLResolversTypes['Report'] }>;
-  ReportReason: GQLReportReason;
-  ReportSource: GQLReportSource;
-  ResetLikerIdInput: GQLResetLikerIdInput;
-  ResetPasswordInput: GQLResetPasswordInput;
-  ResetPasswordType: GQLResetPasswordType;
-  Response: ResolverTypeWrapper<GQLResolversUnionTypes<GQLResolversTypes>['Response']>;
-  ResponseConnection: ResolverTypeWrapper<Omit<GQLResponseConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['ResponseEdge']>> }>;
-  ResponseEdge: ResolverTypeWrapper<Omit<GQLResponseEdge, 'node'> & { node: GQLResolversTypes['Response'] }>;
-  ResponseSort: GQLResponseSort;
-  ResponsesInput: GQLResponsesInput;
-  RestoreCommunityWatchCommentInput: GQLRestoreCommunityWatchCommentInput;
-  ReviewTopicChannelFeedbackInput: GQLReviewTopicChannelFeedbackInput;
-  Role: GQLRole;
-  SearchAPIVersion: GQLSearchApiVersion;
-  SearchExclude: GQLSearchExclude;
-  SearchFilter: GQLSearchFilter;
-  SearchInput: GQLSearchInput;
-  SearchResultConnection: ResolverTypeWrapper<Omit<GQLSearchResultConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['SearchResultEdge']>> }>;
-  SearchResultEdge: ResolverTypeWrapper<Omit<GQLSearchResultEdge, 'node'> & { node: GQLResolversTypes['Node'] }>;
-  SearchTypes: GQLSearchTypes;
-  SendCampaignAnnouncementInput: GQLSendCampaignAnnouncementInput;
-  SendVerificationCodeInput: GQLSendVerificationCodeInput;
-  SetAdStatusInput: GQLSetAdStatusInput;
-  SetArticleFederationSettingInput: GQLSetArticleFederationSettingInput;
-  SetArticleTopicChannelsInput: GQLSetArticleTopicChannelsInput;
-  SetBoostInput: GQLSetBoostInput;
-  SetCurrencyInput: GQLSetCurrencyInput;
-  SetEmailInput: GQLSetEmailInput;
-  SetFeatureInput: GQLSetFeatureInput;
-  SetPasswordInput: GQLSetPasswordInput;
-  SetSpamStatusInput: GQLSetSpamStatusInput;
-  SetUserNameInput: GQLSetUserNameInput;
-  SetViewerFederationSettingInput: GQLSetViewerFederationSettingInput;
-  SigningMessagePurpose: GQLSigningMessagePurpose;
-  SigningMessageResult: ResolverTypeWrapper<GQLSigningMessageResult>;
-  SingleFileUploadInput: GQLSingleFileUploadInput;
-  SkippedListItem: ResolverTypeWrapper<GQLSkippedListItem>;
-  SkippedListItemEdge: ResolverTypeWrapper<GQLSkippedListItemEdge>;
-  SkippedListItemType: GQLSkippedListItemType;
-  SkippedListItemsConnection: ResolverTypeWrapper<GQLSkippedListItemsConnection>;
-  SkippedListItemsInput: GQLSkippedListItemsInput;
-  SocialAccount: ResolverTypeWrapper<GQLSocialAccount>;
-  SocialAccountType: GQLSocialAccountType;
-  SocialLoginInput: GQLSocialLoginInput;
-  SpamRing: ResolverTypeWrapper<SpamRingModel>;
-  SpamRingCandidateInput: GQLSpamRingCandidateInput;
-  SpamRingConnection: ResolverTypeWrapper<Omit<GQLSpamRingConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['SpamRingEdge']>> }>;
-  SpamRingEdge: ResolverTypeWrapper<Omit<GQLSpamRingEdge, 'node'> & { node: GQLResolversTypes['SpamRing'] }>;
-  SpamRingEvent: ResolverTypeWrapper<SpamRingEventModel>;
-  SpamRingEventAction: GQLSpamRingEventAction;
-  SpamRingMember: ResolverTypeWrapper<SpamRingMemberModel>;
-  SpamRingMemberConnection: ResolverTypeWrapper<Omit<GQLSpamRingMemberConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['SpamRingMemberEdge']>> }>;
-  SpamRingMemberEdge: ResolverTypeWrapper<Omit<GQLSpamRingMemberEdge, 'node'> & { node: GQLResolversTypes['SpamRingMember'] }>;
-  SpamRingMemberStatus: GQLSpamRingMemberStatus;
-  SpamRingSeverity: GQLSpamRingSeverity;
-  SpamRingSignals: ResolverTypeWrapper<SpamRingSignalsModel>;
-  SpamRingSignalsInput: GQLSpamRingSignalsInput;
-  SpamRingSkip: ResolverTypeWrapper<Omit<GQLSpamRingSkip, 'user'> & { user: GQLResolversTypes['User'] }>;
-  SpamRingStatus: GQLSpamRingStatus;
-  SpamRingsSort: GQLSpamRingsSort;
-  SpamStatus: ResolverTypeWrapper<GQLSpamStatus>;
-  String: ResolverTypeWrapper<Scalars['String']['output']>;
-  StripeAccount: ResolverTypeWrapper<PayoutAccountModel>;
-  StripeAccountCountry: GQLStripeAccountCountry;
-  SubmitReportInput: GQLSubmitReportInput;
-  SubmitTopicChannelFeedbackInput: GQLSubmitTopicChannelFeedbackInput;
-  SubscribeCircleInput: GQLSubscribeCircleInput;
-  SubscribeCircleResult: ResolverTypeWrapper<Omit<GQLSubscribeCircleResult, 'circle'> & { circle: GQLResolversTypes['Circle'] }>;
-  Tag: ResolverTypeWrapper<TagModel>;
-  TagArticlesInput: GQLTagArticlesInput;
-  TagArticlesSortBy: GQLTagArticlesSortBy;
-  TagConnection: ResolverTypeWrapper<Omit<GQLTagConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['TagEdge']>> }>;
-  TagEdge: ResolverTypeWrapper<Omit<GQLTagEdge, 'node'> & { node: GQLResolversTypes['Tag'] }>;
-  TagOSS: ResolverTypeWrapper<TagModel>;
-  TagWritingConnection: ResolverTypeWrapper<Omit<GQLTagWritingConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['TagWritingEdge']>> }>;
-  TagWritingEdge: ResolverTypeWrapper<Omit<GQLTagWritingEdge, 'node'> & { node: GQLResolversTypes['Writing'] }>;
-  TagsInput: GQLTagsInput;
-  TagsSort: GQLTagsSort;
-  ToggleCircleMemberInput: GQLToggleCircleMemberInput;
-  ToggleItemInput: GQLToggleItemInput;
-  TogglePinChannelArticlesInput: GQLTogglePinChannelArticlesInput;
-  ToggleRecommendInput: GQLToggleRecommendInput;
-  ToggleSeedingUsersInput: GQLToggleSeedingUsersInput;
-  ToggleUsersBadgeInput: GQLToggleUsersBadgeInput;
-  ToggleWritingChallengeFeaturedArticlesInput: GQLToggleWritingChallengeFeaturedArticlesInput;
-  TopDonatorConnection: ResolverTypeWrapper<Omit<GQLTopDonatorConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['TopDonatorEdge']>> }>;
-  TopDonatorEdge: ResolverTypeWrapper<Omit<GQLTopDonatorEdge, 'node'> & { node: GQLResolversTypes['Donator'] }>;
-  TopDonatorFilter: GQLTopDonatorFilter;
-  TopDonatorInput: GQLTopDonatorInput;
-  TopicChannel: ResolverTypeWrapper<TopicChannelModel>;
-  TopicChannelClassification: ResolverTypeWrapper<ArticleModel>;
-  TopicChannelFeedback: ResolverTypeWrapper<TopicChannelFeedbackModel>;
-  TopicChannelFeedbackAction: GQLTopicChannelFeedbackAction;
-  TopicChannelFeedbackConnection: ResolverTypeWrapper<Omit<GQLTopicChannelFeedbackConnection, 'edges'> & { edges: Array<GQLResolversTypes['TopicChannelFeedbackEdge']> }>;
-  TopicChannelFeedbackEdge: ResolverTypeWrapper<Omit<GQLTopicChannelFeedbackEdge, 'node'> & { node: GQLResolversTypes['TopicChannelFeedback'] }>;
-  TopicChannelFeedbackState: GQLTopicChannelFeedbackState;
-  TopicChannelFeedbackType: GQLTopicChannelFeedbackType;
-  TopicChannelFeedbacksFilterInput: GQLTopicChannelFeedbacksFilterInput;
-  TopicChannelFeedbacksInput: GQLTopicChannelFeedbacksInput;
-  Transaction: ResolverTypeWrapper<TransactionModel>;
-  TransactionConnection: ResolverTypeWrapper<Omit<GQLTransactionConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['TransactionEdge']>> }>;
-  TransactionCurrency: GQLTransactionCurrency;
-  TransactionEdge: ResolverTypeWrapper<Omit<GQLTransactionEdge, 'node'> & { node: GQLResolversTypes['Transaction'] }>;
-  TransactionNotice: ResolverTypeWrapper<NoticeItemModel>;
-  TransactionNoticeType: GQLTransactionNoticeType;
-  TransactionPurpose: GQLTransactionPurpose;
-  TransactionState: GQLTransactionState;
-  TransactionTarget: ResolverTypeWrapper<GQLResolversUnionTypes<GQLResolversTypes>['TransactionTarget']>;
-  TransactionsArgs: GQLTransactionsArgs;
-  TransactionsFilter: GQLTransactionsFilter;
-  TransactionsReceivedByArgs: GQLTransactionsReceivedByArgs;
-  TranslatedAnnouncement: ResolverTypeWrapper<GQLTranslatedAnnouncement>;
-  TranslationArgs: GQLTranslationArgs;
-  TranslationInput: GQLTranslationInput;
-  TranslationModel: GQLTranslationModel;
-  UnbindLikerIdInput: GQLUnbindLikerIdInput;
-  UnfreezeSpamRingInput: GQLUnfreezeSpamRingInput;
-  UnfreezeSpamRingResult: ResolverTypeWrapper<Omit<GQLUnfreezeSpamRingResult, 'ring' | 'skipped' | 'unbanned'> & { ring: GQLResolversTypes['SpamRing'], skipped: Array<GQLResolversTypes['SpamRingSkip']>, unbanned: Array<GQLResolversTypes['User']> }>;
-  UnlikeCollectionInput: GQLUnlikeCollectionInput;
-  UnlikeMomentInput: GQLUnlikeMomentInput;
-  UnpinCommentInput: GQLUnpinCommentInput;
-  UnsubscribeCircleInput: GQLUnsubscribeCircleInput;
-  UnvoteCommentInput: GQLUnvoteCommentInput;
-  UpdateArticleSensitiveInput: GQLUpdateArticleSensitiveInput;
-  UpdateArticleStateInput: GQLUpdateArticleStateInput;
-  UpdateCampaignApplicationStateInput: GQLUpdateCampaignApplicationStateInput;
-  UpdateCommentsStateInput: GQLUpdateCommentsStateInput;
-  UpdateCommunityWatchActionStateInput: GQLUpdateCommunityWatchActionStateInput;
-  UpdateMomentFeedApplicationStateInput: GQLUpdateMomentFeedApplicationStateInput;
-  UpdateNotificationSettingInput: GQLUpdateNotificationSettingInput;
-  UpdateUserExtraInput: GQLUpdateUserExtraInput;
-  UpdateUserInfoInput: GQLUpdateUserInfoInput;
-  UpdateUserRoleInput: GQLUpdateUserRoleInput;
-  UpdateUserStateInput: GQLUpdateUserStateInput;
-  Upload: ResolverTypeWrapper<Scalars['Upload']['output']>;
-  UpsertSpamRingCandidatesInput: GQLUpsertSpamRingCandidatesInput;
-  UpsertSpamRingCandidatesResult: ResolverTypeWrapper<Omit<GQLUpsertSpamRingCandidatesResult, 'rings'> & { rings: Array<GQLResolversTypes['SpamRing']> }>;
-  User: ResolverTypeWrapper<UserModel>;
-  UserActivity: ResolverTypeWrapper<UserModel>;
-  UserAddArticleTagActivity: ResolverTypeWrapper<Omit<GQLUserAddArticleTagActivity, 'actor' | 'node' | 'target'> & { actor: GQLResolversTypes['User'], node: GQLResolversTypes['Article'], target: GQLResolversTypes['Tag'] }>;
-  UserAnalytics: ResolverTypeWrapper<UserModel>;
-  UserArticlesFilter: GQLUserArticlesFilter;
-  UserArticlesInput: GQLUserArticlesInput;
-  UserArticlesSort: GQLUserArticlesSort;
-  UserBroadcastCircleActivity: ResolverTypeWrapper<Omit<GQLUserBroadcastCircleActivity, 'actor' | 'node' | 'target'> & { actor: GQLResolversTypes['User'], node: GQLResolversTypes['Comment'], target: GQLResolversTypes['Circle'] }>;
-  UserConnection: ResolverTypeWrapper<Omit<GQLUserConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['UserEdge']>> }>;
-  UserCreateCircleActivity: ResolverTypeWrapper<Omit<GQLUserCreateCircleActivity, 'actor' | 'node'> & { actor: GQLResolversTypes['User'], node: GQLResolversTypes['Circle'] }>;
-  UserEdge: ResolverTypeWrapper<Omit<GQLUserEdge, 'node'> & { node: GQLResolversTypes['User'] }>;
-  UserFeatureFlag: ResolverTypeWrapper<GQLUserFeatureFlag>;
-  UserFeatureFlagType: GQLUserFeatureFlagType;
-  UserFeatures: ResolverTypeWrapper<GQLUserFeatures>;
-  UserFederationSetting: ResolverTypeWrapper<GQLUserFederationSetting>;
-  UserGroup: GQLUserGroup;
-  UserInfo: ResolverTypeWrapper<UserModel>;
-  UserInfoFields: GQLUserInfoFields;
-  UserInput: GQLUserInput;
-  UserLanguage: GQLUserLanguage;
-  UserNotice: ResolverTypeWrapper<NoticeItemModel>;
-  UserNoticeType: GQLUserNoticeType;
-  UserOSS: ResolverTypeWrapper<UserModel>;
-  UserPostMomentActivity: ResolverTypeWrapper<Omit<GQLUserPostMomentActivity, 'actor' | 'more' | 'node'> & { actor: GQLResolversTypes['User'], more: Array<GQLResolversTypes['Moment']>, node: GQLResolversTypes['Moment'] }>;
-  UserPublishArticleActivity: ResolverTypeWrapper<Omit<GQLUserPublishArticleActivity, 'actor' | 'node'> & { actor: GQLResolversTypes['User'], node: GQLResolversTypes['Article'] }>;
-  UserRecommendationActivity: ResolverTypeWrapper<Omit<GQLUserRecommendationActivity, 'nodes'> & { nodes?: Maybe<Array<GQLResolversTypes['User']>> }>;
-  UserRecommendationActivitySource: GQLUserRecommendationActivitySource;
-  UserRestriction: ResolverTypeWrapper<GQLUserRestriction>;
-  UserRestrictionType: GQLUserRestrictionType;
-  UserRole: GQLUserRole;
-  UserSettings: ResolverTypeWrapper<UserModel>;
-  UserState: GQLUserState;
-  UserStatus: ResolverTypeWrapper<UserModel>;
-  VerificationCodeType: GQLVerificationCodeType;
-  VerifyEmailInput: GQLVerifyEmailInput;
-  Vote: GQLVote;
-  VoteCommentInput: GQLVoteCommentInput;
-  Wallet: ResolverTypeWrapper<UserModel>;
-  WalletLoginInput: GQLWalletLoginInput;
-  WithdrawLockedTokensResult: ResolverTypeWrapper<Omit<GQLWithdrawLockedTokensResult, 'transaction'> & { transaction: GQLResolversTypes['Transaction'] }>;
-  Writing: ResolverTypeWrapper<WritingModel>;
-  WritingChallenge: ResolverTypeWrapper<CampaignModel>;
-  WritingConnection: ResolverTypeWrapper<Omit<GQLWritingConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversTypes['WritingEdge']>> }>;
-  WritingEdge: ResolverTypeWrapper<Omit<GQLWritingEdge, 'node'> & { node: GQLResolversTypes['Writing'] }>;
-  WritingInput: GQLWritingInput;
-}>;
+  AdStatus: ResolverTypeWrapper<GQLAdStatus>
+  AddCollectionsArticlesInput: GQLAddCollectionsArticlesInput
+  AddCreditInput: GQLAddCreditInput
+  AddCreditResult: ResolverTypeWrapper<
+    Omit<GQLAddCreditResult, 'transaction'> & {
+      transaction: GQLResolversTypes['Transaction']
+    }
+  >
+  AddCurationChannelArticlesInput: GQLAddCurationChannelArticlesInput
+  Announcement: ResolverTypeWrapper<AnnouncementModel>
+  AnnouncementChannel: ResolverTypeWrapper<
+    Omit<GQLAnnouncementChannel, 'channel'> & {
+      channel: GQLResolversTypes['Channel']
+    }
+  >
+  AnnouncementChannelInput: GQLAnnouncementChannelInput
+  AnnouncementType: GQLAnnouncementType
+  AnnouncementsInput: GQLAnnouncementsInput
+  ApplyCampaignInput: GQLApplyCampaignInput
+  AppreciateArticleInput: GQLAppreciateArticleInput
+  Appreciation: ResolverTypeWrapper<AppreciationModel>
+  AppreciationConnection: ResolverTypeWrapper<
+    Omit<GQLAppreciationConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['AppreciationEdge']>>
+    }
+  >
+  AppreciationEdge: ResolverTypeWrapper<
+    Omit<GQLAppreciationEdge, 'node'> & {
+      node: GQLResolversTypes['Appreciation']
+    }
+  >
+  AppreciationPurpose: GQLAppreciationPurpose
+  ArchiveUserFailure: ResolverTypeWrapper<GQLArchiveUserFailure>
+  ArchiveUsersInput: GQLArchiveUsersInput
+  ArchiveUsersResult: ResolverTypeWrapper<
+    Omit<GQLArchiveUsersResult, 'archived'> & {
+      archived: Array<GQLResolversTypes['User']>
+    }
+  >
+  Article: ResolverTypeWrapper<ArticleModel>
+  ArticleAccess: ResolverTypeWrapper<ArticleModel>
+  ArticleAccessType: GQLArticleAccessType
+  ArticleArticleNotice: ResolverTypeWrapper<NoticeItemModel>
+  ArticleArticleNoticeType: GQLArticleArticleNoticeType
+  ArticleCampaign: ResolverTypeWrapper<
+    Omit<GQLArticleCampaign, 'campaign' | 'stage'> & {
+      campaign: GQLResolversTypes['Campaign']
+      stage?: Maybe<GQLResolversTypes['CampaignStage']>
+    }
+  >
+  ArticleCampaignInput: GQLArticleCampaignInput
+  ArticleClassification: ResolverTypeWrapper<ArticleModel>
+  ArticleConnection: ResolverTypeWrapper<
+    Omit<GQLArticleConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['ArticleEdge']>>
+    }
+  >
+  ArticleContents: ResolverTypeWrapper<ArticleVersionModel>
+  ArticleDonation: ResolverTypeWrapper<
+    Omit<GQLArticleDonation, 'sender'> & {
+      sender?: Maybe<GQLResolversTypes['User']>
+    }
+  >
+  ArticleDonationConnection: ResolverTypeWrapper<
+    Omit<GQLArticleDonationConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['ArticleDonationEdge']>>
+    }
+  >
+  ArticleDonationEdge: ResolverTypeWrapper<
+    Omit<GQLArticleDonationEdge, 'node'> & {
+      node: GQLResolversTypes['ArticleDonation']
+    }
+  >
+  ArticleEdge: ResolverTypeWrapper<
+    Omit<GQLArticleEdge, 'node'> & { node: GQLResolversTypes['Article'] }
+  >
+  ArticleFederationEligibility: ResolverTypeWrapper<GQLArticleFederationEligibility>
+  ArticleFederationSetting: ResolverTypeWrapper<GQLArticleFederationSetting>
+  ArticleInput: GQLArticleInput
+  ArticleLicenseType: GQLArticleLicenseType
+  ArticleNotice: ResolverTypeWrapper<NoticeItemModel>
+  ArticleNoticeType: GQLArticleNoticeType
+  ArticleOSS: ResolverTypeWrapper<ArticleModel>
+  ArticleRecommendationActivity: ResolverTypeWrapper<
+    Omit<GQLArticleRecommendationActivity, 'nodes'> & {
+      nodes?: Maybe<Array<GQLResolversTypes['Article']>>
+    }
+  >
+  ArticleRecommendationActivitySource: GQLArticleRecommendationActivitySource
+  ArticleState: GQLArticleState
+  ArticleTopicChannel: ResolverTypeWrapper<
+    Omit<GQLArticleTopicChannel, 'channel'> & {
+      channel: GQLResolversTypes['TopicChannel']
+    }
+  >
+  ArticleTranslation: ResolverTypeWrapper<GQLArticleTranslation>
+  ArticleTranslationInput: GQLArticleTranslationInput
+  ArticleVersion: ResolverTypeWrapper<ArticleVersionModel>
+  ArticleVersionEdge: ResolverTypeWrapper<
+    Omit<GQLArticleVersionEdge, 'node'> & {
+      node: GQLResolversTypes['ArticleVersion']
+    }
+  >
+  ArticleVersionsConnection: ResolverTypeWrapper<
+    Omit<GQLArticleVersionsConnection, 'edges'> & {
+      edges: Array<Maybe<GQLResolversTypes['ArticleVersionEdge']>>
+    }
+  >
+  ArticleVersionsInput: GQLArticleVersionsInput
+  ArticlesSort: GQLArticlesSort
+  Asset: ResolverTypeWrapper<AssetModel>
+  AssetType: GQLAssetType
+  AuthResult: ResolverTypeWrapper<
+    Omit<GQLAuthResult, 'user'> & { user?: Maybe<GQLResolversTypes['User']> }
+  >
+  AuthResultType: GQLAuthResultType
+  AuthorsType: GQLAuthorsType
+  Badge: ResolverTypeWrapper<GQLBadge>
+  BadgeType: GQLBadgeType
+  BadgedUsersInput: GQLBadgedUsersInput
+  Balance: ResolverTypeWrapper<GQLBalance>
+  BanCampaignArticlesInput: GQLBanCampaignArticlesInput
+  BlockchainTransaction: ResolverTypeWrapper<GQLBlockchainTransaction>
+  BlockedSearchKeyword: ResolverTypeWrapper<GQLBlockedSearchKeyword>
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>
+  BoostTypes: GQLBoostTypes
+  CacheControlScope: GQLCacheControlScope
+  Campaign: ResolverTypeWrapper<CampaignModel>
+  CampaignApplication: ResolverTypeWrapper<GQLCampaignApplication>
+  CampaignApplicationState: GQLCampaignApplicationState
+  CampaignArticleConnection: ResolverTypeWrapper<
+    Omit<GQLCampaignArticleConnection, 'edges'> & {
+      edges: Array<GQLResolversTypes['CampaignArticleEdge']>
+    }
+  >
+  CampaignArticleEdge: ResolverTypeWrapper<
+    Omit<GQLCampaignArticleEdge, 'node'> & {
+      node: GQLResolversTypes['Article']
+    }
+  >
+  CampaignArticleNotice: ResolverTypeWrapper<NoticeItemModel>
+  CampaignArticleNoticeType: GQLCampaignArticleNoticeType
+  CampaignArticlesFilter: GQLCampaignArticlesFilter
+  CampaignArticlesInput: GQLCampaignArticlesInput
+  CampaignConnection: ResolverTypeWrapper<
+    Omit<GQLCampaignConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['CampaignEdge']>>
+    }
+  >
+  CampaignEdge: ResolverTypeWrapper<
+    Omit<GQLCampaignEdge, 'node'> & { node: GQLResolversTypes['Campaign'] }
+  >
+  CampaignInput: GQLCampaignInput
+  CampaignOSS: ResolverTypeWrapper<CampaignModel>
+  CampaignParticipantConnection: ResolverTypeWrapper<
+    Omit<GQLCampaignParticipantConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['CampaignParticipantEdge']>>
+    }
+  >
+  CampaignParticipantEdge: ResolverTypeWrapper<
+    Omit<GQLCampaignParticipantEdge, 'application' | 'node'> & {
+      application?: Maybe<GQLResolversTypes['CampaignApplication']>
+      node: GQLResolversTypes['User']
+    }
+  >
+  CampaignParticipantsInput: GQLCampaignParticipantsInput
+  CampaignStage: ResolverTypeWrapper<CampaignStageModel>
+  CampaignStageInput: GQLCampaignStageInput
+  CampaignState: GQLCampaignState
+  CampaignsFilter: GQLCampaignsFilter
+  CampaignsFilterSort: GQLCampaignsFilterSort
+  CampaignsFilterState: GQLCampaignsFilterState
+  CampaignsInput: GQLCampaignsInput
+  Chain: GQLChain
+  Channel: ResolverTypeWrapper<
+    GQLResolversInterfaceTypes<GQLResolversTypes>['Channel']
+  >
+  ChannelArticleConnection: ResolverTypeWrapper<
+    Omit<GQLChannelArticleConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['ChannelArticleEdge']>>
+    }
+  >
+  ChannelArticleEdge: ResolverTypeWrapper<
+    Omit<GQLChannelArticleEdge, 'node'> & { node: GQLResolversTypes['Article'] }
+  >
+  ChannelArticlesFilter: GQLChannelArticlesFilter
+  ChannelArticlesInput: GQLChannelArticlesInput
+  ChannelInput: GQLChannelInput
+  ChannelsInput: GQLChannelsInput
+  Circle: ResolverTypeWrapper<CircleModel>
+  CircleAnalytics: ResolverTypeWrapper<CircleModel>
+  CircleConnection: ResolverTypeWrapper<
+    Omit<GQLCircleConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['CircleEdge']>>
+    }
+  >
+  CircleContentAnalytics: ResolverTypeWrapper<CircleModel>
+  CircleContentAnalyticsDatum: ResolverTypeWrapper<
+    Omit<GQLCircleContentAnalyticsDatum, 'node'> & {
+      node: GQLResolversTypes['Article']
+    }
+  >
+  CircleEdge: ResolverTypeWrapper<
+    Omit<GQLCircleEdge, 'node'> & { node: GQLResolversTypes['Circle'] }
+  >
+  CircleFollowerAnalytics: ResolverTypeWrapper<CircleModel>
+  CircleIncomeAnalytics: ResolverTypeWrapper<CircleModel>
+  CircleInput: GQLCircleInput
+  CircleNotice: ResolverTypeWrapper<NoticeItemModel>
+  CircleNoticeType: GQLCircleNoticeType
+  CircleRecommendationActivity: ResolverTypeWrapper<
+    Omit<GQLCircleRecommendationActivity, 'nodes'> & {
+      nodes?: Maybe<Array<GQLResolversTypes['Circle']>>
+    }
+  >
+  CircleRecommendationActivitySource: GQLCircleRecommendationActivitySource
+  CircleState: GQLCircleState
+  CircleSubscriberAnalytics: ResolverTypeWrapper<CircleModel>
+  ClaimLogbooksInput: GQLClaimLogbooksInput
+  ClaimLogbooksResult: ResolverTypeWrapper<GQLClaimLogbooksResult>
+  ClaimPersonhoodBadgeInput: GQLClaimPersonhoodBadgeInput
+  ClassifyArticlesChannelsInput: GQLClassifyArticlesChannelsInput
+  ClearCommunityWatchOriginalContentInput: GQLClearCommunityWatchOriginalContentInput
+  ClearReadHistoryInput: GQLClearReadHistoryInput
+  Collection: ResolverTypeWrapper<CollectionModel>
+  CollectionArticlesInput: GQLCollectionArticlesInput
+  CollectionConnection: ResolverTypeWrapper<
+    Omit<GQLCollectionConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['CollectionEdge']>>
+    }
+  >
+  CollectionEdge: ResolverTypeWrapper<
+    Omit<GQLCollectionEdge, 'node'> & { node: GQLResolversTypes['Collection'] }
+  >
+  CollectionNotice: ResolverTypeWrapper<NoticeItemModel>
+  Color: GQLColor
+  Comment: ResolverTypeWrapper<CommentModel>
+  CommentCommentNotice: ResolverTypeWrapper<NoticeItemModel>
+  CommentCommentNoticeType: GQLCommentCommentNoticeType
+  CommentCommentsInput: GQLCommentCommentsInput
+  CommentConnection: ResolverTypeWrapper<
+    Omit<GQLCommentConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['CommentEdge']>>
+    }
+  >
+  CommentEdge: ResolverTypeWrapper<
+    Omit<GQLCommentEdge, 'node'> & { node: GQLResolversTypes['Comment'] }
+  >
+  CommentInput: GQLCommentInput
+  CommentNotice: ResolverTypeWrapper<NoticeItemModel>
+  CommentNoticeType: GQLCommentNoticeType
+  CommentSort: GQLCommentSort
+  CommentState: GQLCommentState
+  CommentType: GQLCommentType
+  CommentsFilter: GQLCommentsFilter
+  CommentsInput: GQLCommentsInput
+  CommunityWatchAction: ResolverTypeWrapper<CommunityWatchActionModel>
+  CommunityWatchActionConnection: ResolverTypeWrapper<
+    Omit<GQLCommunityWatchActionConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['CommunityWatchActionEdge']>>
+    }
+  >
+  CommunityWatchActionEdge: ResolverTypeWrapper<
+    Omit<GQLCommunityWatchActionEdge, 'node'> & {
+      node: GQLResolversTypes['CommunityWatchAction']
+    }
+  >
+  CommunityWatchActionInput: GQLCommunityWatchActionInput
+  CommunityWatchActionSourceType: GQLCommunityWatchActionSourceType
+  CommunityWatchActionState: GQLCommunityWatchActionState
+  CommunityWatchActionsInput: GQLCommunityWatchActionsInput
+  CommunityWatchAppealState: GQLCommunityWatchAppealState
+  CommunityWatchRemoveCommentInput: GQLCommunityWatchRemoveCommentInput
+  CommunityWatchRemoveCommentReason: GQLCommunityWatchRemoveCommentReason
+  CommunityWatchReviewState: GQLCommunityWatchReviewState
+  ConfirmVerificationCodeInput: GQLConfirmVerificationCodeInput
+  ConnectStripeAccountInput: GQLConnectStripeAccountInput
+  ConnectStripeAccountResult: ResolverTypeWrapper<GQLConnectStripeAccountResult>
+  Connection: ResolverTypeWrapper<
+    GQLResolversInterfaceTypes<GQLResolversTypes>['Connection']
+  >
+  ConnectionArgs: GQLConnectionArgs
+  CreatePersonhoodHandoffInput: GQLCreatePersonhoodHandoffInput
+  CryptoWallet: ResolverTypeWrapper<ETHWalletModel>
+  CryptoWalletSignaturePurpose: GQLCryptoWalletSignaturePurpose
+  CurationChannel: ResolverTypeWrapper<CurationChannelModel>
+  CurationChannelState: GQLCurationChannelState
+  DateTime: ResolverTypeWrapper<Scalars['DateTime']['output']>
+  DatetimeRange: ResolverTypeWrapper<GQLDatetimeRange>
+  DatetimeRangeInput: GQLDatetimeRangeInput
+  DeleteAnnouncementsInput: GQLDeleteAnnouncementsInput
+  DeleteCollectionArticlesInput: GQLDeleteCollectionArticlesInput
+  DeleteCollectionsInput: GQLDeleteCollectionsInput
+  DeleteCommentInput: GQLDeleteCommentInput
+  DeleteCurationChannelArticlesInput: GQLDeleteCurationChannelArticlesInput
+  DeleteDraftInput: GQLDeleteDraftInput
+  DeleteMomentInput: GQLDeleteMomentInput
+  DeleteQuoteInput: GQLDeleteQuoteInput
+  DeleteTagsInput: GQLDeleteTagsInput
+  DirectImageUploadInput: GQLDirectImageUploadInput
+  DismissSpamRingInput: GQLDismissSpamRingInput
+  Donator: ResolverTypeWrapper<
+    GQLResolversUnionTypes<GQLResolversTypes>['Donator']
+  >
+  Draft: ResolverTypeWrapper<DraftModel>
+  DraftAccess: ResolverTypeWrapper<DraftModel>
+  DraftConnection: ResolverTypeWrapper<
+    Omit<GQLDraftConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['DraftEdge']>>
+    }
+  >
+  DraftEdge: ResolverTypeWrapper<
+    Omit<GQLDraftEdge, 'node'> & { node: GQLResolversTypes['Draft'] }
+  >
+  EditArticleInput: GQLEditArticleInput
+  EmailLoginInput: GQLEmailLoginInput
+  EntityType: GQLEntityType
+  ExchangeRate: ResolverTypeWrapper<GQLExchangeRate>
+  ExchangeRatesInput: GQLExchangeRatesInput
+  Feature: ResolverTypeWrapper<GQLFeature>
+  FeatureFlag: GQLFeatureFlag
+  FeatureName: GQLFeatureName
+  FeaturedCommentsInput: GQLFeaturedCommentsInput
+  FeaturedTagsInput: GQLFeaturedTagsInput
+  FederationArticleSettingState: GQLFederationArticleSettingState
+  FederationAuthorSettingState: GQLFederationAuthorSettingState
+  FederationExportDecisionReason: GQLFederationExportDecisionReason
+  FilterInput: GQLFilterInput
+  Float: ResolverTypeWrapper<Scalars['Float']['output']>
+  Following: ResolverTypeWrapper<UserModel>
+  FollowingActivity: ResolverTypeWrapper<
+    GQLResolversUnionTypes<GQLResolversTypes>['FollowingActivity']
+  >
+  FollowingActivityConnection: ResolverTypeWrapper<
+    Omit<GQLFollowingActivityConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['FollowingActivityEdge']>>
+    }
+  >
+  FollowingActivityEdge: ResolverTypeWrapper<
+    Omit<GQLFollowingActivityEdge, 'node'> & {
+      node: GQLResolversTypes['FollowingActivity']
+    }
+  >
+  FreezeSpamRingInput: GQLFreezeSpamRingInput
+  FreezeSpamRingResult: ResolverTypeWrapper<
+    Omit<GQLFreezeSpamRingResult, 'frozen' | 'ring' | 'skipped'> & {
+      frozen: Array<GQLResolversTypes['User']>
+      ring: GQLResolversTypes['SpamRing']
+      skipped: Array<GQLResolversTypes['SpamRingSkip']>
+    }
+  >
+  FrequentSearchInput: GQLFrequentSearchInput
+  GenerateSigningMessageInput: GQLGenerateSigningMessageInput
+  GrantType: GQLGrantType
+  ID: ResolverTypeWrapper<Scalars['ID']['output']>
+  IcymiTopic: ResolverTypeWrapper<MattersChoiceTopicModel>
+  IcymiTopicConnection: ResolverTypeWrapper<
+    Omit<GQLIcymiTopicConnection, 'edges'> & {
+      edges: Array<GQLResolversTypes['IcymiTopicEdge']>
+    }
+  >
+  IcymiTopicEdge: ResolverTypeWrapper<
+    Omit<GQLIcymiTopicEdge, 'node'> & { node: GQLResolversTypes['IcymiTopic'] }
+  >
+  IcymiTopicState: GQLIcymiTopicState
+  IdentityInput: GQLIdentityInput
+  Int: ResolverTypeWrapper<Scalars['Int']['output']>
+  Invitation: ResolverTypeWrapper<CircleInvitationModel>
+  InvitationConnection: ResolverTypeWrapper<
+    Omit<GQLInvitationConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['InvitationEdge']>>
+    }
+  >
+  InvitationEdge: ResolverTypeWrapper<
+    Omit<GQLInvitationEdge, 'node'> & { node: GQLResolversTypes['Invitation'] }
+  >
+  InvitationState: GQLInvitationState
+  InviteCircleInput: GQLInviteCircleInput
+  InviteCircleInvitee: GQLInviteCircleInvitee
+  Invitee: ResolverTypeWrapper<
+    GQLResolversUnionTypes<GQLResolversTypes>['Invitee']
+  >
+  Invites: ResolverTypeWrapper<CircleModel>
+  KeywordInput: GQLKeywordInput
+  KeywordsInput: GQLKeywordsInput
+  LikeCollectionInput: GQLLikeCollectionInput
+  LikeMomentInput: GQLLikeMomentInput
+  Liker: ResolverTypeWrapper<UserModel>
+  LogRecordInput: GQLLogRecordInput
+  LogRecordTypes: GQLLogRecordTypes
+  Member: ResolverTypeWrapper<CircleMemberModel>
+  MemberConnection: ResolverTypeWrapper<
+    Omit<GQLMemberConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['MemberEdge']>>
+    }
+  >
+  MemberEdge: ResolverTypeWrapper<
+    Omit<GQLMemberEdge, 'node'> & { node: GQLResolversTypes['Member'] }
+  >
+  MergeTagsInput: GQLMergeTagsInput
+  MigrationInput: GQLMigrationInput
+  MigrationType: GQLMigrationType
+  ModerationAutomationRole: GQLModerationAutomationRole
+  ModerationCase: ResolverTypeWrapper<GQLModerationCase>
+  ModerationCaseOutcome: GQLModerationCaseOutcome
+  ModerationCaseSource: GQLModerationCaseSource
+  ModerationCaseStatus: GQLModerationCaseStatus
+  ModerationNoticeState: GQLModerationNoticeState
+  ModerationTargetType: GQLModerationTargetType
+  Moment: ResolverTypeWrapper<MomentModel>
+  MomentConnection: ResolverTypeWrapper<
+    Omit<GQLMomentConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['MomentEdge']>>
+    }
+  >
+  MomentEdge: ResolverTypeWrapper<
+    Omit<GQLMomentEdge, 'node'> & { node: GQLResolversTypes['Moment'] }
+  >
+  MomentFeedApplication: ResolverTypeWrapper<MomentFeedUserModel>
+  MomentFeedUserReviewedBy: GQLMomentFeedUserReviewedBy
+  MomentFeedUserState: GQLMomentFeedUserState
+  MomentFeedUsersInput: GQLMomentFeedUsersInput
+  MomentInput: GQLMomentInput
+  MomentNotice: ResolverTypeWrapper<NoticeItemModel>
+  MomentNoticeType: GQLMomentNoticeType
+  MomentState: GQLMomentState
+  MonthlyDatum: ResolverTypeWrapper<GQLMonthlyDatum>
+  Mutation: ResolverTypeWrapper<{}>
+  NFTAsset: ResolverTypeWrapper<GQLNftAsset>
+  Node: ResolverTypeWrapper<
+    GQLResolversInterfaceTypes<GQLResolversTypes>['Node']
+  >
+  NodeInput: GQLNodeInput
+  NodesInput: GQLNodesInput
+  Notice: ResolverTypeWrapper<NoticeItemModel>
+  NoticeConnection: ResolverTypeWrapper<
+    Omit<GQLNoticeConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['NoticeEdge']>>
+    }
+  >
+  NoticeEdge: ResolverTypeWrapper<
+    Omit<GQLNoticeEdge, 'node'> & { node: GQLResolversTypes['Notice'] }
+  >
+  NotificationSetting: ResolverTypeWrapper<GQLNotificationSetting>
+  NotificationSettingType: GQLNotificationSettingType
+  OAuthClient: ResolverTypeWrapper<OAuthClientDBModel>
+  OAuthClientConnection: ResolverTypeWrapper<
+    Omit<GQLOAuthClientConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['OAuthClientEdge']>>
+    }
+  >
+  OAuthClientEdge: ResolverTypeWrapper<
+    Omit<GQLOAuthClientEdge, 'node'> & {
+      node: GQLResolversTypes['OAuthClient']
+    }
+  >
+  OAuthClientInput: GQLOAuthClientInput
+  OSS: ResolverTypeWrapper<
+    Omit<
+      GQLOss,
+      | 'articles'
+      | 'badgedUsers'
+      | 'comments'
+      | 'icymiTopics'
+      | 'momentFeedUsers'
+      | 'moments'
+      | 'oauthClients'
+      | 'reports'
+      | 'restrictedUsers'
+      | 'seedingUsers'
+      | 'spamRings'
+      | 'tags'
+      | 'topicChannelFeedbacks'
+      | 'users'
+    > & {
+      articles: GQLResolversTypes['ArticleConnection']
+      badgedUsers: GQLResolversTypes['UserConnection']
+      comments: GQLResolversTypes['CommentConnection']
+      icymiTopics: GQLResolversTypes['IcymiTopicConnection']
+      momentFeedUsers: GQLResolversTypes['UserConnection']
+      moments: GQLResolversTypes['MomentConnection']
+      oauthClients: GQLResolversTypes['OAuthClientConnection']
+      reports: GQLResolversTypes['ReportConnection']
+      restrictedUsers: GQLResolversTypes['UserConnection']
+      seedingUsers: GQLResolversTypes['UserConnection']
+      spamRings: GQLResolversTypes['SpamRingConnection']
+      tags: GQLResolversTypes['TagConnection']
+      topicChannelFeedbacks: GQLResolversTypes['TopicChannelFeedbackConnection']
+      users: GQLResolversTypes['UserConnection']
+    }
+  >
+  OSSArticlesFilterInput: GQLOssArticlesFilterInput
+  OSSArticlesInput: GQLOssArticlesInput
+  OSSCommentsInput: GQLOssCommentsInput
+  OSSContentSpamSort: GQLOssContentSpamSort
+  OSSMomentsInput: GQLOssMomentsInput
+  OSSReportsFilter: GQLOssReportsFilter
+  OSSReportsInput: GQLOssReportsInput
+  OSSSpamDatetimeFilterInput: GQLOssSpamDatetimeFilterInput
+  OSSSpamRingsFilter: GQLOssSpamRingsFilter
+  OSSSpamRingsInput: GQLOssSpamRingsInput
+  Oauth1CredentialInput: GQLOauth1CredentialInput
+  Official: ResolverTypeWrapper<
+    Omit<GQLOfficial, 'announcements'> & {
+      announcements?: Maybe<Array<GQLResolversTypes['Announcement']>>
+    }
+  >
+  OfficialAnnouncementNotice: ResolverTypeWrapper<NoticeItemModel>
+  PageInfo: ResolverTypeWrapper<GQLPageInfo>
+  PayToInput: GQLPayToInput
+  PayToResult: ResolverTypeWrapper<
+    Omit<GQLPayToResult, 'transaction'> & {
+      transaction: GQLResolversTypes['Transaction']
+    }
+  >
+  PayoutInput: GQLPayoutInput
+  Person: ResolverTypeWrapper<GQLPerson>
+  PersonhoodHandoff: ResolverTypeWrapper<GQLPersonhoodHandoff>
+  PinCommentInput: GQLPinCommentInput
+  PinHistory: ResolverTypeWrapper<
+    Omit<GQLPinHistory, 'feed'> & { feed: GQLResolversTypes['Node'] }
+  >
+  PinnableWork: ResolverTypeWrapper<
+    GQLResolversInterfaceTypes<GQLResolversTypes>['PinnableWork']
+  >
+  Price: ResolverTypeWrapper<CirclePriceModel>
+  PriceState: GQLPriceState
+  PublishArticleInput: GQLPublishArticleInput
+  PublishState: GQLPublishState
+  PutAnnouncementInput: GQLPutAnnouncementInput
+  PutArticleFederationSettingInput: GQLPutArticleFederationSettingInput
+  PutCircleArticlesInput: GQLPutCircleArticlesInput
+  PutCircleArticlesType: GQLPutCircleArticlesType
+  PutCircleInput: GQLPutCircleInput
+  PutCollectionInput: GQLPutCollectionInput
+  PutCommentInput: GQLPutCommentInput
+  PutCurationChannelInput: GQLPutCurationChannelInput
+  PutDraftInput: GQLPutDraftInput
+  PutIcymiTopicInput: GQLPutIcymiTopicInput
+  PutMomentInput: GQLPutMomentInput
+  PutOAuthClientInput: GQLPutOAuthClientInput
+  PutQuoteInput: GQLPutQuoteInput
+  PutRemarkInput: GQLPutRemarkInput
+  PutRestrictedUsersInput: GQLPutRestrictedUsersInput
+  PutSkippedListItemInput: GQLPutSkippedListItemInput
+  PutTagChannelInput: GQLPutTagChannelInput
+  PutTopicChannelInput: GQLPutTopicChannelInput
+  PutUserFeatureFlagsInput: GQLPutUserFeatureFlagsInput
+  PutUserFederationSettingInput: GQLPutUserFederationSettingInput
+  PutWritingChallengeInput: GQLPutWritingChallengeInput
+  Query: ResolverTypeWrapper<{}>
+  Quote: ResolverTypeWrapper<QuoteModel>
+  QuoteConnection: ResolverTypeWrapper<
+    Omit<GQLQuoteConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['QuoteEdge']>>
+    }
+  >
+  QuoteCurrency: GQLQuoteCurrency
+  QuoteEdge: ResolverTypeWrapper<
+    Omit<GQLQuoteEdge, 'node'> & { node: GQLResolversTypes['Quote'] }
+  >
+  QuotesInput: GQLQuotesInput
+  ReadArticleInput: GQLReadArticleInput
+  ReadHistory: ResolverTypeWrapper<
+    Omit<GQLReadHistory, 'article'> & { article: GQLResolversTypes['Article'] }
+  >
+  ReadHistoryConnection: ResolverTypeWrapper<
+    Omit<GQLReadHistoryConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['ReadHistoryEdge']>>
+    }
+  >
+  ReadHistoryEdge: ResolverTypeWrapper<
+    Omit<GQLReadHistoryEdge, 'node'> & {
+      node: GQLResolversTypes['ReadHistory']
+    }
+  >
+  RecentSearchConnection: ResolverTypeWrapper<GQLRecentSearchConnection>
+  RecentSearchEdge: ResolverTypeWrapper<GQLRecentSearchEdge>
+  RecommendFilterInput: GQLRecommendFilterInput
+  RecommendInput: GQLRecommendInput
+  RecommendTypes: GQLRecommendTypes
+  Recommendation: ResolverTypeWrapper<UserModel>
+  RecommendationFollowingFilterInput: GQLRecommendationFollowingFilterInput
+  RecommendationFollowingFilterType: GQLRecommendationFollowingFilterType
+  RecommendationFollowingInput: GQLRecommendationFollowingInput
+  RecommendationNewestInput: GQLRecommendationNewestInput
+  RefreshIPNSFeedInput: GQLRefreshIpnsFeedInput
+  RelatedDonationArticlesInput: GQLRelatedDonationArticlesInput
+  RemarkTypes: GQLRemarkTypes
+  RemoveSocialLoginInput: GQLRemoveSocialLoginInput
+  RenameTagInput: GQLRenameTagInput
+  ReorderChannelsInput: GQLReorderChannelsInput
+  ReorderCollectionArticlesInput: GQLReorderCollectionArticlesInput
+  ReorderMoveInput: GQLReorderMoveInput
+  Report: ResolverTypeWrapper<ReportModel>
+  ReportConnection: ResolverTypeWrapper<
+    Omit<GQLReportConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['ReportEdge']>>
+    }
+  >
+  ReportEdge: ResolverTypeWrapper<
+    Omit<GQLReportEdge, 'node'> & { node: GQLResolversTypes['Report'] }
+  >
+  ReportReason: GQLReportReason
+  ReportSource: GQLReportSource
+  ResetLikerIdInput: GQLResetLikerIdInput
+  ResetPasswordInput: GQLResetPasswordInput
+  ResetPasswordType: GQLResetPasswordType
+  Response: ResolverTypeWrapper<
+    GQLResolversUnionTypes<GQLResolversTypes>['Response']
+  >
+  ResponseConnection: ResolverTypeWrapper<
+    Omit<GQLResponseConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['ResponseEdge']>>
+    }
+  >
+  ResponseEdge: ResolverTypeWrapper<
+    Omit<GQLResponseEdge, 'node'> & { node: GQLResolversTypes['Response'] }
+  >
+  ResponseSort: GQLResponseSort
+  ResponsesInput: GQLResponsesInput
+  RestoreCommunityWatchCommentInput: GQLRestoreCommunityWatchCommentInput
+  ReviewTopicChannelFeedbackInput: GQLReviewTopicChannelFeedbackInput
+  Role: GQLRole
+  SearchAPIVersion: GQLSearchApiVersion
+  SearchExclude: GQLSearchExclude
+  SearchFilter: GQLSearchFilter
+  SearchInput: GQLSearchInput
+  SearchResultConnection: ResolverTypeWrapper<
+    Omit<GQLSearchResultConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['SearchResultEdge']>>
+    }
+  >
+  SearchResultEdge: ResolverTypeWrapper<
+    Omit<GQLSearchResultEdge, 'node'> & { node: GQLResolversTypes['Node'] }
+  >
+  SearchTypes: GQLSearchTypes
+  SendCampaignAnnouncementInput: GQLSendCampaignAnnouncementInput
+  SendVerificationCodeInput: GQLSendVerificationCodeInput
+  SetAdStatusInput: GQLSetAdStatusInput
+  SetArticleFederationSettingInput: GQLSetArticleFederationSettingInput
+  SetArticleTopicChannelsInput: GQLSetArticleTopicChannelsInput
+  SetBoostInput: GQLSetBoostInput
+  SetCurrencyInput: GQLSetCurrencyInput
+  SetEmailInput: GQLSetEmailInput
+  SetFeatureInput: GQLSetFeatureInput
+  SetPasswordInput: GQLSetPasswordInput
+  SetSpamStatusInput: GQLSetSpamStatusInput
+  SetUserNameInput: GQLSetUserNameInput
+  SetViewerFederationSettingInput: GQLSetViewerFederationSettingInput
+  SigningMessagePurpose: GQLSigningMessagePurpose
+  SigningMessageResult: ResolverTypeWrapper<GQLSigningMessageResult>
+  SingleFileUploadInput: GQLSingleFileUploadInput
+  SkippedListItem: ResolverTypeWrapper<GQLSkippedListItem>
+  SkippedListItemEdge: ResolverTypeWrapper<GQLSkippedListItemEdge>
+  SkippedListItemType: GQLSkippedListItemType
+  SkippedListItemsConnection: ResolverTypeWrapper<GQLSkippedListItemsConnection>
+  SkippedListItemsInput: GQLSkippedListItemsInput
+  SocialAccount: ResolverTypeWrapper<GQLSocialAccount>
+  SocialAccountType: GQLSocialAccountType
+  SocialLoginInput: GQLSocialLoginInput
+  SpamRing: ResolverTypeWrapper<SpamRingModel>
+  SpamRingCandidateInput: GQLSpamRingCandidateInput
+  SpamRingConnection: ResolverTypeWrapper<
+    Omit<GQLSpamRingConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['SpamRingEdge']>>
+    }
+  >
+  SpamRingEdge: ResolverTypeWrapper<
+    Omit<GQLSpamRingEdge, 'node'> & { node: GQLResolversTypes['SpamRing'] }
+  >
+  SpamRingEvent: ResolverTypeWrapper<SpamRingEventModel>
+  SpamRingEventAction: GQLSpamRingEventAction
+  SpamRingMember: ResolverTypeWrapper<SpamRingMemberModel>
+  SpamRingMemberConnection: ResolverTypeWrapper<
+    Omit<GQLSpamRingMemberConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['SpamRingMemberEdge']>>
+    }
+  >
+  SpamRingMemberEdge: ResolverTypeWrapper<
+    Omit<GQLSpamRingMemberEdge, 'node'> & {
+      node: GQLResolversTypes['SpamRingMember']
+    }
+  >
+  SpamRingMemberStatus: GQLSpamRingMemberStatus
+  SpamRingSeverity: GQLSpamRingSeverity
+  SpamRingSignals: ResolverTypeWrapper<SpamRingSignalsModel>
+  SpamRingSignalsInput: GQLSpamRingSignalsInput
+  SpamRingSkip: ResolverTypeWrapper<
+    Omit<GQLSpamRingSkip, 'user'> & { user: GQLResolversTypes['User'] }
+  >
+  SpamRingStatus: GQLSpamRingStatus
+  SpamRingsSort: GQLSpamRingsSort
+  SpamStatus: ResolverTypeWrapper<GQLSpamStatus>
+  String: ResolverTypeWrapper<Scalars['String']['output']>
+  StripeAccount: ResolverTypeWrapper<PayoutAccountModel>
+  StripeAccountCountry: GQLStripeAccountCountry
+  SubmitReportInput: GQLSubmitReportInput
+  SubmitTopicChannelFeedbackInput: GQLSubmitTopicChannelFeedbackInput
+  SubscribeCircleInput: GQLSubscribeCircleInput
+  SubscribeCircleResult: ResolverTypeWrapper<
+    Omit<GQLSubscribeCircleResult, 'circle'> & {
+      circle: GQLResolversTypes['Circle']
+    }
+  >
+  Tag: ResolverTypeWrapper<TagModel>
+  TagArticlesInput: GQLTagArticlesInput
+  TagArticlesSortBy: GQLTagArticlesSortBy
+  TagConnection: ResolverTypeWrapper<
+    Omit<GQLTagConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['TagEdge']>>
+    }
+  >
+  TagEdge: ResolverTypeWrapper<
+    Omit<GQLTagEdge, 'node'> & { node: GQLResolversTypes['Tag'] }
+  >
+  TagOSS: ResolverTypeWrapper<TagModel>
+  TagWritingConnection: ResolverTypeWrapper<
+    Omit<GQLTagWritingConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['TagWritingEdge']>>
+    }
+  >
+  TagWritingEdge: ResolverTypeWrapper<
+    Omit<GQLTagWritingEdge, 'node'> & { node: GQLResolversTypes['Writing'] }
+  >
+  TagsInput: GQLTagsInput
+  TagsSort: GQLTagsSort
+  ToggleCircleMemberInput: GQLToggleCircleMemberInput
+  ToggleItemInput: GQLToggleItemInput
+  TogglePinChannelArticlesInput: GQLTogglePinChannelArticlesInput
+  ToggleRecommendInput: GQLToggleRecommendInput
+  ToggleSeedingUsersInput: GQLToggleSeedingUsersInput
+  ToggleUsersBadgeInput: GQLToggleUsersBadgeInput
+  ToggleWritingChallengeFeaturedArticlesInput: GQLToggleWritingChallengeFeaturedArticlesInput
+  TopDonatorConnection: ResolverTypeWrapper<
+    Omit<GQLTopDonatorConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['TopDonatorEdge']>>
+    }
+  >
+  TopDonatorEdge: ResolverTypeWrapper<
+    Omit<GQLTopDonatorEdge, 'node'> & { node: GQLResolversTypes['Donator'] }
+  >
+  TopDonatorFilter: GQLTopDonatorFilter
+  TopDonatorInput: GQLTopDonatorInput
+  TopicChannel: ResolverTypeWrapper<TopicChannelModel>
+  TopicChannelClassification: ResolverTypeWrapper<ArticleModel>
+  TopicChannelFeedback: ResolverTypeWrapper<TopicChannelFeedbackModel>
+  TopicChannelFeedbackAction: GQLTopicChannelFeedbackAction
+  TopicChannelFeedbackConnection: ResolverTypeWrapper<
+    Omit<GQLTopicChannelFeedbackConnection, 'edges'> & {
+      edges: Array<GQLResolversTypes['TopicChannelFeedbackEdge']>
+    }
+  >
+  TopicChannelFeedbackEdge: ResolverTypeWrapper<
+    Omit<GQLTopicChannelFeedbackEdge, 'node'> & {
+      node: GQLResolversTypes['TopicChannelFeedback']
+    }
+  >
+  TopicChannelFeedbackState: GQLTopicChannelFeedbackState
+  TopicChannelFeedbackType: GQLTopicChannelFeedbackType
+  TopicChannelFeedbacksFilterInput: GQLTopicChannelFeedbacksFilterInput
+  TopicChannelFeedbacksInput: GQLTopicChannelFeedbacksInput
+  Transaction: ResolverTypeWrapper<TransactionModel>
+  TransactionConnection: ResolverTypeWrapper<
+    Omit<GQLTransactionConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['TransactionEdge']>>
+    }
+  >
+  TransactionCurrency: GQLTransactionCurrency
+  TransactionEdge: ResolverTypeWrapper<
+    Omit<GQLTransactionEdge, 'node'> & {
+      node: GQLResolversTypes['Transaction']
+    }
+  >
+  TransactionNotice: ResolverTypeWrapper<NoticeItemModel>
+  TransactionNoticeType: GQLTransactionNoticeType
+  TransactionPurpose: GQLTransactionPurpose
+  TransactionState: GQLTransactionState
+  TransactionTarget: ResolverTypeWrapper<
+    GQLResolversUnionTypes<GQLResolversTypes>['TransactionTarget']
+  >
+  TransactionsArgs: GQLTransactionsArgs
+  TransactionsFilter: GQLTransactionsFilter
+  TransactionsReceivedByArgs: GQLTransactionsReceivedByArgs
+  TranslatedAnnouncement: ResolverTypeWrapper<GQLTranslatedAnnouncement>
+  TranslationArgs: GQLTranslationArgs
+  TranslationInput: GQLTranslationInput
+  TranslationModel: GQLTranslationModel
+  UnbindLikerIdInput: GQLUnbindLikerIdInput
+  UnfreezeSpamRingInput: GQLUnfreezeSpamRingInput
+  UnfreezeSpamRingResult: ResolverTypeWrapper<
+    Omit<GQLUnfreezeSpamRingResult, 'ring' | 'skipped' | 'unbanned'> & {
+      ring: GQLResolversTypes['SpamRing']
+      skipped: Array<GQLResolversTypes['SpamRingSkip']>
+      unbanned: Array<GQLResolversTypes['User']>
+    }
+  >
+  UnlikeCollectionInput: GQLUnlikeCollectionInput
+  UnlikeMomentInput: GQLUnlikeMomentInput
+  UnpinCommentInput: GQLUnpinCommentInput
+  UnsubscribeCircleInput: GQLUnsubscribeCircleInput
+  UnvoteCommentInput: GQLUnvoteCommentInput
+  UpdateArticleSensitiveInput: GQLUpdateArticleSensitiveInput
+  UpdateArticleStateInput: GQLUpdateArticleStateInput
+  UpdateCampaignApplicationStateInput: GQLUpdateCampaignApplicationStateInput
+  UpdateCommentsStateInput: GQLUpdateCommentsStateInput
+  UpdateCommunityWatchActionStateInput: GQLUpdateCommunityWatchActionStateInput
+  UpdateModerationCaseInput: GQLUpdateModerationCaseInput
+  UpdateMomentFeedApplicationStateInput: GQLUpdateMomentFeedApplicationStateInput
+  UpdateNotificationSettingInput: GQLUpdateNotificationSettingInput
+  UpdateUserExtraInput: GQLUpdateUserExtraInput
+  UpdateUserInfoInput: GQLUpdateUserInfoInput
+  UpdateUserRoleInput: GQLUpdateUserRoleInput
+  UpdateUserStateInput: GQLUpdateUserStateInput
+  Upload: ResolverTypeWrapper<Scalars['Upload']['output']>
+  UpsertSpamRingCandidatesInput: GQLUpsertSpamRingCandidatesInput
+  UpsertSpamRingCandidatesResult: ResolverTypeWrapper<
+    Omit<GQLUpsertSpamRingCandidatesResult, 'rings'> & {
+      rings: Array<GQLResolversTypes['SpamRing']>
+    }
+  >
+  User: ResolverTypeWrapper<UserModel>
+  UserActivity: ResolverTypeWrapper<UserModel>
+  UserAddArticleTagActivity: ResolverTypeWrapper<
+    Omit<GQLUserAddArticleTagActivity, 'actor' | 'node' | 'target'> & {
+      actor: GQLResolversTypes['User']
+      node: GQLResolversTypes['Article']
+      target: GQLResolversTypes['Tag']
+    }
+  >
+  UserAnalytics: ResolverTypeWrapper<UserModel>
+  UserArticlesFilter: GQLUserArticlesFilter
+  UserArticlesInput: GQLUserArticlesInput
+  UserArticlesSort: GQLUserArticlesSort
+  UserBroadcastCircleActivity: ResolverTypeWrapper<
+    Omit<GQLUserBroadcastCircleActivity, 'actor' | 'node' | 'target'> & {
+      actor: GQLResolversTypes['User']
+      node: GQLResolversTypes['Comment']
+      target: GQLResolversTypes['Circle']
+    }
+  >
+  UserConnection: ResolverTypeWrapper<
+    Omit<GQLUserConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['UserEdge']>>
+    }
+  >
+  UserCreateCircleActivity: ResolverTypeWrapper<
+    Omit<GQLUserCreateCircleActivity, 'actor' | 'node'> & {
+      actor: GQLResolversTypes['User']
+      node: GQLResolversTypes['Circle']
+    }
+  >
+  UserEdge: ResolverTypeWrapper<
+    Omit<GQLUserEdge, 'node'> & { node: GQLResolversTypes['User'] }
+  >
+  UserFeatureFlag: ResolverTypeWrapper<GQLUserFeatureFlag>
+  UserFeatureFlagType: GQLUserFeatureFlagType
+  UserFeatures: ResolverTypeWrapper<GQLUserFeatures>
+  UserFederationSetting: ResolverTypeWrapper<GQLUserFederationSetting>
+  UserGroup: GQLUserGroup
+  UserInfo: ResolverTypeWrapper<UserModel>
+  UserInfoFields: GQLUserInfoFields
+  UserInput: GQLUserInput
+  UserLanguage: GQLUserLanguage
+  UserNotice: ResolverTypeWrapper<NoticeItemModel>
+  UserNoticeType: GQLUserNoticeType
+  UserOSS: ResolverTypeWrapper<UserModel>
+  UserPostMomentActivity: ResolverTypeWrapper<
+    Omit<GQLUserPostMomentActivity, 'actor' | 'more' | 'node'> & {
+      actor: GQLResolversTypes['User']
+      more: Array<GQLResolversTypes['Moment']>
+      node: GQLResolversTypes['Moment']
+    }
+  >
+  UserPublishArticleActivity: ResolverTypeWrapper<
+    Omit<GQLUserPublishArticleActivity, 'actor' | 'node'> & {
+      actor: GQLResolversTypes['User']
+      node: GQLResolversTypes['Article']
+    }
+  >
+  UserRecommendationActivity: ResolverTypeWrapper<
+    Omit<GQLUserRecommendationActivity, 'nodes'> & {
+      nodes?: Maybe<Array<GQLResolversTypes['User']>>
+    }
+  >
+  UserRecommendationActivitySource: GQLUserRecommendationActivitySource
+  UserRestriction: ResolverTypeWrapper<GQLUserRestriction>
+  UserRestrictionType: GQLUserRestrictionType
+  UserRole: GQLUserRole
+  UserSettings: ResolverTypeWrapper<UserModel>
+  UserState: GQLUserState
+  UserStatus: ResolverTypeWrapper<UserModel>
+  VerificationCodeType: GQLVerificationCodeType
+  VerifyEmailInput: GQLVerifyEmailInput
+  Vote: GQLVote
+  VoteCommentInput: GQLVoteCommentInput
+  Wallet: ResolverTypeWrapper<UserModel>
+  WalletLoginInput: GQLWalletLoginInput
+  WithdrawLockedTokensResult: ResolverTypeWrapper<
+    Omit<GQLWithdrawLockedTokensResult, 'transaction'> & {
+      transaction: GQLResolversTypes['Transaction']
+    }
+  >
+  Writing: ResolverTypeWrapper<WritingModel>
+  WritingChallenge: ResolverTypeWrapper<CampaignModel>
+  WritingConnection: ResolverTypeWrapper<
+    Omit<GQLWritingConnection, 'edges'> & {
+      edges?: Maybe<Array<GQLResolversTypes['WritingEdge']>>
+    }
+  >
+  WritingEdge: ResolverTypeWrapper<
+    Omit<GQLWritingEdge, 'node'> & { node: GQLResolversTypes['Writing'] }
+  >
+  WritingInput: GQLWritingInput
+}>
 
 /** Mapping between all available schema types and the resolvers parents */
 export type GQLResolversParentTypes = ResolversObject<{
-  AdStatus: GQLAdStatus;
-  AddCollectionsArticlesInput: GQLAddCollectionsArticlesInput;
-  AddCreditInput: GQLAddCreditInput;
-  AddCreditResult: Omit<GQLAddCreditResult, 'transaction'> & { transaction: GQLResolversParentTypes['Transaction'] };
-  AddCurationChannelArticlesInput: GQLAddCurationChannelArticlesInput;
-  Announcement: AnnouncementModel;
-  AnnouncementChannel: Omit<GQLAnnouncementChannel, 'channel'> & { channel: GQLResolversParentTypes['Channel'] };
-  AnnouncementChannelInput: GQLAnnouncementChannelInput;
-  AnnouncementsInput: GQLAnnouncementsInput;
-  ApplyCampaignInput: GQLApplyCampaignInput;
-  AppreciateArticleInput: GQLAppreciateArticleInput;
-  Appreciation: AppreciationModel;
-  AppreciationConnection: Omit<GQLAppreciationConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['AppreciationEdge']>> };
-  AppreciationEdge: Omit<GQLAppreciationEdge, 'node'> & { node: GQLResolversParentTypes['Appreciation'] };
-  ArchiveUserFailure: GQLArchiveUserFailure;
-  ArchiveUsersInput: GQLArchiveUsersInput;
-  ArchiveUsersResult: Omit<GQLArchiveUsersResult, 'archived'> & { archived: Array<GQLResolversParentTypes['User']> };
-  Article: ArticleModel;
-  ArticleAccess: ArticleModel;
-  ArticleArticleNotice: NoticeItemModel;
-  ArticleCampaign: Omit<GQLArticleCampaign, 'campaign' | 'stage'> & { campaign: GQLResolversParentTypes['Campaign'], stage?: Maybe<GQLResolversParentTypes['CampaignStage']> };
-  ArticleCampaignInput: GQLArticleCampaignInput;
-  ArticleClassification: ArticleModel;
-  ArticleConnection: Omit<GQLArticleConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['ArticleEdge']>> };
-  ArticleContents: ArticleVersionModel;
-  ArticleDonation: Omit<GQLArticleDonation, 'sender'> & { sender?: Maybe<GQLResolversParentTypes['User']> };
-  ArticleDonationConnection: Omit<GQLArticleDonationConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['ArticleDonationEdge']>> };
-  ArticleDonationEdge: Omit<GQLArticleDonationEdge, 'node'> & { node: GQLResolversParentTypes['ArticleDonation'] };
-  ArticleEdge: Omit<GQLArticleEdge, 'node'> & { node: GQLResolversParentTypes['Article'] };
-  ArticleFederationEligibility: GQLArticleFederationEligibility;
-  ArticleFederationSetting: GQLArticleFederationSetting;
-  ArticleInput: GQLArticleInput;
-  ArticleNotice: NoticeItemModel;
-  ArticleOSS: ArticleModel;
-  ArticleRecommendationActivity: Omit<GQLArticleRecommendationActivity, 'nodes'> & { nodes?: Maybe<Array<GQLResolversParentTypes['Article']>> };
-  ArticleTopicChannel: Omit<GQLArticleTopicChannel, 'channel'> & { channel: GQLResolversParentTypes['TopicChannel'] };
-  ArticleTranslation: GQLArticleTranslation;
-  ArticleTranslationInput: GQLArticleTranslationInput;
-  ArticleVersion: ArticleVersionModel;
-  ArticleVersionEdge: Omit<GQLArticleVersionEdge, 'node'> & { node: GQLResolversParentTypes['ArticleVersion'] };
-  ArticleVersionsConnection: Omit<GQLArticleVersionsConnection, 'edges'> & { edges: Array<Maybe<GQLResolversParentTypes['ArticleVersionEdge']>> };
-  ArticleVersionsInput: GQLArticleVersionsInput;
-  Asset: AssetModel;
-  AuthResult: Omit<GQLAuthResult, 'user'> & { user?: Maybe<GQLResolversParentTypes['User']> };
-  Badge: GQLBadge;
-  BadgedUsersInput: GQLBadgedUsersInput;
-  Balance: GQLBalance;
-  BanCampaignArticlesInput: GQLBanCampaignArticlesInput;
-  BlockchainTransaction: GQLBlockchainTransaction;
-  BlockedSearchKeyword: GQLBlockedSearchKeyword;
-  Boolean: Scalars['Boolean']['output'];
-  Campaign: CampaignModel;
-  CampaignApplication: GQLCampaignApplication;
-  CampaignArticleConnection: Omit<GQLCampaignArticleConnection, 'edges'> & { edges: Array<GQLResolversParentTypes['CampaignArticleEdge']> };
-  CampaignArticleEdge: Omit<GQLCampaignArticleEdge, 'node'> & { node: GQLResolversParentTypes['Article'] };
-  CampaignArticleNotice: NoticeItemModel;
-  CampaignArticlesFilter: GQLCampaignArticlesFilter;
-  CampaignArticlesInput: GQLCampaignArticlesInput;
-  CampaignConnection: Omit<GQLCampaignConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['CampaignEdge']>> };
-  CampaignEdge: Omit<GQLCampaignEdge, 'node'> & { node: GQLResolversParentTypes['Campaign'] };
-  CampaignInput: GQLCampaignInput;
-  CampaignOSS: CampaignModel;
-  CampaignParticipantConnection: Omit<GQLCampaignParticipantConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['CampaignParticipantEdge']>> };
-  CampaignParticipantEdge: Omit<GQLCampaignParticipantEdge, 'application' | 'node'> & { application?: Maybe<GQLResolversParentTypes['CampaignApplication']>, node: GQLResolversParentTypes['User'] };
-  CampaignParticipantsInput: GQLCampaignParticipantsInput;
-  CampaignStage: CampaignStageModel;
-  CampaignStageInput: GQLCampaignStageInput;
-  CampaignsFilter: GQLCampaignsFilter;
-  CampaignsInput: GQLCampaignsInput;
-  Channel: GQLResolversInterfaceTypes<GQLResolversParentTypes>['Channel'];
-  ChannelArticleConnection: Omit<GQLChannelArticleConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['ChannelArticleEdge']>> };
-  ChannelArticleEdge: Omit<GQLChannelArticleEdge, 'node'> & { node: GQLResolversParentTypes['Article'] };
-  ChannelArticlesFilter: GQLChannelArticlesFilter;
-  ChannelArticlesInput: GQLChannelArticlesInput;
-  ChannelInput: GQLChannelInput;
-  ChannelsInput: GQLChannelsInput;
-  Circle: CircleModel;
-  CircleAnalytics: CircleModel;
-  CircleConnection: Omit<GQLCircleConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['CircleEdge']>> };
-  CircleContentAnalytics: CircleModel;
-  CircleContentAnalyticsDatum: Omit<GQLCircleContentAnalyticsDatum, 'node'> & { node: GQLResolversParentTypes['Article'] };
-  CircleEdge: Omit<GQLCircleEdge, 'node'> & { node: GQLResolversParentTypes['Circle'] };
-  CircleFollowerAnalytics: CircleModel;
-  CircleIncomeAnalytics: CircleModel;
-  CircleInput: GQLCircleInput;
-  CircleNotice: NoticeItemModel;
-  CircleRecommendationActivity: Omit<GQLCircleRecommendationActivity, 'nodes'> & { nodes?: Maybe<Array<GQLResolversParentTypes['Circle']>> };
-  CircleSubscriberAnalytics: CircleModel;
-  ClaimLogbooksInput: GQLClaimLogbooksInput;
-  ClaimLogbooksResult: GQLClaimLogbooksResult;
-  ClaimPersonhoodBadgeInput: GQLClaimPersonhoodBadgeInput;
-  ClassifyArticlesChannelsInput: GQLClassifyArticlesChannelsInput;
-  ClearCommunityWatchOriginalContentInput: GQLClearCommunityWatchOriginalContentInput;
-  ClearReadHistoryInput: GQLClearReadHistoryInput;
-  Collection: CollectionModel;
-  CollectionArticlesInput: GQLCollectionArticlesInput;
-  CollectionConnection: Omit<GQLCollectionConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['CollectionEdge']>> };
-  CollectionEdge: Omit<GQLCollectionEdge, 'node'> & { node: GQLResolversParentTypes['Collection'] };
-  CollectionNotice: NoticeItemModel;
-  Comment: CommentModel;
-  CommentCommentNotice: NoticeItemModel;
-  CommentCommentsInput: GQLCommentCommentsInput;
-  CommentConnection: Omit<GQLCommentConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['CommentEdge']>> };
-  CommentEdge: Omit<GQLCommentEdge, 'node'> & { node: GQLResolversParentTypes['Comment'] };
-  CommentInput: GQLCommentInput;
-  CommentNotice: NoticeItemModel;
-  CommentsFilter: GQLCommentsFilter;
-  CommentsInput: GQLCommentsInput;
-  CommunityWatchAction: CommunityWatchActionModel;
-  CommunityWatchActionConnection: Omit<GQLCommunityWatchActionConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['CommunityWatchActionEdge']>> };
-  CommunityWatchActionEdge: Omit<GQLCommunityWatchActionEdge, 'node'> & { node: GQLResolversParentTypes['CommunityWatchAction'] };
-  CommunityWatchActionInput: GQLCommunityWatchActionInput;
-  CommunityWatchActionsInput: GQLCommunityWatchActionsInput;
-  CommunityWatchRemoveCommentInput: GQLCommunityWatchRemoveCommentInput;
-  ConfirmVerificationCodeInput: GQLConfirmVerificationCodeInput;
-  ConnectStripeAccountInput: GQLConnectStripeAccountInput;
-  ConnectStripeAccountResult: GQLConnectStripeAccountResult;
-  Connection: GQLResolversInterfaceTypes<GQLResolversParentTypes>['Connection'];
-  ConnectionArgs: GQLConnectionArgs;
-  CreatePersonhoodHandoffInput: GQLCreatePersonhoodHandoffInput;
-  CryptoWallet: ETHWalletModel;
-  CurationChannel: CurationChannelModel;
-  DateTime: Scalars['DateTime']['output'];
-  DatetimeRange: GQLDatetimeRange;
-  DatetimeRangeInput: GQLDatetimeRangeInput;
-  DeleteAnnouncementsInput: GQLDeleteAnnouncementsInput;
-  DeleteCollectionArticlesInput: GQLDeleteCollectionArticlesInput;
-  DeleteCollectionsInput: GQLDeleteCollectionsInput;
-  DeleteCommentInput: GQLDeleteCommentInput;
-  DeleteCurationChannelArticlesInput: GQLDeleteCurationChannelArticlesInput;
-  DeleteDraftInput: GQLDeleteDraftInput;
-  DeleteMomentInput: GQLDeleteMomentInput;
-  DeleteQuoteInput: GQLDeleteQuoteInput;
-  DeleteTagsInput: GQLDeleteTagsInput;
-  DirectImageUploadInput: GQLDirectImageUploadInput;
-  DismissSpamRingInput: GQLDismissSpamRingInput;
-  Donator: GQLResolversUnionTypes<GQLResolversParentTypes>['Donator'];
-  Draft: DraftModel;
-  DraftAccess: DraftModel;
-  DraftConnection: Omit<GQLDraftConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['DraftEdge']>> };
-  DraftEdge: Omit<GQLDraftEdge, 'node'> & { node: GQLResolversParentTypes['Draft'] };
-  EditArticleInput: GQLEditArticleInput;
-  EmailLoginInput: GQLEmailLoginInput;
-  ExchangeRate: GQLExchangeRate;
-  ExchangeRatesInput: GQLExchangeRatesInput;
-  Feature: GQLFeature;
-  FeaturedCommentsInput: GQLFeaturedCommentsInput;
-  FeaturedTagsInput: GQLFeaturedTagsInput;
-  FilterInput: GQLFilterInput;
-  Float: Scalars['Float']['output'];
-  Following: UserModel;
-  FollowingActivity: GQLResolversUnionTypes<GQLResolversParentTypes>['FollowingActivity'];
-  FollowingActivityConnection: Omit<GQLFollowingActivityConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['FollowingActivityEdge']>> };
-  FollowingActivityEdge: Omit<GQLFollowingActivityEdge, 'node'> & { node: GQLResolversParentTypes['FollowingActivity'] };
-  FreezeSpamRingInput: GQLFreezeSpamRingInput;
-  FreezeSpamRingResult: Omit<GQLFreezeSpamRingResult, 'frozen' | 'ring' | 'skipped'> & { frozen: Array<GQLResolversParentTypes['User']>, ring: GQLResolversParentTypes['SpamRing'], skipped: Array<GQLResolversParentTypes['SpamRingSkip']> };
-  FrequentSearchInput: GQLFrequentSearchInput;
-  GenerateSigningMessageInput: GQLGenerateSigningMessageInput;
-  ID: Scalars['ID']['output'];
-  IcymiTopic: MattersChoiceTopicModel;
-  IcymiTopicConnection: Omit<GQLIcymiTopicConnection, 'edges'> & { edges: Array<GQLResolversParentTypes['IcymiTopicEdge']> };
-  IcymiTopicEdge: Omit<GQLIcymiTopicEdge, 'node'> & { node: GQLResolversParentTypes['IcymiTopic'] };
-  IdentityInput: GQLIdentityInput;
-  Int: Scalars['Int']['output'];
-  Invitation: CircleInvitationModel;
-  InvitationConnection: Omit<GQLInvitationConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['InvitationEdge']>> };
-  InvitationEdge: Omit<GQLInvitationEdge, 'node'> & { node: GQLResolversParentTypes['Invitation'] };
-  InviteCircleInput: GQLInviteCircleInput;
-  InviteCircleInvitee: GQLInviteCircleInvitee;
-  Invitee: GQLResolversUnionTypes<GQLResolversParentTypes>['Invitee'];
-  Invites: CircleModel;
-  KeywordInput: GQLKeywordInput;
-  KeywordsInput: GQLKeywordsInput;
-  LikeCollectionInput: GQLLikeCollectionInput;
-  LikeMomentInput: GQLLikeMomentInput;
-  Liker: UserModel;
-  LogRecordInput: GQLLogRecordInput;
-  Member: CircleMemberModel;
-  MemberConnection: Omit<GQLMemberConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['MemberEdge']>> };
-  MemberEdge: Omit<GQLMemberEdge, 'node'> & { node: GQLResolversParentTypes['Member'] };
-  MergeTagsInput: GQLMergeTagsInput;
-  MigrationInput: GQLMigrationInput;
-  Moment: MomentModel;
-  MomentConnection: Omit<GQLMomentConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['MomentEdge']>> };
-  MomentEdge: Omit<GQLMomentEdge, 'node'> & { node: GQLResolversParentTypes['Moment'] };
-  MomentFeedApplication: MomentFeedUserModel;
-  MomentFeedUsersInput: GQLMomentFeedUsersInput;
-  MomentInput: GQLMomentInput;
-  MomentNotice: NoticeItemModel;
-  MonthlyDatum: GQLMonthlyDatum;
-  Mutation: {};
-  NFTAsset: GQLNftAsset;
-  Node: GQLResolversInterfaceTypes<GQLResolversParentTypes>['Node'];
-  NodeInput: GQLNodeInput;
-  NodesInput: GQLNodesInput;
-  Notice: NoticeItemModel;
-  NoticeConnection: Omit<GQLNoticeConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['NoticeEdge']>> };
-  NoticeEdge: Omit<GQLNoticeEdge, 'node'> & { node: GQLResolversParentTypes['Notice'] };
-  NotificationSetting: GQLNotificationSetting;
-  OAuthClient: OAuthClientDBModel;
-  OAuthClientConnection: Omit<GQLOAuthClientConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['OAuthClientEdge']>> };
-  OAuthClientEdge: Omit<GQLOAuthClientEdge, 'node'> & { node: GQLResolversParentTypes['OAuthClient'] };
-  OAuthClientInput: GQLOAuthClientInput;
-  OSS: Omit<GQLOss, 'articles' | 'badgedUsers' | 'comments' | 'icymiTopics' | 'momentFeedUsers' | 'moments' | 'oauthClients' | 'reports' | 'restrictedUsers' | 'seedingUsers' | 'spamRings' | 'tags' | 'topicChannelFeedbacks' | 'users'> & { articles: GQLResolversParentTypes['ArticleConnection'], badgedUsers: GQLResolversParentTypes['UserConnection'], comments: GQLResolversParentTypes['CommentConnection'], icymiTopics: GQLResolversParentTypes['IcymiTopicConnection'], momentFeedUsers: GQLResolversParentTypes['UserConnection'], moments: GQLResolversParentTypes['MomentConnection'], oauthClients: GQLResolversParentTypes['OAuthClientConnection'], reports: GQLResolversParentTypes['ReportConnection'], restrictedUsers: GQLResolversParentTypes['UserConnection'], seedingUsers: GQLResolversParentTypes['UserConnection'], spamRings: GQLResolversParentTypes['SpamRingConnection'], tags: GQLResolversParentTypes['TagConnection'], topicChannelFeedbacks: GQLResolversParentTypes['TopicChannelFeedbackConnection'], users: GQLResolversParentTypes['UserConnection'] };
-  OSSArticlesFilterInput: GQLOssArticlesFilterInput;
-  OSSArticlesInput: GQLOssArticlesInput;
-  OSSCommentsInput: GQLOssCommentsInput;
-  OSSMomentsInput: GQLOssMomentsInput;
-  OSSReportsFilter: GQLOssReportsFilter;
-  OSSReportsInput: GQLOssReportsInput;
-  OSSSpamDatetimeFilterInput: GQLOssSpamDatetimeFilterInput;
-  OSSSpamRingsFilter: GQLOssSpamRingsFilter;
-  OSSSpamRingsInput: GQLOssSpamRingsInput;
-  Oauth1CredentialInput: GQLOauth1CredentialInput;
-  Official: Omit<GQLOfficial, 'announcements'> & { announcements?: Maybe<Array<GQLResolversParentTypes['Announcement']>> };
-  OfficialAnnouncementNotice: NoticeItemModel;
-  PageInfo: GQLPageInfo;
-  PayToInput: GQLPayToInput;
-  PayToResult: Omit<GQLPayToResult, 'transaction'> & { transaction: GQLResolversParentTypes['Transaction'] };
-  PayoutInput: GQLPayoutInput;
-  Person: GQLPerson;
-  PersonhoodHandoff: GQLPersonhoodHandoff;
-  PinCommentInput: GQLPinCommentInput;
-  PinHistory: Omit<GQLPinHistory, 'feed'> & { feed: GQLResolversParentTypes['Node'] };
-  PinnableWork: GQLResolversInterfaceTypes<GQLResolversParentTypes>['PinnableWork'];
-  Price: CirclePriceModel;
-  PublishArticleInput: GQLPublishArticleInput;
-  PutAnnouncementInput: GQLPutAnnouncementInput;
-  PutArticleFederationSettingInput: GQLPutArticleFederationSettingInput;
-  PutCircleArticlesInput: GQLPutCircleArticlesInput;
-  PutCircleInput: GQLPutCircleInput;
-  PutCollectionInput: GQLPutCollectionInput;
-  PutCommentInput: GQLPutCommentInput;
-  PutCurationChannelInput: GQLPutCurationChannelInput;
-  PutDraftInput: GQLPutDraftInput;
-  PutIcymiTopicInput: GQLPutIcymiTopicInput;
-  PutMomentInput: GQLPutMomentInput;
-  PutOAuthClientInput: GQLPutOAuthClientInput;
-  PutQuoteInput: GQLPutQuoteInput;
-  PutRemarkInput: GQLPutRemarkInput;
-  PutRestrictedUsersInput: GQLPutRestrictedUsersInput;
-  PutSkippedListItemInput: GQLPutSkippedListItemInput;
-  PutTagChannelInput: GQLPutTagChannelInput;
-  PutTopicChannelInput: GQLPutTopicChannelInput;
-  PutUserFeatureFlagsInput: GQLPutUserFeatureFlagsInput;
-  PutUserFederationSettingInput: GQLPutUserFederationSettingInput;
-  PutWritingChallengeInput: GQLPutWritingChallengeInput;
-  Query: {};
-  Quote: QuoteModel;
-  QuoteConnection: Omit<GQLQuoteConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['QuoteEdge']>> };
-  QuoteEdge: Omit<GQLQuoteEdge, 'node'> & { node: GQLResolversParentTypes['Quote'] };
-  QuotesInput: GQLQuotesInput;
-  ReadArticleInput: GQLReadArticleInput;
-  ReadHistory: Omit<GQLReadHistory, 'article'> & { article: GQLResolversParentTypes['Article'] };
-  ReadHistoryConnection: Omit<GQLReadHistoryConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['ReadHistoryEdge']>> };
-  ReadHistoryEdge: Omit<GQLReadHistoryEdge, 'node'> & { node: GQLResolversParentTypes['ReadHistory'] };
-  RecentSearchConnection: GQLRecentSearchConnection;
-  RecentSearchEdge: GQLRecentSearchEdge;
-  RecommendFilterInput: GQLRecommendFilterInput;
-  RecommendInput: GQLRecommendInput;
-  Recommendation: UserModel;
-  RecommendationFollowingFilterInput: GQLRecommendationFollowingFilterInput;
-  RecommendationFollowingInput: GQLRecommendationFollowingInput;
-  RecommendationNewestInput: GQLRecommendationNewestInput;
-  RefreshIPNSFeedInput: GQLRefreshIpnsFeedInput;
-  RelatedDonationArticlesInput: GQLRelatedDonationArticlesInput;
-  RemoveSocialLoginInput: GQLRemoveSocialLoginInput;
-  RenameTagInput: GQLRenameTagInput;
-  ReorderChannelsInput: GQLReorderChannelsInput;
-  ReorderCollectionArticlesInput: GQLReorderCollectionArticlesInput;
-  ReorderMoveInput: GQLReorderMoveInput;
-  Report: ReportModel;
-  ReportConnection: Omit<GQLReportConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['ReportEdge']>> };
-  ReportEdge: Omit<GQLReportEdge, 'node'> & { node: GQLResolversParentTypes['Report'] };
-  ResetLikerIdInput: GQLResetLikerIdInput;
-  ResetPasswordInput: GQLResetPasswordInput;
-  Response: GQLResolversUnionTypes<GQLResolversParentTypes>['Response'];
-  ResponseConnection: Omit<GQLResponseConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['ResponseEdge']>> };
-  ResponseEdge: Omit<GQLResponseEdge, 'node'> & { node: GQLResolversParentTypes['Response'] };
-  ResponsesInput: GQLResponsesInput;
-  RestoreCommunityWatchCommentInput: GQLRestoreCommunityWatchCommentInput;
-  ReviewTopicChannelFeedbackInput: GQLReviewTopicChannelFeedbackInput;
-  SearchFilter: GQLSearchFilter;
-  SearchInput: GQLSearchInput;
-  SearchResultConnection: Omit<GQLSearchResultConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['SearchResultEdge']>> };
-  SearchResultEdge: Omit<GQLSearchResultEdge, 'node'> & { node: GQLResolversParentTypes['Node'] };
-  SendCampaignAnnouncementInput: GQLSendCampaignAnnouncementInput;
-  SendVerificationCodeInput: GQLSendVerificationCodeInput;
-  SetAdStatusInput: GQLSetAdStatusInput;
-  SetArticleFederationSettingInput: GQLSetArticleFederationSettingInput;
-  SetArticleTopicChannelsInput: GQLSetArticleTopicChannelsInput;
-  SetBoostInput: GQLSetBoostInput;
-  SetCurrencyInput: GQLSetCurrencyInput;
-  SetEmailInput: GQLSetEmailInput;
-  SetFeatureInput: GQLSetFeatureInput;
-  SetPasswordInput: GQLSetPasswordInput;
-  SetSpamStatusInput: GQLSetSpamStatusInput;
-  SetUserNameInput: GQLSetUserNameInput;
-  SetViewerFederationSettingInput: GQLSetViewerFederationSettingInput;
-  SigningMessageResult: GQLSigningMessageResult;
-  SingleFileUploadInput: GQLSingleFileUploadInput;
-  SkippedListItem: GQLSkippedListItem;
-  SkippedListItemEdge: GQLSkippedListItemEdge;
-  SkippedListItemsConnection: GQLSkippedListItemsConnection;
-  SkippedListItemsInput: GQLSkippedListItemsInput;
-  SocialAccount: GQLSocialAccount;
-  SocialLoginInput: GQLSocialLoginInput;
-  SpamRing: SpamRingModel;
-  SpamRingCandidateInput: GQLSpamRingCandidateInput;
-  SpamRingConnection: Omit<GQLSpamRingConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['SpamRingEdge']>> };
-  SpamRingEdge: Omit<GQLSpamRingEdge, 'node'> & { node: GQLResolversParentTypes['SpamRing'] };
-  SpamRingEvent: SpamRingEventModel;
-  SpamRingMember: SpamRingMemberModel;
-  SpamRingMemberConnection: Omit<GQLSpamRingMemberConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['SpamRingMemberEdge']>> };
-  SpamRingMemberEdge: Omit<GQLSpamRingMemberEdge, 'node'> & { node: GQLResolversParentTypes['SpamRingMember'] };
-  SpamRingSignals: SpamRingSignalsModel;
-  SpamRingSignalsInput: GQLSpamRingSignalsInput;
-  SpamRingSkip: Omit<GQLSpamRingSkip, 'user'> & { user: GQLResolversParentTypes['User'] };
-  SpamStatus: GQLSpamStatus;
-  String: Scalars['String']['output'];
-  StripeAccount: PayoutAccountModel;
-  SubmitReportInput: GQLSubmitReportInput;
-  SubmitTopicChannelFeedbackInput: GQLSubmitTopicChannelFeedbackInput;
-  SubscribeCircleInput: GQLSubscribeCircleInput;
-  SubscribeCircleResult: Omit<GQLSubscribeCircleResult, 'circle'> & { circle: GQLResolversParentTypes['Circle'] };
-  Tag: TagModel;
-  TagArticlesInput: GQLTagArticlesInput;
-  TagConnection: Omit<GQLTagConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['TagEdge']>> };
-  TagEdge: Omit<GQLTagEdge, 'node'> & { node: GQLResolversParentTypes['Tag'] };
-  TagOSS: TagModel;
-  TagWritingConnection: Omit<GQLTagWritingConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['TagWritingEdge']>> };
-  TagWritingEdge: Omit<GQLTagWritingEdge, 'node'> & { node: GQLResolversParentTypes['Writing'] };
-  TagsInput: GQLTagsInput;
-  ToggleCircleMemberInput: GQLToggleCircleMemberInput;
-  ToggleItemInput: GQLToggleItemInput;
-  TogglePinChannelArticlesInput: GQLTogglePinChannelArticlesInput;
-  ToggleRecommendInput: GQLToggleRecommendInput;
-  ToggleSeedingUsersInput: GQLToggleSeedingUsersInput;
-  ToggleUsersBadgeInput: GQLToggleUsersBadgeInput;
-  ToggleWritingChallengeFeaturedArticlesInput: GQLToggleWritingChallengeFeaturedArticlesInput;
-  TopDonatorConnection: Omit<GQLTopDonatorConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['TopDonatorEdge']>> };
-  TopDonatorEdge: Omit<GQLTopDonatorEdge, 'node'> & { node: GQLResolversParentTypes['Donator'] };
-  TopDonatorFilter: GQLTopDonatorFilter;
-  TopDonatorInput: GQLTopDonatorInput;
-  TopicChannel: TopicChannelModel;
-  TopicChannelClassification: ArticleModel;
-  TopicChannelFeedback: TopicChannelFeedbackModel;
-  TopicChannelFeedbackConnection: Omit<GQLTopicChannelFeedbackConnection, 'edges'> & { edges: Array<GQLResolversParentTypes['TopicChannelFeedbackEdge']> };
-  TopicChannelFeedbackEdge: Omit<GQLTopicChannelFeedbackEdge, 'node'> & { node: GQLResolversParentTypes['TopicChannelFeedback'] };
-  TopicChannelFeedbacksFilterInput: GQLTopicChannelFeedbacksFilterInput;
-  TopicChannelFeedbacksInput: GQLTopicChannelFeedbacksInput;
-  Transaction: TransactionModel;
-  TransactionConnection: Omit<GQLTransactionConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['TransactionEdge']>> };
-  TransactionEdge: Omit<GQLTransactionEdge, 'node'> & { node: GQLResolversParentTypes['Transaction'] };
-  TransactionNotice: NoticeItemModel;
-  TransactionTarget: GQLResolversUnionTypes<GQLResolversParentTypes>['TransactionTarget'];
-  TransactionsArgs: GQLTransactionsArgs;
-  TransactionsFilter: GQLTransactionsFilter;
-  TransactionsReceivedByArgs: GQLTransactionsReceivedByArgs;
-  TranslatedAnnouncement: GQLTranslatedAnnouncement;
-  TranslationArgs: GQLTranslationArgs;
-  TranslationInput: GQLTranslationInput;
-  UnbindLikerIdInput: GQLUnbindLikerIdInput;
-  UnfreezeSpamRingInput: GQLUnfreezeSpamRingInput;
-  UnfreezeSpamRingResult: Omit<GQLUnfreezeSpamRingResult, 'ring' | 'skipped' | 'unbanned'> & { ring: GQLResolversParentTypes['SpamRing'], skipped: Array<GQLResolversParentTypes['SpamRingSkip']>, unbanned: Array<GQLResolversParentTypes['User']> };
-  UnlikeCollectionInput: GQLUnlikeCollectionInput;
-  UnlikeMomentInput: GQLUnlikeMomentInput;
-  UnpinCommentInput: GQLUnpinCommentInput;
-  UnsubscribeCircleInput: GQLUnsubscribeCircleInput;
-  UnvoteCommentInput: GQLUnvoteCommentInput;
-  UpdateArticleSensitiveInput: GQLUpdateArticleSensitiveInput;
-  UpdateArticleStateInput: GQLUpdateArticleStateInput;
-  UpdateCampaignApplicationStateInput: GQLUpdateCampaignApplicationStateInput;
-  UpdateCommentsStateInput: GQLUpdateCommentsStateInput;
-  UpdateCommunityWatchActionStateInput: GQLUpdateCommunityWatchActionStateInput;
-  UpdateMomentFeedApplicationStateInput: GQLUpdateMomentFeedApplicationStateInput;
-  UpdateNotificationSettingInput: GQLUpdateNotificationSettingInput;
-  UpdateUserExtraInput: GQLUpdateUserExtraInput;
-  UpdateUserInfoInput: GQLUpdateUserInfoInput;
-  UpdateUserRoleInput: GQLUpdateUserRoleInput;
-  UpdateUserStateInput: GQLUpdateUserStateInput;
-  Upload: Scalars['Upload']['output'];
-  UpsertSpamRingCandidatesInput: GQLUpsertSpamRingCandidatesInput;
-  UpsertSpamRingCandidatesResult: Omit<GQLUpsertSpamRingCandidatesResult, 'rings'> & { rings: Array<GQLResolversParentTypes['SpamRing']> };
-  User: UserModel;
-  UserActivity: UserModel;
-  UserAddArticleTagActivity: Omit<GQLUserAddArticleTagActivity, 'actor' | 'node' | 'target'> & { actor: GQLResolversParentTypes['User'], node: GQLResolversParentTypes['Article'], target: GQLResolversParentTypes['Tag'] };
-  UserAnalytics: UserModel;
-  UserArticlesFilter: GQLUserArticlesFilter;
-  UserArticlesInput: GQLUserArticlesInput;
-  UserBroadcastCircleActivity: Omit<GQLUserBroadcastCircleActivity, 'actor' | 'node' | 'target'> & { actor: GQLResolversParentTypes['User'], node: GQLResolversParentTypes['Comment'], target: GQLResolversParentTypes['Circle'] };
-  UserConnection: Omit<GQLUserConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['UserEdge']>> };
-  UserCreateCircleActivity: Omit<GQLUserCreateCircleActivity, 'actor' | 'node'> & { actor: GQLResolversParentTypes['User'], node: GQLResolversParentTypes['Circle'] };
-  UserEdge: Omit<GQLUserEdge, 'node'> & { node: GQLResolversParentTypes['User'] };
-  UserFeatureFlag: GQLUserFeatureFlag;
-  UserFeatures: GQLUserFeatures;
-  UserFederationSetting: GQLUserFederationSetting;
-  UserInfo: UserModel;
-  UserInput: GQLUserInput;
-  UserNotice: NoticeItemModel;
-  UserOSS: UserModel;
-  UserPostMomentActivity: Omit<GQLUserPostMomentActivity, 'actor' | 'more' | 'node'> & { actor: GQLResolversParentTypes['User'], more: Array<GQLResolversParentTypes['Moment']>, node: GQLResolversParentTypes['Moment'] };
-  UserPublishArticleActivity: Omit<GQLUserPublishArticleActivity, 'actor' | 'node'> & { actor: GQLResolversParentTypes['User'], node: GQLResolversParentTypes['Article'] };
-  UserRecommendationActivity: Omit<GQLUserRecommendationActivity, 'nodes'> & { nodes?: Maybe<Array<GQLResolversParentTypes['User']>> };
-  UserRestriction: GQLUserRestriction;
-  UserSettings: UserModel;
-  UserStatus: UserModel;
-  VerifyEmailInput: GQLVerifyEmailInput;
-  VoteCommentInput: GQLVoteCommentInput;
-  Wallet: UserModel;
-  WalletLoginInput: GQLWalletLoginInput;
-  WithdrawLockedTokensResult: Omit<GQLWithdrawLockedTokensResult, 'transaction'> & { transaction: GQLResolversParentTypes['Transaction'] };
-  Writing: WritingModel;
-  WritingChallenge: CampaignModel;
-  WritingConnection: Omit<GQLWritingConnection, 'edges'> & { edges?: Maybe<Array<GQLResolversParentTypes['WritingEdge']>> };
-  WritingEdge: Omit<GQLWritingEdge, 'node'> & { node: GQLResolversParentTypes['Writing'] };
-  WritingInput: GQLWritingInput;
-}>;
+  AdStatus: GQLAdStatus
+  AddCollectionsArticlesInput: GQLAddCollectionsArticlesInput
+  AddCreditInput: GQLAddCreditInput
+  AddCreditResult: Omit<GQLAddCreditResult, 'transaction'> & {
+    transaction: GQLResolversParentTypes['Transaction']
+  }
+  AddCurationChannelArticlesInput: GQLAddCurationChannelArticlesInput
+  Announcement: AnnouncementModel
+  AnnouncementChannel: Omit<GQLAnnouncementChannel, 'channel'> & {
+    channel: GQLResolversParentTypes['Channel']
+  }
+  AnnouncementChannelInput: GQLAnnouncementChannelInput
+  AnnouncementsInput: GQLAnnouncementsInput
+  ApplyCampaignInput: GQLApplyCampaignInput
+  AppreciateArticleInput: GQLAppreciateArticleInput
+  Appreciation: AppreciationModel
+  AppreciationConnection: Omit<GQLAppreciationConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['AppreciationEdge']>>
+  }
+  AppreciationEdge: Omit<GQLAppreciationEdge, 'node'> & {
+    node: GQLResolversParentTypes['Appreciation']
+  }
+  ArchiveUserFailure: GQLArchiveUserFailure
+  ArchiveUsersInput: GQLArchiveUsersInput
+  ArchiveUsersResult: Omit<GQLArchiveUsersResult, 'archived'> & {
+    archived: Array<GQLResolversParentTypes['User']>
+  }
+  Article: ArticleModel
+  ArticleAccess: ArticleModel
+  ArticleArticleNotice: NoticeItemModel
+  ArticleCampaign: Omit<GQLArticleCampaign, 'campaign' | 'stage'> & {
+    campaign: GQLResolversParentTypes['Campaign']
+    stage?: Maybe<GQLResolversParentTypes['CampaignStage']>
+  }
+  ArticleCampaignInput: GQLArticleCampaignInput
+  ArticleClassification: ArticleModel
+  ArticleConnection: Omit<GQLArticleConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['ArticleEdge']>>
+  }
+  ArticleContents: ArticleVersionModel
+  ArticleDonation: Omit<GQLArticleDonation, 'sender'> & {
+    sender?: Maybe<GQLResolversParentTypes['User']>
+  }
+  ArticleDonationConnection: Omit<GQLArticleDonationConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['ArticleDonationEdge']>>
+  }
+  ArticleDonationEdge: Omit<GQLArticleDonationEdge, 'node'> & {
+    node: GQLResolversParentTypes['ArticleDonation']
+  }
+  ArticleEdge: Omit<GQLArticleEdge, 'node'> & {
+    node: GQLResolversParentTypes['Article']
+  }
+  ArticleFederationEligibility: GQLArticleFederationEligibility
+  ArticleFederationSetting: GQLArticleFederationSetting
+  ArticleInput: GQLArticleInput
+  ArticleNotice: NoticeItemModel
+  ArticleOSS: ArticleModel
+  ArticleRecommendationActivity: Omit<
+    GQLArticleRecommendationActivity,
+    'nodes'
+  > & { nodes?: Maybe<Array<GQLResolversParentTypes['Article']>> }
+  ArticleTopicChannel: Omit<GQLArticleTopicChannel, 'channel'> & {
+    channel: GQLResolversParentTypes['TopicChannel']
+  }
+  ArticleTranslation: GQLArticleTranslation
+  ArticleTranslationInput: GQLArticleTranslationInput
+  ArticleVersion: ArticleVersionModel
+  ArticleVersionEdge: Omit<GQLArticleVersionEdge, 'node'> & {
+    node: GQLResolversParentTypes['ArticleVersion']
+  }
+  ArticleVersionsConnection: Omit<GQLArticleVersionsConnection, 'edges'> & {
+    edges: Array<Maybe<GQLResolversParentTypes['ArticleVersionEdge']>>
+  }
+  ArticleVersionsInput: GQLArticleVersionsInput
+  Asset: AssetModel
+  AuthResult: Omit<GQLAuthResult, 'user'> & {
+    user?: Maybe<GQLResolversParentTypes['User']>
+  }
+  Badge: GQLBadge
+  BadgedUsersInput: GQLBadgedUsersInput
+  Balance: GQLBalance
+  BanCampaignArticlesInput: GQLBanCampaignArticlesInput
+  BlockchainTransaction: GQLBlockchainTransaction
+  BlockedSearchKeyword: GQLBlockedSearchKeyword
+  Boolean: Scalars['Boolean']['output']
+  Campaign: CampaignModel
+  CampaignApplication: GQLCampaignApplication
+  CampaignArticleConnection: Omit<GQLCampaignArticleConnection, 'edges'> & {
+    edges: Array<GQLResolversParentTypes['CampaignArticleEdge']>
+  }
+  CampaignArticleEdge: Omit<GQLCampaignArticleEdge, 'node'> & {
+    node: GQLResolversParentTypes['Article']
+  }
+  CampaignArticleNotice: NoticeItemModel
+  CampaignArticlesFilter: GQLCampaignArticlesFilter
+  CampaignArticlesInput: GQLCampaignArticlesInput
+  CampaignConnection: Omit<GQLCampaignConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['CampaignEdge']>>
+  }
+  CampaignEdge: Omit<GQLCampaignEdge, 'node'> & {
+    node: GQLResolversParentTypes['Campaign']
+  }
+  CampaignInput: GQLCampaignInput
+  CampaignOSS: CampaignModel
+  CampaignParticipantConnection: Omit<
+    GQLCampaignParticipantConnection,
+    'edges'
+  > & {
+    edges?: Maybe<Array<GQLResolversParentTypes['CampaignParticipantEdge']>>
+  }
+  CampaignParticipantEdge: Omit<
+    GQLCampaignParticipantEdge,
+    'application' | 'node'
+  > & {
+    application?: Maybe<GQLResolversParentTypes['CampaignApplication']>
+    node: GQLResolversParentTypes['User']
+  }
+  CampaignParticipantsInput: GQLCampaignParticipantsInput
+  CampaignStage: CampaignStageModel
+  CampaignStageInput: GQLCampaignStageInput
+  CampaignsFilter: GQLCampaignsFilter
+  CampaignsInput: GQLCampaignsInput
+  Channel: GQLResolversInterfaceTypes<GQLResolversParentTypes>['Channel']
+  ChannelArticleConnection: Omit<GQLChannelArticleConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['ChannelArticleEdge']>>
+  }
+  ChannelArticleEdge: Omit<GQLChannelArticleEdge, 'node'> & {
+    node: GQLResolversParentTypes['Article']
+  }
+  ChannelArticlesFilter: GQLChannelArticlesFilter
+  ChannelArticlesInput: GQLChannelArticlesInput
+  ChannelInput: GQLChannelInput
+  ChannelsInput: GQLChannelsInput
+  Circle: CircleModel
+  CircleAnalytics: CircleModel
+  CircleConnection: Omit<GQLCircleConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['CircleEdge']>>
+  }
+  CircleContentAnalytics: CircleModel
+  CircleContentAnalyticsDatum: Omit<GQLCircleContentAnalyticsDatum, 'node'> & {
+    node: GQLResolversParentTypes['Article']
+  }
+  CircleEdge: Omit<GQLCircleEdge, 'node'> & {
+    node: GQLResolversParentTypes['Circle']
+  }
+  CircleFollowerAnalytics: CircleModel
+  CircleIncomeAnalytics: CircleModel
+  CircleInput: GQLCircleInput
+  CircleNotice: NoticeItemModel
+  CircleRecommendationActivity: Omit<
+    GQLCircleRecommendationActivity,
+    'nodes'
+  > & { nodes?: Maybe<Array<GQLResolversParentTypes['Circle']>> }
+  CircleSubscriberAnalytics: CircleModel
+  ClaimLogbooksInput: GQLClaimLogbooksInput
+  ClaimLogbooksResult: GQLClaimLogbooksResult
+  ClaimPersonhoodBadgeInput: GQLClaimPersonhoodBadgeInput
+  ClassifyArticlesChannelsInput: GQLClassifyArticlesChannelsInput
+  ClearCommunityWatchOriginalContentInput: GQLClearCommunityWatchOriginalContentInput
+  ClearReadHistoryInput: GQLClearReadHistoryInput
+  Collection: CollectionModel
+  CollectionArticlesInput: GQLCollectionArticlesInput
+  CollectionConnection: Omit<GQLCollectionConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['CollectionEdge']>>
+  }
+  CollectionEdge: Omit<GQLCollectionEdge, 'node'> & {
+    node: GQLResolversParentTypes['Collection']
+  }
+  CollectionNotice: NoticeItemModel
+  Comment: CommentModel
+  CommentCommentNotice: NoticeItemModel
+  CommentCommentsInput: GQLCommentCommentsInput
+  CommentConnection: Omit<GQLCommentConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['CommentEdge']>>
+  }
+  CommentEdge: Omit<GQLCommentEdge, 'node'> & {
+    node: GQLResolversParentTypes['Comment']
+  }
+  CommentInput: GQLCommentInput
+  CommentNotice: NoticeItemModel
+  CommentsFilter: GQLCommentsFilter
+  CommentsInput: GQLCommentsInput
+  CommunityWatchAction: CommunityWatchActionModel
+  CommunityWatchActionConnection: Omit<
+    GQLCommunityWatchActionConnection,
+    'edges'
+  > & {
+    edges?: Maybe<Array<GQLResolversParentTypes['CommunityWatchActionEdge']>>
+  }
+  CommunityWatchActionEdge: Omit<GQLCommunityWatchActionEdge, 'node'> & {
+    node: GQLResolversParentTypes['CommunityWatchAction']
+  }
+  CommunityWatchActionInput: GQLCommunityWatchActionInput
+  CommunityWatchActionsInput: GQLCommunityWatchActionsInput
+  CommunityWatchRemoveCommentInput: GQLCommunityWatchRemoveCommentInput
+  ConfirmVerificationCodeInput: GQLConfirmVerificationCodeInput
+  ConnectStripeAccountInput: GQLConnectStripeAccountInput
+  ConnectStripeAccountResult: GQLConnectStripeAccountResult
+  Connection: GQLResolversInterfaceTypes<GQLResolversParentTypes>['Connection']
+  ConnectionArgs: GQLConnectionArgs
+  CreatePersonhoodHandoffInput: GQLCreatePersonhoodHandoffInput
+  CryptoWallet: ETHWalletModel
+  CurationChannel: CurationChannelModel
+  DateTime: Scalars['DateTime']['output']
+  DatetimeRange: GQLDatetimeRange
+  DatetimeRangeInput: GQLDatetimeRangeInput
+  DeleteAnnouncementsInput: GQLDeleteAnnouncementsInput
+  DeleteCollectionArticlesInput: GQLDeleteCollectionArticlesInput
+  DeleteCollectionsInput: GQLDeleteCollectionsInput
+  DeleteCommentInput: GQLDeleteCommentInput
+  DeleteCurationChannelArticlesInput: GQLDeleteCurationChannelArticlesInput
+  DeleteDraftInput: GQLDeleteDraftInput
+  DeleteMomentInput: GQLDeleteMomentInput
+  DeleteQuoteInput: GQLDeleteQuoteInput
+  DeleteTagsInput: GQLDeleteTagsInput
+  DirectImageUploadInput: GQLDirectImageUploadInput
+  DismissSpamRingInput: GQLDismissSpamRingInput
+  Donator: GQLResolversUnionTypes<GQLResolversParentTypes>['Donator']
+  Draft: DraftModel
+  DraftAccess: DraftModel
+  DraftConnection: Omit<GQLDraftConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['DraftEdge']>>
+  }
+  DraftEdge: Omit<GQLDraftEdge, 'node'> & {
+    node: GQLResolversParentTypes['Draft']
+  }
+  EditArticleInput: GQLEditArticleInput
+  EmailLoginInput: GQLEmailLoginInput
+  ExchangeRate: GQLExchangeRate
+  ExchangeRatesInput: GQLExchangeRatesInput
+  Feature: GQLFeature
+  FeaturedCommentsInput: GQLFeaturedCommentsInput
+  FeaturedTagsInput: GQLFeaturedTagsInput
+  FilterInput: GQLFilterInput
+  Float: Scalars['Float']['output']
+  Following: UserModel
+  FollowingActivity: GQLResolversUnionTypes<GQLResolversParentTypes>['FollowingActivity']
+  FollowingActivityConnection: Omit<GQLFollowingActivityConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['FollowingActivityEdge']>>
+  }
+  FollowingActivityEdge: Omit<GQLFollowingActivityEdge, 'node'> & {
+    node: GQLResolversParentTypes['FollowingActivity']
+  }
+  FreezeSpamRingInput: GQLFreezeSpamRingInput
+  FreezeSpamRingResult: Omit<
+    GQLFreezeSpamRingResult,
+    'frozen' | 'ring' | 'skipped'
+  > & {
+    frozen: Array<GQLResolversParentTypes['User']>
+    ring: GQLResolversParentTypes['SpamRing']
+    skipped: Array<GQLResolversParentTypes['SpamRingSkip']>
+  }
+  FrequentSearchInput: GQLFrequentSearchInput
+  GenerateSigningMessageInput: GQLGenerateSigningMessageInput
+  ID: Scalars['ID']['output']
+  IcymiTopic: MattersChoiceTopicModel
+  IcymiTopicConnection: Omit<GQLIcymiTopicConnection, 'edges'> & {
+    edges: Array<GQLResolversParentTypes['IcymiTopicEdge']>
+  }
+  IcymiTopicEdge: Omit<GQLIcymiTopicEdge, 'node'> & {
+    node: GQLResolversParentTypes['IcymiTopic']
+  }
+  IdentityInput: GQLIdentityInput
+  Int: Scalars['Int']['output']
+  Invitation: CircleInvitationModel
+  InvitationConnection: Omit<GQLInvitationConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['InvitationEdge']>>
+  }
+  InvitationEdge: Omit<GQLInvitationEdge, 'node'> & {
+    node: GQLResolversParentTypes['Invitation']
+  }
+  InviteCircleInput: GQLInviteCircleInput
+  InviteCircleInvitee: GQLInviteCircleInvitee
+  Invitee: GQLResolversUnionTypes<GQLResolversParentTypes>['Invitee']
+  Invites: CircleModel
+  KeywordInput: GQLKeywordInput
+  KeywordsInput: GQLKeywordsInput
+  LikeCollectionInput: GQLLikeCollectionInput
+  LikeMomentInput: GQLLikeMomentInput
+  Liker: UserModel
+  LogRecordInput: GQLLogRecordInput
+  Member: CircleMemberModel
+  MemberConnection: Omit<GQLMemberConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['MemberEdge']>>
+  }
+  MemberEdge: Omit<GQLMemberEdge, 'node'> & {
+    node: GQLResolversParentTypes['Member']
+  }
+  MergeTagsInput: GQLMergeTagsInput
+  MigrationInput: GQLMigrationInput
+  ModerationCase: GQLModerationCase
+  Moment: MomentModel
+  MomentConnection: Omit<GQLMomentConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['MomentEdge']>>
+  }
+  MomentEdge: Omit<GQLMomentEdge, 'node'> & {
+    node: GQLResolversParentTypes['Moment']
+  }
+  MomentFeedApplication: MomentFeedUserModel
+  MomentFeedUsersInput: GQLMomentFeedUsersInput
+  MomentInput: GQLMomentInput
+  MomentNotice: NoticeItemModel
+  MonthlyDatum: GQLMonthlyDatum
+  Mutation: {}
+  NFTAsset: GQLNftAsset
+  Node: GQLResolversInterfaceTypes<GQLResolversParentTypes>['Node']
+  NodeInput: GQLNodeInput
+  NodesInput: GQLNodesInput
+  Notice: NoticeItemModel
+  NoticeConnection: Omit<GQLNoticeConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['NoticeEdge']>>
+  }
+  NoticeEdge: Omit<GQLNoticeEdge, 'node'> & {
+    node: GQLResolversParentTypes['Notice']
+  }
+  NotificationSetting: GQLNotificationSetting
+  OAuthClient: OAuthClientDBModel
+  OAuthClientConnection: Omit<GQLOAuthClientConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['OAuthClientEdge']>>
+  }
+  OAuthClientEdge: Omit<GQLOAuthClientEdge, 'node'> & {
+    node: GQLResolversParentTypes['OAuthClient']
+  }
+  OAuthClientInput: GQLOAuthClientInput
+  OSS: Omit<
+    GQLOss,
+    | 'articles'
+    | 'badgedUsers'
+    | 'comments'
+    | 'icymiTopics'
+    | 'momentFeedUsers'
+    | 'moments'
+    | 'oauthClients'
+    | 'reports'
+    | 'restrictedUsers'
+    | 'seedingUsers'
+    | 'spamRings'
+    | 'tags'
+    | 'topicChannelFeedbacks'
+    | 'users'
+  > & {
+    articles: GQLResolversParentTypes['ArticleConnection']
+    badgedUsers: GQLResolversParentTypes['UserConnection']
+    comments: GQLResolversParentTypes['CommentConnection']
+    icymiTopics: GQLResolversParentTypes['IcymiTopicConnection']
+    momentFeedUsers: GQLResolversParentTypes['UserConnection']
+    moments: GQLResolversParentTypes['MomentConnection']
+    oauthClients: GQLResolversParentTypes['OAuthClientConnection']
+    reports: GQLResolversParentTypes['ReportConnection']
+    restrictedUsers: GQLResolversParentTypes['UserConnection']
+    seedingUsers: GQLResolversParentTypes['UserConnection']
+    spamRings: GQLResolversParentTypes['SpamRingConnection']
+    tags: GQLResolversParentTypes['TagConnection']
+    topicChannelFeedbacks: GQLResolversParentTypes['TopicChannelFeedbackConnection']
+    users: GQLResolversParentTypes['UserConnection']
+  }
+  OSSArticlesFilterInput: GQLOssArticlesFilterInput
+  OSSArticlesInput: GQLOssArticlesInput
+  OSSCommentsInput: GQLOssCommentsInput
+  OSSMomentsInput: GQLOssMomentsInput
+  OSSReportsFilter: GQLOssReportsFilter
+  OSSReportsInput: GQLOssReportsInput
+  OSSSpamDatetimeFilterInput: GQLOssSpamDatetimeFilterInput
+  OSSSpamRingsFilter: GQLOssSpamRingsFilter
+  OSSSpamRingsInput: GQLOssSpamRingsInput
+  Oauth1CredentialInput: GQLOauth1CredentialInput
+  Official: Omit<GQLOfficial, 'announcements'> & {
+    announcements?: Maybe<Array<GQLResolversParentTypes['Announcement']>>
+  }
+  OfficialAnnouncementNotice: NoticeItemModel
+  PageInfo: GQLPageInfo
+  PayToInput: GQLPayToInput
+  PayToResult: Omit<GQLPayToResult, 'transaction'> & {
+    transaction: GQLResolversParentTypes['Transaction']
+  }
+  PayoutInput: GQLPayoutInput
+  Person: GQLPerson
+  PersonhoodHandoff: GQLPersonhoodHandoff
+  PinCommentInput: GQLPinCommentInput
+  PinHistory: Omit<GQLPinHistory, 'feed'> & {
+    feed: GQLResolversParentTypes['Node']
+  }
+  PinnableWork: GQLResolversInterfaceTypes<GQLResolversParentTypes>['PinnableWork']
+  Price: CirclePriceModel
+  PublishArticleInput: GQLPublishArticleInput
+  PutAnnouncementInput: GQLPutAnnouncementInput
+  PutArticleFederationSettingInput: GQLPutArticleFederationSettingInput
+  PutCircleArticlesInput: GQLPutCircleArticlesInput
+  PutCircleInput: GQLPutCircleInput
+  PutCollectionInput: GQLPutCollectionInput
+  PutCommentInput: GQLPutCommentInput
+  PutCurationChannelInput: GQLPutCurationChannelInput
+  PutDraftInput: GQLPutDraftInput
+  PutIcymiTopicInput: GQLPutIcymiTopicInput
+  PutMomentInput: GQLPutMomentInput
+  PutOAuthClientInput: GQLPutOAuthClientInput
+  PutQuoteInput: GQLPutQuoteInput
+  PutRemarkInput: GQLPutRemarkInput
+  PutRestrictedUsersInput: GQLPutRestrictedUsersInput
+  PutSkippedListItemInput: GQLPutSkippedListItemInput
+  PutTagChannelInput: GQLPutTagChannelInput
+  PutTopicChannelInput: GQLPutTopicChannelInput
+  PutUserFeatureFlagsInput: GQLPutUserFeatureFlagsInput
+  PutUserFederationSettingInput: GQLPutUserFederationSettingInput
+  PutWritingChallengeInput: GQLPutWritingChallengeInput
+  Query: {}
+  Quote: QuoteModel
+  QuoteConnection: Omit<GQLQuoteConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['QuoteEdge']>>
+  }
+  QuoteEdge: Omit<GQLQuoteEdge, 'node'> & {
+    node: GQLResolversParentTypes['Quote']
+  }
+  QuotesInput: GQLQuotesInput
+  ReadArticleInput: GQLReadArticleInput
+  ReadHistory: Omit<GQLReadHistory, 'article'> & {
+    article: GQLResolversParentTypes['Article']
+  }
+  ReadHistoryConnection: Omit<GQLReadHistoryConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['ReadHistoryEdge']>>
+  }
+  ReadHistoryEdge: Omit<GQLReadHistoryEdge, 'node'> & {
+    node: GQLResolversParentTypes['ReadHistory']
+  }
+  RecentSearchConnection: GQLRecentSearchConnection
+  RecentSearchEdge: GQLRecentSearchEdge
+  RecommendFilterInput: GQLRecommendFilterInput
+  RecommendInput: GQLRecommendInput
+  Recommendation: UserModel
+  RecommendationFollowingFilterInput: GQLRecommendationFollowingFilterInput
+  RecommendationFollowingInput: GQLRecommendationFollowingInput
+  RecommendationNewestInput: GQLRecommendationNewestInput
+  RefreshIPNSFeedInput: GQLRefreshIpnsFeedInput
+  RelatedDonationArticlesInput: GQLRelatedDonationArticlesInput
+  RemoveSocialLoginInput: GQLRemoveSocialLoginInput
+  RenameTagInput: GQLRenameTagInput
+  ReorderChannelsInput: GQLReorderChannelsInput
+  ReorderCollectionArticlesInput: GQLReorderCollectionArticlesInput
+  ReorderMoveInput: GQLReorderMoveInput
+  Report: ReportModel
+  ReportConnection: Omit<GQLReportConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['ReportEdge']>>
+  }
+  ReportEdge: Omit<GQLReportEdge, 'node'> & {
+    node: GQLResolversParentTypes['Report']
+  }
+  ResetLikerIdInput: GQLResetLikerIdInput
+  ResetPasswordInput: GQLResetPasswordInput
+  Response: GQLResolversUnionTypes<GQLResolversParentTypes>['Response']
+  ResponseConnection: Omit<GQLResponseConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['ResponseEdge']>>
+  }
+  ResponseEdge: Omit<GQLResponseEdge, 'node'> & {
+    node: GQLResolversParentTypes['Response']
+  }
+  ResponsesInput: GQLResponsesInput
+  RestoreCommunityWatchCommentInput: GQLRestoreCommunityWatchCommentInput
+  ReviewTopicChannelFeedbackInput: GQLReviewTopicChannelFeedbackInput
+  SearchFilter: GQLSearchFilter
+  SearchInput: GQLSearchInput
+  SearchResultConnection: Omit<GQLSearchResultConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['SearchResultEdge']>>
+  }
+  SearchResultEdge: Omit<GQLSearchResultEdge, 'node'> & {
+    node: GQLResolversParentTypes['Node']
+  }
+  SendCampaignAnnouncementInput: GQLSendCampaignAnnouncementInput
+  SendVerificationCodeInput: GQLSendVerificationCodeInput
+  SetAdStatusInput: GQLSetAdStatusInput
+  SetArticleFederationSettingInput: GQLSetArticleFederationSettingInput
+  SetArticleTopicChannelsInput: GQLSetArticleTopicChannelsInput
+  SetBoostInput: GQLSetBoostInput
+  SetCurrencyInput: GQLSetCurrencyInput
+  SetEmailInput: GQLSetEmailInput
+  SetFeatureInput: GQLSetFeatureInput
+  SetPasswordInput: GQLSetPasswordInput
+  SetSpamStatusInput: GQLSetSpamStatusInput
+  SetUserNameInput: GQLSetUserNameInput
+  SetViewerFederationSettingInput: GQLSetViewerFederationSettingInput
+  SigningMessageResult: GQLSigningMessageResult
+  SingleFileUploadInput: GQLSingleFileUploadInput
+  SkippedListItem: GQLSkippedListItem
+  SkippedListItemEdge: GQLSkippedListItemEdge
+  SkippedListItemsConnection: GQLSkippedListItemsConnection
+  SkippedListItemsInput: GQLSkippedListItemsInput
+  SocialAccount: GQLSocialAccount
+  SocialLoginInput: GQLSocialLoginInput
+  SpamRing: SpamRingModel
+  SpamRingCandidateInput: GQLSpamRingCandidateInput
+  SpamRingConnection: Omit<GQLSpamRingConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['SpamRingEdge']>>
+  }
+  SpamRingEdge: Omit<GQLSpamRingEdge, 'node'> & {
+    node: GQLResolversParentTypes['SpamRing']
+  }
+  SpamRingEvent: SpamRingEventModel
+  SpamRingMember: SpamRingMemberModel
+  SpamRingMemberConnection: Omit<GQLSpamRingMemberConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['SpamRingMemberEdge']>>
+  }
+  SpamRingMemberEdge: Omit<GQLSpamRingMemberEdge, 'node'> & {
+    node: GQLResolversParentTypes['SpamRingMember']
+  }
+  SpamRingSignals: SpamRingSignalsModel
+  SpamRingSignalsInput: GQLSpamRingSignalsInput
+  SpamRingSkip: Omit<GQLSpamRingSkip, 'user'> & {
+    user: GQLResolversParentTypes['User']
+  }
+  SpamStatus: GQLSpamStatus
+  String: Scalars['String']['output']
+  StripeAccount: PayoutAccountModel
+  SubmitReportInput: GQLSubmitReportInput
+  SubmitTopicChannelFeedbackInput: GQLSubmitTopicChannelFeedbackInput
+  SubscribeCircleInput: GQLSubscribeCircleInput
+  SubscribeCircleResult: Omit<GQLSubscribeCircleResult, 'circle'> & {
+    circle: GQLResolversParentTypes['Circle']
+  }
+  Tag: TagModel
+  TagArticlesInput: GQLTagArticlesInput
+  TagConnection: Omit<GQLTagConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['TagEdge']>>
+  }
+  TagEdge: Omit<GQLTagEdge, 'node'> & { node: GQLResolversParentTypes['Tag'] }
+  TagOSS: TagModel
+  TagWritingConnection: Omit<GQLTagWritingConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['TagWritingEdge']>>
+  }
+  TagWritingEdge: Omit<GQLTagWritingEdge, 'node'> & {
+    node: GQLResolversParentTypes['Writing']
+  }
+  TagsInput: GQLTagsInput
+  ToggleCircleMemberInput: GQLToggleCircleMemberInput
+  ToggleItemInput: GQLToggleItemInput
+  TogglePinChannelArticlesInput: GQLTogglePinChannelArticlesInput
+  ToggleRecommendInput: GQLToggleRecommendInput
+  ToggleSeedingUsersInput: GQLToggleSeedingUsersInput
+  ToggleUsersBadgeInput: GQLToggleUsersBadgeInput
+  ToggleWritingChallengeFeaturedArticlesInput: GQLToggleWritingChallengeFeaturedArticlesInput
+  TopDonatorConnection: Omit<GQLTopDonatorConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['TopDonatorEdge']>>
+  }
+  TopDonatorEdge: Omit<GQLTopDonatorEdge, 'node'> & {
+    node: GQLResolversParentTypes['Donator']
+  }
+  TopDonatorFilter: GQLTopDonatorFilter
+  TopDonatorInput: GQLTopDonatorInput
+  TopicChannel: TopicChannelModel
+  TopicChannelClassification: ArticleModel
+  TopicChannelFeedback: TopicChannelFeedbackModel
+  TopicChannelFeedbackConnection: Omit<
+    GQLTopicChannelFeedbackConnection,
+    'edges'
+  > & { edges: Array<GQLResolversParentTypes['TopicChannelFeedbackEdge']> }
+  TopicChannelFeedbackEdge: Omit<GQLTopicChannelFeedbackEdge, 'node'> & {
+    node: GQLResolversParentTypes['TopicChannelFeedback']
+  }
+  TopicChannelFeedbacksFilterInput: GQLTopicChannelFeedbacksFilterInput
+  TopicChannelFeedbacksInput: GQLTopicChannelFeedbacksInput
+  Transaction: TransactionModel
+  TransactionConnection: Omit<GQLTransactionConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['TransactionEdge']>>
+  }
+  TransactionEdge: Omit<GQLTransactionEdge, 'node'> & {
+    node: GQLResolversParentTypes['Transaction']
+  }
+  TransactionNotice: NoticeItemModel
+  TransactionTarget: GQLResolversUnionTypes<GQLResolversParentTypes>['TransactionTarget']
+  TransactionsArgs: GQLTransactionsArgs
+  TransactionsFilter: GQLTransactionsFilter
+  TransactionsReceivedByArgs: GQLTransactionsReceivedByArgs
+  TranslatedAnnouncement: GQLTranslatedAnnouncement
+  TranslationArgs: GQLTranslationArgs
+  TranslationInput: GQLTranslationInput
+  UnbindLikerIdInput: GQLUnbindLikerIdInput
+  UnfreezeSpamRingInput: GQLUnfreezeSpamRingInput
+  UnfreezeSpamRingResult: Omit<
+    GQLUnfreezeSpamRingResult,
+    'ring' | 'skipped' | 'unbanned'
+  > & {
+    ring: GQLResolversParentTypes['SpamRing']
+    skipped: Array<GQLResolversParentTypes['SpamRingSkip']>
+    unbanned: Array<GQLResolversParentTypes['User']>
+  }
+  UnlikeCollectionInput: GQLUnlikeCollectionInput
+  UnlikeMomentInput: GQLUnlikeMomentInput
+  UnpinCommentInput: GQLUnpinCommentInput
+  UnsubscribeCircleInput: GQLUnsubscribeCircleInput
+  UnvoteCommentInput: GQLUnvoteCommentInput
+  UpdateArticleSensitiveInput: GQLUpdateArticleSensitiveInput
+  UpdateArticleStateInput: GQLUpdateArticleStateInput
+  UpdateCampaignApplicationStateInput: GQLUpdateCampaignApplicationStateInput
+  UpdateCommentsStateInput: GQLUpdateCommentsStateInput
+  UpdateCommunityWatchActionStateInput: GQLUpdateCommunityWatchActionStateInput
+  UpdateModerationCaseInput: GQLUpdateModerationCaseInput
+  UpdateMomentFeedApplicationStateInput: GQLUpdateMomentFeedApplicationStateInput
+  UpdateNotificationSettingInput: GQLUpdateNotificationSettingInput
+  UpdateUserExtraInput: GQLUpdateUserExtraInput
+  UpdateUserInfoInput: GQLUpdateUserInfoInput
+  UpdateUserRoleInput: GQLUpdateUserRoleInput
+  UpdateUserStateInput: GQLUpdateUserStateInput
+  Upload: Scalars['Upload']['output']
+  UpsertSpamRingCandidatesInput: GQLUpsertSpamRingCandidatesInput
+  UpsertSpamRingCandidatesResult: Omit<
+    GQLUpsertSpamRingCandidatesResult,
+    'rings'
+  > & { rings: Array<GQLResolversParentTypes['SpamRing']> }
+  User: UserModel
+  UserActivity: UserModel
+  UserAddArticleTagActivity: Omit<
+    GQLUserAddArticleTagActivity,
+    'actor' | 'node' | 'target'
+  > & {
+    actor: GQLResolversParentTypes['User']
+    node: GQLResolversParentTypes['Article']
+    target: GQLResolversParentTypes['Tag']
+  }
+  UserAnalytics: UserModel
+  UserArticlesFilter: GQLUserArticlesFilter
+  UserArticlesInput: GQLUserArticlesInput
+  UserBroadcastCircleActivity: Omit<
+    GQLUserBroadcastCircleActivity,
+    'actor' | 'node' | 'target'
+  > & {
+    actor: GQLResolversParentTypes['User']
+    node: GQLResolversParentTypes['Comment']
+    target: GQLResolversParentTypes['Circle']
+  }
+  UserConnection: Omit<GQLUserConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['UserEdge']>>
+  }
+  UserCreateCircleActivity: Omit<
+    GQLUserCreateCircleActivity,
+    'actor' | 'node'
+  > & {
+    actor: GQLResolversParentTypes['User']
+    node: GQLResolversParentTypes['Circle']
+  }
+  UserEdge: Omit<GQLUserEdge, 'node'> & {
+    node: GQLResolversParentTypes['User']
+  }
+  UserFeatureFlag: GQLUserFeatureFlag
+  UserFeatures: GQLUserFeatures
+  UserFederationSetting: GQLUserFederationSetting
+  UserInfo: UserModel
+  UserInput: GQLUserInput
+  UserNotice: NoticeItemModel
+  UserOSS: UserModel
+  UserPostMomentActivity: Omit<
+    GQLUserPostMomentActivity,
+    'actor' | 'more' | 'node'
+  > & {
+    actor: GQLResolversParentTypes['User']
+    more: Array<GQLResolversParentTypes['Moment']>
+    node: GQLResolversParentTypes['Moment']
+  }
+  UserPublishArticleActivity: Omit<
+    GQLUserPublishArticleActivity,
+    'actor' | 'node'
+  > & {
+    actor: GQLResolversParentTypes['User']
+    node: GQLResolversParentTypes['Article']
+  }
+  UserRecommendationActivity: Omit<GQLUserRecommendationActivity, 'nodes'> & {
+    nodes?: Maybe<Array<GQLResolversParentTypes['User']>>
+  }
+  UserRestriction: GQLUserRestriction
+  UserSettings: UserModel
+  UserStatus: UserModel
+  VerifyEmailInput: GQLVerifyEmailInput
+  VoteCommentInput: GQLVoteCommentInput
+  Wallet: UserModel
+  WalletLoginInput: GQLWalletLoginInput
+  WithdrawLockedTokensResult: Omit<
+    GQLWithdrawLockedTokensResult,
+    'transaction'
+  > & { transaction: GQLResolversParentTypes['Transaction'] }
+  Writing: WritingModel
+  WritingChallenge: CampaignModel
+  WritingConnection: Omit<GQLWritingConnection, 'edges'> & {
+    edges?: Maybe<Array<GQLResolversParentTypes['WritingEdge']>>
+  }
+  WritingEdge: Omit<GQLWritingEdge, 'node'> & {
+    node: GQLResolversParentTypes['Writing']
+  }
+  WritingInput: GQLWritingInput
+}>
 
 export type GQLAuthDirectiveArgs = {
-  group?: Maybe<Scalars['String']['input']>;
-  mode: Scalars['String']['input'];
-};
+  group?: Maybe<Scalars['String']['input']>
+  mode: Scalars['String']['input']
+}
 
-export type GQLAuthDirectiveResolver<Result, Parent, ContextType = Context, Args = GQLAuthDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+export type GQLAuthDirectiveResolver<
+  Result,
+  Parent,
+  ContextType = Context,
+  Args = GQLAuthDirectiveArgs
+> = DirectiveResolverFn<Result, Parent, ContextType, Args>
 
 export type GQLCacheControlDirectiveArgs = {
-  inheritMaxAge?: Maybe<Scalars['Boolean']['input']>;
-  maxAge?: Maybe<Scalars['Int']['input']>;
-  scope?: Maybe<GQLCacheControlScope>;
-};
+  inheritMaxAge?: Maybe<Scalars['Boolean']['input']>
+  maxAge?: Maybe<Scalars['Int']['input']>
+  scope?: Maybe<GQLCacheControlScope>
+}
 
-export type GQLCacheControlDirectiveResolver<Result, Parent, ContextType = Context, Args = GQLCacheControlDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+export type GQLCacheControlDirectiveResolver<
+  Result,
+  Parent,
+  ContextType = Context,
+  Args = GQLCacheControlDirectiveArgs
+> = DirectiveResolverFn<Result, Parent, ContextType, Args>
 
 export type GQLComplexityDirectiveArgs = {
-  multipliers?: Maybe<Array<Scalars['String']['input']>>;
-  value: Scalars['Int']['input'];
-};
+  multipliers?: Maybe<Array<Scalars['String']['input']>>
+  value: Scalars['Int']['input']
+}
 
-export type GQLComplexityDirectiveResolver<Result, Parent, ContextType = Context, Args = GQLComplexityDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+export type GQLComplexityDirectiveResolver<
+  Result,
+  Parent,
+  ContextType = Context,
+  Args = GQLComplexityDirectiveArgs
+> = DirectiveResolverFn<Result, Parent, ContextType, Args>
 
 export type GQLConstraintDirectiveArgs = {
-  contains?: Maybe<Scalars['String']['input']>;
-  endsWith?: Maybe<Scalars['String']['input']>;
-  exclusiveMax?: Maybe<Scalars['Float']['input']>;
-  exclusiveMin?: Maybe<Scalars['Float']['input']>;
-  format?: Maybe<Scalars['String']['input']>;
-  max?: Maybe<Scalars['Float']['input']>;
-  maxItems?: Maybe<Scalars['Int']['input']>;
-  maxLength?: Maybe<Scalars['Int']['input']>;
-  min?: Maybe<Scalars['Float']['input']>;
-  minItems?: Maybe<Scalars['Int']['input']>;
-  minLength?: Maybe<Scalars['Int']['input']>;
-  multipleOf?: Maybe<Scalars['Float']['input']>;
-  notContains?: Maybe<Scalars['String']['input']>;
-  pattern?: Maybe<Scalars['String']['input']>;
-  startsWith?: Maybe<Scalars['String']['input']>;
-  uniqueTypeName?: Maybe<Scalars['String']['input']>;
-};
+  contains?: Maybe<Scalars['String']['input']>
+  endsWith?: Maybe<Scalars['String']['input']>
+  exclusiveMax?: Maybe<Scalars['Float']['input']>
+  exclusiveMin?: Maybe<Scalars['Float']['input']>
+  format?: Maybe<Scalars['String']['input']>
+  max?: Maybe<Scalars['Float']['input']>
+  maxItems?: Maybe<Scalars['Int']['input']>
+  maxLength?: Maybe<Scalars['Int']['input']>
+  min?: Maybe<Scalars['Float']['input']>
+  minItems?: Maybe<Scalars['Int']['input']>
+  minLength?: Maybe<Scalars['Int']['input']>
+  multipleOf?: Maybe<Scalars['Float']['input']>
+  notContains?: Maybe<Scalars['String']['input']>
+  pattern?: Maybe<Scalars['String']['input']>
+  startsWith?: Maybe<Scalars['String']['input']>
+  uniqueTypeName?: Maybe<Scalars['String']['input']>
+}
 
-export type GQLConstraintDirectiveResolver<Result, Parent, ContextType = Context, Args = GQLConstraintDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+export type GQLConstraintDirectiveResolver<
+  Result,
+  Parent,
+  ContextType = Context,
+  Args = GQLConstraintDirectiveArgs
+> = DirectiveResolverFn<Result, Parent, ContextType, Args>
 
 export type GQLLogCacheDirectiveArgs = {
-  identifier?: Maybe<Scalars['String']['input']>;
-  type: Scalars['String']['input'];
-};
+  identifier?: Maybe<Scalars['String']['input']>
+  type: Scalars['String']['input']
+}
 
-export type GQLLogCacheDirectiveResolver<Result, Parent, ContextType = Context, Args = GQLLogCacheDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+export type GQLLogCacheDirectiveResolver<
+  Result,
+  Parent,
+  ContextType = Context,
+  Args = GQLLogCacheDirectiveArgs
+> = DirectiveResolverFn<Result, Parent, ContextType, Args>
 
 export type GQLObjectCacheDirectiveArgs = {
-  maxAge?: Maybe<Scalars['Int']['input']>;
-};
+  maxAge?: Maybe<Scalars['Int']['input']>
+}
 
-export type GQLObjectCacheDirectiveResolver<Result, Parent, ContextType = Context, Args = GQLObjectCacheDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+export type GQLObjectCacheDirectiveResolver<
+  Result,
+  Parent,
+  ContextType = Context,
+  Args = GQLObjectCacheDirectiveArgs
+> = DirectiveResolverFn<Result, Parent, ContextType, Args>
 
 export type GQLPrivateCacheDirectiveArgs = {
-  strict?: Scalars['Boolean']['input'];
-};
+  strict?: Scalars['Boolean']['input']
+}
 
-export type GQLPrivateCacheDirectiveResolver<Result, Parent, ContextType = Context, Args = GQLPrivateCacheDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+export type GQLPrivateCacheDirectiveResolver<
+  Result,
+  Parent,
+  ContextType = Context,
+  Args = GQLPrivateCacheDirectiveArgs
+> = DirectiveResolverFn<Result, Parent, ContextType, Args>
 
 export type GQLPurgeCacheDirectiveArgs = {
-  identifier?: Maybe<Scalars['String']['input']>;
-  type: Scalars['String']['input'];
-};
+  identifier?: Maybe<Scalars['String']['input']>
+  type: Scalars['String']['input']
+}
 
-export type GQLPurgeCacheDirectiveResolver<Result, Parent, ContextType = Context, Args = GQLPurgeCacheDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+export type GQLPurgeCacheDirectiveResolver<
+  Result,
+  Parent,
+  ContextType = Context,
+  Args = GQLPurgeCacheDirectiveArgs
+> = DirectiveResolverFn<Result, Parent, ContextType, Args>
 
 export type GQLRateLimitDirectiveArgs = {
-  ip?: Maybe<Scalars['Boolean']['input']>;
-  limit: Scalars['Int']['input'];
-  period: Scalars['Int']['input'];
-};
-
-export type GQLRateLimitDirectiveResolver<Result, Parent, ContextType = Context, Args = GQLRateLimitDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
-
-export type GQLAdStatusResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['AdStatus'] = GQLResolversParentTypes['AdStatus']> = ResolversObject<{
-  isAd?: Resolver<Maybe<GQLResolversTypes['Boolean']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLAddCreditResultResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['AddCreditResult'] = GQLResolversParentTypes['AddCreditResult']> = ResolversObject<{
-  client_secret?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  transaction?: Resolver<GQLResolversTypes['Transaction'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLAnnouncementResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Announcement'] = GQLResolversParentTypes['Announcement']> = ResolversObject<{
-  channels?: Resolver<Array<GQLResolversTypes['AnnouncementChannel']>, ParentType, ContextType>;
-  content?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType, Partial<GQLAnnouncementContentArgs>>;
-  cover?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  expiredAt?: Resolver<Maybe<GQLResolversTypes['DateTime']>, ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  link?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType, Partial<GQLAnnouncementLinkArgs>>;
-  order?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  title?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType, Partial<GQLAnnouncementTitleArgs>>;
-  translations?: Resolver<Maybe<Array<GQLResolversTypes['TranslatedAnnouncement']>>, ParentType, ContextType>;
-  type?: Resolver<GQLResolversTypes['AnnouncementType'], ParentType, ContextType>;
-  updatedAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  visible?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLAnnouncementChannelResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['AnnouncementChannel'] = GQLResolversParentTypes['AnnouncementChannel']> = ResolversObject<{
-  channel?: Resolver<GQLResolversTypes['Channel'], ParentType, ContextType>;
-  order?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  visible?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLAppreciationResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Appreciation'] = GQLResolversParentTypes['Appreciation']> = ResolversObject<{
-  amount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  content?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  purpose?: Resolver<GQLResolversTypes['AppreciationPurpose'], ParentType, ContextType>;
-  recipient?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>;
-  sender?: Resolver<Maybe<GQLResolversTypes['User']>, ParentType, ContextType>;
-  target?: Resolver<Maybe<GQLResolversTypes['Article']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLAppreciationConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['AppreciationConnection'] = GQLResolversParentTypes['AppreciationConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['AppreciationEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLAppreciationEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['AppreciationEdge'] = GQLResolversParentTypes['AppreciationEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Appreciation'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLArchiveUserFailureResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ArchiveUserFailure'] = GQLResolversParentTypes['ArchiveUserFailure']> = ResolversObject<{
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  message?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLArchiveUsersResultResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ArchiveUsersResult'] = GQLResolversParentTypes['ArchiveUsersResult']> = ResolversObject<{
-  archived?: Resolver<Array<GQLResolversTypes['User']>, ParentType, ContextType>;
-  skipped?: Resolver<Array<GQLResolversTypes['ArchiveUserFailure']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLArticleResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Article'] = GQLResolversParentTypes['Article']> = ResolversObject<{
-  access?: Resolver<GQLResolversTypes['ArticleAccess'], ParentType, ContextType>;
-  appreciateLeft?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  appreciateLimit?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  appreciationsReceived?: Resolver<GQLResolversTypes['AppreciationConnection'], ParentType, ContextType, RequireFields<GQLArticleAppreciationsReceivedArgs, 'input'>>;
-  appreciationsReceivedTotal?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  assets?: Resolver<Array<GQLResolversTypes['Asset']>, ParentType, ContextType>;
-  author?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>;
-  availableTranslations?: Resolver<Maybe<Array<GQLResolversTypes['UserLanguage']>>, ParentType, ContextType>;
-  bookmarkCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  bookmarked?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  campaigns?: Resolver<Array<GQLResolversTypes['ArticleCampaign']>, ParentType, ContextType>;
-  canComment?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  canSuperLike?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  classification?: Resolver<GQLResolversTypes['ArticleClassification'], ParentType, ContextType>;
-  collection?: Resolver<GQLResolversTypes['ArticleConnection'], ParentType, ContextType, RequireFields<GQLArticleCollectionArgs, 'input'>>;
-  collections?: Resolver<GQLResolversTypes['CollectionConnection'], ParentType, ContextType, RequireFields<GQLArticleCollectionsArgs, 'input'>>;
-  commentCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  comments?: Resolver<GQLResolversTypes['CommentConnection'], ParentType, ContextType, RequireFields<GQLArticleCommentsArgs, 'input'>>;
-  connectedBy?: Resolver<GQLResolversTypes['ArticleConnection'], ParentType, ContextType, RequireFields<GQLArticleConnectedByArgs, 'input'>>;
-  connections?: Resolver<GQLResolversTypes['ArticleConnection'], ParentType, ContextType, RequireFields<GQLArticleConnectionsArgs, 'input'>>;
-  content?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  contents?: Resolver<GQLResolversTypes['ArticleContents'], ParentType, ContextType>;
-  cover?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  dataHash?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  displayCover?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  donated?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  donationCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  donations?: Resolver<GQLResolversTypes['ArticleDonationConnection'], ParentType, ContextType, RequireFields<GQLArticleDonationsArgs, 'input'>>;
-  featuredComments?: Resolver<GQLResolversTypes['CommentConnection'], ParentType, ContextType, RequireFields<GQLArticleFeaturedCommentsArgs, 'input'>>;
-  federationEligibility?: Resolver<GQLResolversTypes['ArticleFederationEligibility'], ParentType, ContextType>;
-  federationSetting?: Resolver<Maybe<GQLResolversTypes['ArticleFederationSetting']>, ParentType, ContextType>;
-  hasAppreciate?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  indentFirstLine?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  iscnId?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  language?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  license?: Resolver<GQLResolversTypes['ArticleLicenseType'], ParentType, ContextType>;
-  mediaHash?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  noindex?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  oss?: Resolver<GQLResolversTypes['ArticleOSS'], ParentType, ContextType>;
-  pinCommentLeft?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  pinCommentLimit?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  pinned?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  pinnedComments?: Resolver<Maybe<Array<GQLResolversTypes['Comment']>>, ParentType, ContextType>;
-  readTime?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>;
-  readerCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  relatedArticles?: Resolver<GQLResolversTypes['ArticleConnection'], ParentType, ContextType, RequireFields<GQLArticleRelatedArticlesArgs, 'input'>>;
-  relatedDonationArticles?: Resolver<GQLResolversTypes['ArticleConnection'], ParentType, ContextType, RequireFields<GQLArticleRelatedDonationArticlesArgs, 'input'>>;
-  remark?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  replyToDonator?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  requestForDonation?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  responseCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  responses?: Resolver<GQLResolversTypes['ResponseConnection'], ParentType, ContextType, RequireFields<GQLArticleResponsesArgs, 'input'>>;
-  revisedAt?: Resolver<Maybe<GQLResolversTypes['DateTime']>, ParentType, ContextType>;
-  revisionCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  sensitiveByAdmin?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  sensitiveByAuthor?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  shortHash?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  slug?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  state?: Resolver<GQLResolversTypes['ArticleState'], ParentType, ContextType>;
-  subscribed?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  summary?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  summaryCustomized?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  tags?: Resolver<Maybe<Array<GQLResolversTypes['Tag']>>, ParentType, ContextType>;
-  title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  transactionsReceivedBy?: Resolver<GQLResolversTypes['UserConnection'], ParentType, ContextType, RequireFields<GQLArticleTransactionsReceivedByArgs, 'input'>>;
-  translation?: Resolver<Maybe<GQLResolversTypes['ArticleTranslation']>, ParentType, ContextType, Partial<GQLArticleTranslationArgs>>;
-  versions?: Resolver<GQLResolversTypes['ArticleVersionsConnection'], ParentType, ContextType, RequireFields<GQLArticleVersionsArgs, 'input'>>;
-  wordCount?: Resolver<Maybe<GQLResolversTypes['Int']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLArticleAccessResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ArticleAccess'] = GQLResolversParentTypes['ArticleAccess']> = ResolversObject<{
-  circle?: Resolver<Maybe<GQLResolversTypes['Circle']>, ParentType, ContextType>;
-  secret?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  type?: Resolver<GQLResolversTypes['ArticleAccessType'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLArticleArticleNoticeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ArticleArticleNotice'] = GQLResolversParentTypes['ArticleArticleNotice']> = ResolversObject<{
-  actors?: Resolver<Maybe<Array<GQLResolversTypes['User']>>, ParentType, ContextType>;
-  article?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  target?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>;
-  type?: Resolver<GQLResolversTypes['ArticleArticleNoticeType'], ParentType, ContextType>;
-  unread?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLArticleCampaignResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ArticleCampaign'] = GQLResolversParentTypes['ArticleCampaign']> = ResolversObject<{
-  campaign?: Resolver<GQLResolversTypes['Campaign'], ParentType, ContextType>;
-  stage?: Resolver<Maybe<GQLResolversTypes['CampaignStage']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLArticleClassificationResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ArticleClassification'] = GQLResolversParentTypes['ArticleClassification']> = ResolversObject<{
-  topicChannel?: Resolver<GQLResolversTypes['TopicChannelClassification'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLArticleConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ArticleConnection'] = GQLResolversParentTypes['ArticleConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['ArticleEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLArticleContentsResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ArticleContents'] = GQLResolversParentTypes['ArticleContents']> = ResolversObject<{
-  html?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  markdown?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLArticleDonationResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ArticleDonation'] = GQLResolversParentTypes['ArticleDonation']> = ResolversObject<{
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  sender?: Resolver<Maybe<GQLResolversTypes['User']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLArticleDonationConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ArticleDonationConnection'] = GQLResolversParentTypes['ArticleDonationConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['ArticleDonationEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLArticleDonationEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ArticleDonationEdge'] = GQLResolversParentTypes['ArticleDonationEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['ArticleDonation'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLArticleEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ArticleEdge'] = GQLResolversParentTypes['ArticleEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLArticleFederationEligibilityResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ArticleFederationEligibility'] = GQLResolversParentTypes['ArticleFederationEligibility']> = ResolversObject<{
-  effectiveArticleSetting?: Resolver<GQLResolversTypes['FederationArticleSettingState'], ParentType, ContextType>;
-  eligible?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  reason?: Resolver<GQLResolversTypes['FederationExportDecisionReason'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLArticleFederationSettingResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ArticleFederationSetting'] = GQLResolversParentTypes['ArticleFederationSetting']> = ResolversObject<{
-  articleId?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  state?: Resolver<GQLResolversTypes['FederationArticleSettingState'], ParentType, ContextType>;
-  updatedBy?: Resolver<Maybe<GQLResolversTypes['ID']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLArticleNoticeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ArticleNotice'] = GQLResolversParentTypes['ArticleNotice']> = ResolversObject<{
-  actors?: Resolver<Maybe<Array<GQLResolversTypes['User']>>, ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  entities?: Resolver<Array<GQLResolversTypes['Node']>, ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  target?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>;
-  type?: Resolver<GQLResolversTypes['ArticleNoticeType'], ParentType, ContextType>;
-  unread?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLArticleOssResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ArticleOSS'] = GQLResolversParentTypes['ArticleOSS']> = ResolversObject<{
-  adStatus?: Resolver<GQLResolversTypes['AdStatus'], ParentType, ContextType>;
-  boost?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>;
-  inRecommendHottest?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  inRecommendIcymi?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  inRecommendNewest?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  inSearch?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  pinHistory?: Resolver<Array<Maybe<GQLResolversTypes['PinHistory']>>, ParentType, ContextType>;
-  score?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>;
-  spamStatus?: Resolver<GQLResolversTypes['SpamStatus'], ParentType, ContextType>;
-  topicChannels?: Resolver<Maybe<Array<GQLResolversTypes['ArticleTopicChannel']>>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLArticleRecommendationActivityResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ArticleRecommendationActivity'] = GQLResolversParentTypes['ArticleRecommendationActivity']> = ResolversObject<{
-  nodes?: Resolver<Maybe<Array<GQLResolversTypes['Article']>>, ParentType, ContextType>;
-  source?: Resolver<Maybe<GQLResolversTypes['ArticleRecommendationActivitySource']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLArticleTopicChannelResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ArticleTopicChannel'] = GQLResolversParentTypes['ArticleTopicChannel']> = ResolversObject<{
-  antiFlooded?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  channel?: Resolver<GQLResolversTypes['TopicChannel'], ParentType, ContextType>;
-  classicfiedAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  enabled?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  isLabeled?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  pinned?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  score?: Resolver<Maybe<GQLResolversTypes['Float']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLArticleTranslationResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ArticleTranslation'] = GQLResolversParentTypes['ArticleTranslation']> = ResolversObject<{
-  content?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  language?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  model?: Resolver<Maybe<GQLResolversTypes['TranslationModel']>, ParentType, ContextType>;
-  summary?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  title?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLArticleVersionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ArticleVersion'] = GQLResolversParentTypes['ArticleVersion']> = ResolversObject<{
-  contents?: Resolver<GQLResolversTypes['ArticleContents'], ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  dataHash?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  description?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  mediaHash?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  summary?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  translation?: Resolver<Maybe<GQLResolversTypes['ArticleTranslation']>, ParentType, ContextType, Partial<GQLArticleVersionTranslationArgs>>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLArticleVersionEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ArticleVersionEdge'] = GQLResolversParentTypes['ArticleVersionEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['ArticleVersion'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLArticleVersionsConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ArticleVersionsConnection'] = GQLResolversParentTypes['ArticleVersionsConnection']> = ResolversObject<{
-  edges?: Resolver<Array<Maybe<GQLResolversTypes['ArticleVersionEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLAssetResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Asset'] = GQLResolversParentTypes['Asset']> = ResolversObject<{
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  draft?: Resolver<Maybe<GQLResolversTypes['Boolean']>, ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  path?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  type?: Resolver<GQLResolversTypes['AssetType'], ParentType, ContextType>;
-  uploadURL?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLAuthResultResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['AuthResult'] = GQLResolversParentTypes['AuthResult']> = ResolversObject<{
-  auth?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  token?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  type?: Resolver<GQLResolversTypes['AuthResultType'], ParentType, ContextType>;
-  user?: Resolver<Maybe<GQLResolversTypes['User']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLBadgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Badge'] = GQLResolversParentTypes['Badge']> = ResolversObject<{
-  type?: Resolver<GQLResolversTypes['BadgeType'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLBalanceResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Balance'] = GQLResolversParentTypes['Balance']> = ResolversObject<{
-  HKD?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLBlockchainTransactionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['BlockchainTransaction'] = GQLResolversParentTypes['BlockchainTransaction']> = ResolversObject<{
-  chain?: Resolver<GQLResolversTypes['Chain'], ParentType, ContextType>;
-  txHash?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLBlockedSearchKeywordResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['BlockedSearchKeyword'] = GQLResolversParentTypes['BlockedSearchKeyword']> = ResolversObject<{
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  searchKey?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCampaignResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Campaign'] = GQLResolversParentTypes['Campaign']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'WritingChallenge', ParentType, ContextType>;
-}>;
-
-export type GQLCampaignApplicationResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CampaignApplication'] = GQLResolversParentTypes['CampaignApplication']> = ResolversObject<{
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  state?: Resolver<GQLResolversTypes['CampaignApplicationState'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCampaignArticleConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CampaignArticleConnection'] = GQLResolversParentTypes['CampaignArticleConnection']> = ResolversObject<{
-  edges?: Resolver<Array<GQLResolversTypes['CampaignArticleEdge']>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCampaignArticleEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CampaignArticleEdge'] = GQLResolversParentTypes['CampaignArticleEdge']> = ResolversObject<{
-  announcement?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  featured?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCampaignArticleNoticeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CampaignArticleNotice'] = GQLResolversParentTypes['CampaignArticleNotice']> = ResolversObject<{
-  actors?: Resolver<Maybe<Array<GQLResolversTypes['User']>>, ParentType, ContextType>;
-  article?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  target?: Resolver<GQLResolversTypes['Campaign'], ParentType, ContextType>;
-  type?: Resolver<GQLResolversTypes['CampaignArticleNoticeType'], ParentType, ContextType>;
-  unread?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCampaignConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CampaignConnection'] = GQLResolversParentTypes['CampaignConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['CampaignEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCampaignEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CampaignEdge'] = GQLResolversParentTypes['CampaignEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Campaign'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCampaignOssResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CampaignOSS'] = GQLResolversParentTypes['CampaignOSS']> = ResolversObject<{
-  boost?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>;
-  exclusive?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  managers?: Resolver<Array<GQLResolversTypes['User']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCampaignParticipantConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CampaignParticipantConnection'] = GQLResolversParentTypes['CampaignParticipantConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['CampaignParticipantEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCampaignParticipantEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CampaignParticipantEdge'] = GQLResolversParentTypes['CampaignParticipantEdge']> = ResolversObject<{
-  application?: Resolver<Maybe<GQLResolversTypes['CampaignApplication']>, ParentType, ContextType>;
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCampaignStageResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CampaignStage'] = GQLResolversParentTypes['CampaignStage']> = ResolversObject<{
-  description?: Resolver<GQLResolversTypes['String'], ParentType, ContextType, Partial<GQLCampaignStageDescriptionArgs>>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  name?: Resolver<GQLResolversTypes['String'], ParentType, ContextType, Partial<GQLCampaignStageNameArgs>>;
-  period?: Resolver<Maybe<GQLResolversTypes['DatetimeRange']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLChannelResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Channel'] = GQLResolversParentTypes['Channel']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'CurationChannel' | 'Tag' | 'TopicChannel' | 'WritingChallenge', ParentType, ContextType>;
-}>;
-
-export type GQLChannelArticleConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ChannelArticleConnection'] = GQLResolversParentTypes['ChannelArticleConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['ChannelArticleEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLChannelArticleEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ChannelArticleEdge'] = GQLResolversParentTypes['ChannelArticleEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>;
-  pinned?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCircleResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Circle'] = GQLResolversParentTypes['Circle']> = ResolversObject<{
-  analytics?: Resolver<GQLResolversTypes['CircleAnalytics'], ParentType, ContextType>;
-  avatar?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  broadcast?: Resolver<GQLResolversTypes['CommentConnection'], ParentType, ContextType, RequireFields<GQLCircleBroadcastArgs, 'input'>>;
-  cover?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  description?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  discussion?: Resolver<GQLResolversTypes['CommentConnection'], ParentType, ContextType, RequireFields<GQLCircleDiscussionArgs, 'input'>>;
-  discussionCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  discussionThreadCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  displayName?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  followers?: Resolver<GQLResolversTypes['UserConnection'], ParentType, ContextType, RequireFields<GQLCircleFollowersArgs, 'input'>>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  invitedBy?: Resolver<Maybe<GQLResolversTypes['Invitation']>, ParentType, ContextType>;
-  invites?: Resolver<GQLResolversTypes['Invites'], ParentType, ContextType>;
-  isFollower?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  isMember?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  members?: Resolver<GQLResolversTypes['MemberConnection'], ParentType, ContextType, RequireFields<GQLCircleMembersArgs, 'input'>>;
-  name?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  owner?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>;
-  pinnedBroadcast?: Resolver<Maybe<Array<GQLResolversTypes['Comment']>>, ParentType, ContextType>;
-  prices?: Resolver<Maybe<Array<GQLResolversTypes['Price']>>, ParentType, ContextType>;
-  state?: Resolver<GQLResolversTypes['CircleState'], ParentType, ContextType>;
-  updatedAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  works?: Resolver<GQLResolversTypes['ArticleConnection'], ParentType, ContextType, RequireFields<GQLCircleWorksArgs, 'input'>>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCircleAnalyticsResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CircleAnalytics'] = GQLResolversParentTypes['CircleAnalytics']> = ResolversObject<{
-  content?: Resolver<GQLResolversTypes['CircleContentAnalytics'], ParentType, ContextType>;
-  follower?: Resolver<GQLResolversTypes['CircleFollowerAnalytics'], ParentType, ContextType>;
-  income?: Resolver<GQLResolversTypes['CircleIncomeAnalytics'], ParentType, ContextType>;
-  subscriber?: Resolver<GQLResolversTypes['CircleSubscriberAnalytics'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCircleConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CircleConnection'] = GQLResolversParentTypes['CircleConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['CircleEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCircleContentAnalyticsResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CircleContentAnalytics'] = GQLResolversParentTypes['CircleContentAnalytics']> = ResolversObject<{
-  paywall?: Resolver<Maybe<Array<GQLResolversTypes['CircleContentAnalyticsDatum']>>, ParentType, ContextType>;
-  public?: Resolver<Maybe<Array<GQLResolversTypes['CircleContentAnalyticsDatum']>>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCircleContentAnalyticsDatumResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CircleContentAnalyticsDatum'] = GQLResolversParentTypes['CircleContentAnalyticsDatum']> = ResolversObject<{
-  node?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>;
-  readCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCircleEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CircleEdge'] = GQLResolversParentTypes['CircleEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Circle'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCircleFollowerAnalyticsResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CircleFollowerAnalytics'] = GQLResolversParentTypes['CircleFollowerAnalytics']> = ResolversObject<{
-  current?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  followerPercentage?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>;
-  history?: Resolver<Array<GQLResolversTypes['MonthlyDatum']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCircleIncomeAnalyticsResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CircleIncomeAnalytics'] = GQLResolversParentTypes['CircleIncomeAnalytics']> = ResolversObject<{
-  history?: Resolver<Array<GQLResolversTypes['MonthlyDatum']>, ParentType, ContextType>;
-  nextMonth?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>;
-  thisMonth?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>;
-  total?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCircleNoticeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CircleNotice'] = GQLResolversParentTypes['CircleNotice']> = ResolversObject<{
-  actors?: Resolver<Maybe<Array<GQLResolversTypes['User']>>, ParentType, ContextType>;
-  comments?: Resolver<Maybe<Array<GQLResolversTypes['Comment']>>, ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  mentions?: Resolver<Maybe<Array<GQLResolversTypes['Comment']>>, ParentType, ContextType>;
-  replies?: Resolver<Maybe<Array<GQLResolversTypes['Comment']>>, ParentType, ContextType>;
-  target?: Resolver<GQLResolversTypes['Circle'], ParentType, ContextType>;
-  type?: Resolver<GQLResolversTypes['CircleNoticeType'], ParentType, ContextType>;
-  unread?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCircleRecommendationActivityResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CircleRecommendationActivity'] = GQLResolversParentTypes['CircleRecommendationActivity']> = ResolversObject<{
-  nodes?: Resolver<Maybe<Array<GQLResolversTypes['Circle']>>, ParentType, ContextType>;
-  source?: Resolver<Maybe<GQLResolversTypes['CircleRecommendationActivitySource']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCircleSubscriberAnalyticsResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CircleSubscriberAnalytics'] = GQLResolversParentTypes['CircleSubscriberAnalytics']> = ResolversObject<{
-  currentInvitee?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  currentSubscriber?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  inviteeHistory?: Resolver<Array<GQLResolversTypes['MonthlyDatum']>, ParentType, ContextType>;
-  subscriberHistory?: Resolver<Array<GQLResolversTypes['MonthlyDatum']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLClaimLogbooksResultResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ClaimLogbooksResult'] = GQLResolversParentTypes['ClaimLogbooksResult']> = ResolversObject<{
-  ids?: Resolver<Maybe<Array<GQLResolversTypes['ID']>>, ParentType, ContextType>;
-  txHash?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCollectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Collection'] = GQLResolversParentTypes['Collection']> = ResolversObject<{
-  articles?: Resolver<GQLResolversTypes['ArticleConnection'], ParentType, ContextType, RequireFields<GQLCollectionArticlesArgs, 'input'>>;
-  author?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>;
-  contains?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType, RequireFields<GQLCollectionContainsArgs, 'input'>>;
-  cover?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  description?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  likeCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  liked?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  pinned?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  updatedAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCollectionConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CollectionConnection'] = GQLResolversParentTypes['CollectionConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['CollectionEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCollectionEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CollectionEdge'] = GQLResolversParentTypes['CollectionEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Collection'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCollectionNoticeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CollectionNotice'] = GQLResolversParentTypes['CollectionNotice']> = ResolversObject<{
-  actors?: Resolver<Maybe<Array<GQLResolversTypes['User']>>, ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  target?: Resolver<GQLResolversTypes['Collection'], ParentType, ContextType>;
-  unread?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCommentResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Comment'] = GQLResolversParentTypes['Comment']> = ResolversObject<{
-  author?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>;
-  comments?: Resolver<GQLResolversTypes['CommentConnection'], ParentType, ContextType, RequireFields<GQLCommentCommentsArgs, 'input'>>;
-  communityWatchAction?: Resolver<Maybe<GQLResolversTypes['CommunityWatchAction']>, ParentType, ContextType>;
-  content?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  downvotes?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  fromDonator?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  myVote?: Resolver<Maybe<GQLResolversTypes['Vote']>, ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Node'], ParentType, ContextType>;
-  parentComment?: Resolver<Maybe<GQLResolversTypes['Comment']>, ParentType, ContextType>;
-  pinned?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  remark?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  replyTo?: Resolver<Maybe<GQLResolversTypes['Comment']>, ParentType, ContextType>;
-  spamStatus?: Resolver<GQLResolversTypes['SpamStatus'], ParentType, ContextType>;
-  state?: Resolver<GQLResolversTypes['CommentState'], ParentType, ContextType>;
-  type?: Resolver<GQLResolversTypes['CommentType'], ParentType, ContextType>;
-  upvotes?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCommentCommentNoticeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CommentCommentNotice'] = GQLResolversParentTypes['CommentCommentNotice']> = ResolversObject<{
-  actors?: Resolver<Maybe<Array<GQLResolversTypes['User']>>, ParentType, ContextType>;
-  comment?: Resolver<GQLResolversTypes['Comment'], ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  target?: Resolver<GQLResolversTypes['Comment'], ParentType, ContextType>;
-  type?: Resolver<GQLResolversTypes['CommentCommentNoticeType'], ParentType, ContextType>;
-  unread?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCommentConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CommentConnection'] = GQLResolversParentTypes['CommentConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['CommentEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCommentEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CommentEdge'] = GQLResolversParentTypes['CommentEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Comment'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCommentNoticeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CommentNotice'] = GQLResolversParentTypes['CommentNotice']> = ResolversObject<{
-  actors?: Resolver<Maybe<Array<GQLResolversTypes['User']>>, ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  target?: Resolver<GQLResolversTypes['Comment'], ParentType, ContextType>;
-  type?: Resolver<GQLResolversTypes['CommentNoticeType'], ParentType, ContextType>;
-  unread?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCommunityWatchActionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CommunityWatchAction'] = GQLResolversParentTypes['CommunityWatchAction']> = ResolversObject<{
-  actionState?: Resolver<GQLResolversTypes['CommunityWatchActionState'], ParentType, ContextType>;
-  actorDisplayName?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  appealState?: Resolver<GQLResolversTypes['CommunityWatchAppealState'], ParentType, ContextType>;
-  commentId?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  contentCleared?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  contentHash?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  originalContent?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  reason?: Resolver<GQLResolversTypes['CommunityWatchRemoveCommentReason'], ParentType, ContextType>;
-  reportSynced?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  reviewState?: Resolver<GQLResolversTypes['CommunityWatchReviewState'], ParentType, ContextType>;
-  sourceId?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  sourceTitle?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  sourceType?: Resolver<GQLResolversTypes['CommunityWatchActionSourceType'], ParentType, ContextType>;
-  sourceUrl?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  uuid?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCommunityWatchActionConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CommunityWatchActionConnection'] = GQLResolversParentTypes['CommunityWatchActionConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['CommunityWatchActionEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCommunityWatchActionEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CommunityWatchActionEdge'] = GQLResolversParentTypes['CommunityWatchActionEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['CommunityWatchAction'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLConnectStripeAccountResultResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ConnectStripeAccountResult'] = GQLResolversParentTypes['ConnectStripeAccountResult']> = ResolversObject<{
-  redirectUrl?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Connection'] = GQLResolversParentTypes['Connection']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'AppreciationConnection' | 'ArticleConnection' | 'ArticleVersionsConnection' | 'CampaignArticleConnection' | 'CampaignConnection' | 'CampaignParticipantConnection' | 'ChannelArticleConnection' | 'CircleConnection' | 'CollectionConnection' | 'CommentConnection' | 'CommunityWatchActionConnection' | 'DraftConnection' | 'FollowingActivityConnection' | 'IcymiTopicConnection' | 'InvitationConnection' | 'MemberConnection' | 'MomentConnection' | 'NoticeConnection' | 'OAuthClientConnection' | 'QuoteConnection' | 'ReadHistoryConnection' | 'RecentSearchConnection' | 'ReportConnection' | 'ResponseConnection' | 'SearchResultConnection' | 'SkippedListItemsConnection' | 'SpamRingConnection' | 'SpamRingMemberConnection' | 'TagConnection' | 'TagWritingConnection' | 'TopDonatorConnection' | 'TopicChannelFeedbackConnection' | 'TransactionConnection' | 'UserConnection' | 'WritingConnection', ParentType, ContextType>;
-}>;
-
-export type GQLCryptoWalletResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CryptoWallet'] = GQLResolversParentTypes['CryptoWallet']> = ResolversObject<{
-  address?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  hasNFTs?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  nfts?: Resolver<Maybe<Array<GQLResolversTypes['NFTAsset']>>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLCurationChannelResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['CurationChannel'] = GQLResolversParentTypes['CurationChannel']> = ResolversObject<{
-  activePeriod?: Resolver<GQLResolversTypes['DatetimeRange'], ParentType, ContextType>;
-  articles?: Resolver<GQLResolversTypes['ChannelArticleConnection'], ParentType, ContextType, RequireFields<GQLCurationChannelArticlesArgs, 'input'>>;
-  color?: Resolver<GQLResolversTypes['Color'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  name?: Resolver<GQLResolversTypes['String'], ParentType, ContextType, Partial<GQLCurationChannelNameArgs>>;
-  navbarTitle?: Resolver<GQLResolversTypes['String'], ParentType, ContextType, Partial<GQLCurationChannelNavbarTitleArgs>>;
-  note?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType, Partial<GQLCurationChannelNoteArgs>>;
-  pinAmount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  shortHash?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  showRecommendation?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  state?: Resolver<GQLResolversTypes['CurationChannelState'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export interface GQLDateTimeScalarConfig extends GraphQLScalarTypeConfig<GQLResolversTypes['DateTime'], any> {
-  name: 'DateTime';
+  ip?: Maybe<Scalars['Boolean']['input']>
+  limit: Scalars['Int']['input']
+  period: Scalars['Int']['input']
 }
 
-export type GQLDatetimeRangeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['DatetimeRange'] = GQLResolversParentTypes['DatetimeRange']> = ResolversObject<{
-  end?: Resolver<Maybe<GQLResolversTypes['DateTime']>, ParentType, ContextType>;
-  start?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLDonatorResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Donator'] = GQLResolversParentTypes['Donator']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'CryptoWallet' | 'User', ParentType, ContextType>;
-}>;
-
-export type GQLDraftResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Draft'] = GQLResolversParentTypes['Draft']> = ResolversObject<{
-  access?: Resolver<GQLResolversTypes['DraftAccess'], ParentType, ContextType>;
-  article?: Resolver<Maybe<GQLResolversTypes['Article']>, ParentType, ContextType>;
-  assets?: Resolver<Array<GQLResolversTypes['Asset']>, ParentType, ContextType>;
-  campaigns?: Resolver<Array<GQLResolversTypes['ArticleCampaign']>, ParentType, ContextType>;
-  canComment?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  collection?: Resolver<GQLResolversTypes['ArticleConnection'], ParentType, ContextType, RequireFields<GQLDraftCollectionArgs, 'input'>>;
-  collections?: Resolver<GQLResolversTypes['CollectionConnection'], ParentType, ContextType, RequireFields<GQLDraftCollectionsArgs, 'input'>>;
-  connections?: Resolver<GQLResolversTypes['ArticleConnection'], ParentType, ContextType, RequireFields<GQLDraftConnectionsArgs, 'input'>>;
-  content?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  cover?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  indentFirstLine?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  iscnPublish?: Resolver<Maybe<GQLResolversTypes['Boolean']>, ParentType, ContextType>;
-  license?: Resolver<GQLResolversTypes['ArticleLicenseType'], ParentType, ContextType>;
-  mediaHash?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  publishAt?: Resolver<Maybe<GQLResolversTypes['DateTime']>, ParentType, ContextType>;
-  publishState?: Resolver<GQLResolversTypes['PublishState'], ParentType, ContextType>;
-  replyToDonator?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  requestForDonation?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  sensitiveByAuthor?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  slug?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  summary?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  summaryCustomized?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  tags?: Resolver<Maybe<Array<GQLResolversTypes['String']>>, ParentType, ContextType>;
-  title?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  updatedAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  wordCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLDraftAccessResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['DraftAccess'] = GQLResolversParentTypes['DraftAccess']> = ResolversObject<{
-  circle?: Resolver<Maybe<GQLResolversTypes['Circle']>, ParentType, ContextType>;
-  type?: Resolver<GQLResolversTypes['ArticleAccessType'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLDraftConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['DraftConnection'] = GQLResolversParentTypes['DraftConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['DraftEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLDraftEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['DraftEdge'] = GQLResolversParentTypes['DraftEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Draft'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLExchangeRateResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ExchangeRate'] = GQLResolversParentTypes['ExchangeRate']> = ResolversObject<{
-  from?: Resolver<GQLResolversTypes['TransactionCurrency'], ParentType, ContextType>;
-  rate?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>;
-  to?: Resolver<GQLResolversTypes['QuoteCurrency'], ParentType, ContextType>;
-  updatedAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLFeatureResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Feature'] = GQLResolversParentTypes['Feature']> = ResolversObject<{
-  enabled?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  name?: Resolver<GQLResolversTypes['FeatureName'], ParentType, ContextType>;
-  value?: Resolver<Maybe<GQLResolversTypes['Float']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLFollowingResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Following'] = GQLResolversParentTypes['Following']> = ResolversObject<{
-  circles?: Resolver<GQLResolversTypes['CircleConnection'], ParentType, ContextType, RequireFields<GQLFollowingCirclesArgs, 'input'>>;
-  users?: Resolver<GQLResolversTypes['UserConnection'], ParentType, ContextType, RequireFields<GQLFollowingUsersArgs, 'input'>>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLFollowingActivityResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['FollowingActivity'] = GQLResolversParentTypes['FollowingActivity']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'ArticleRecommendationActivity' | 'CircleRecommendationActivity' | 'UserAddArticleTagActivity' | 'UserBroadcastCircleActivity' | 'UserCreateCircleActivity' | 'UserPostMomentActivity' | 'UserPublishArticleActivity' | 'UserRecommendationActivity', ParentType, ContextType>;
-}>;
-
-export type GQLFollowingActivityConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['FollowingActivityConnection'] = GQLResolversParentTypes['FollowingActivityConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['FollowingActivityEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLFollowingActivityEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['FollowingActivityEdge'] = GQLResolversParentTypes['FollowingActivityEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['FollowingActivity'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLFreezeSpamRingResultResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['FreezeSpamRingResult'] = GQLResolversParentTypes['FreezeSpamRingResult']> = ResolversObject<{
-  frozen?: Resolver<Array<GQLResolversTypes['User']>, ParentType, ContextType>;
-  ring?: Resolver<GQLResolversTypes['SpamRing'], ParentType, ContextType>;
-  skipped?: Resolver<Array<GQLResolversTypes['SpamRingSkip']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLIcymiTopicResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['IcymiTopic'] = GQLResolversParentTypes['IcymiTopic']> = ResolversObject<{
-  archivedAt?: Resolver<Maybe<GQLResolversTypes['DateTime']>, ParentType, ContextType>;
-  articles?: Resolver<Array<GQLResolversTypes['Article']>, ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  note?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType, Partial<GQLIcymiTopicNoteArgs>>;
-  pinAmount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  publishedAt?: Resolver<Maybe<GQLResolversTypes['DateTime']>, ParentType, ContextType>;
-  state?: Resolver<GQLResolversTypes['IcymiTopicState'], ParentType, ContextType>;
-  title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType, Partial<GQLIcymiTopicTitleArgs>>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLIcymiTopicConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['IcymiTopicConnection'] = GQLResolversParentTypes['IcymiTopicConnection']> = ResolversObject<{
-  edges?: Resolver<Array<GQLResolversTypes['IcymiTopicEdge']>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLIcymiTopicEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['IcymiTopicEdge'] = GQLResolversParentTypes['IcymiTopicEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['IcymiTopic'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLInvitationResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Invitation'] = GQLResolversParentTypes['Invitation']> = ResolversObject<{
-  acceptedAt?: Resolver<Maybe<GQLResolversTypes['DateTime']>, ParentType, ContextType>;
-  circle?: Resolver<GQLResolversTypes['Circle'], ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  freePeriod?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  invitee?: Resolver<GQLResolversTypes['Invitee'], ParentType, ContextType>;
-  inviter?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>;
-  sentAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  state?: Resolver<GQLResolversTypes['InvitationState'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLInvitationConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['InvitationConnection'] = GQLResolversParentTypes['InvitationConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['InvitationEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLInvitationEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['InvitationEdge'] = GQLResolversParentTypes['InvitationEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Invitation'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLInviteeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Invitee'] = GQLResolversParentTypes['Invitee']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'Person' | 'User', ParentType, ContextType>;
-}>;
-
-export type GQLInvitesResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Invites'] = GQLResolversParentTypes['Invites']> = ResolversObject<{
-  accepted?: Resolver<GQLResolversTypes['InvitationConnection'], ParentType, ContextType, RequireFields<GQLInvitesAcceptedArgs, 'input'>>;
-  pending?: Resolver<GQLResolversTypes['InvitationConnection'], ParentType, ContextType, RequireFields<GQLInvitesPendingArgs, 'input'>>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLLikerResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Liker'] = GQLResolversParentTypes['Liker']> = ResolversObject<{
-  civicLiker?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  likerId?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  total?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLMemberResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Member'] = GQLResolversParentTypes['Member']> = ResolversObject<{
-  price?: Resolver<GQLResolversTypes['Price'], ParentType, ContextType>;
-  user?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLMemberConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['MemberConnection'] = GQLResolversParentTypes['MemberConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['MemberEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLMemberEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['MemberEdge'] = GQLResolversParentTypes['MemberEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Member'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLMomentResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Moment'] = GQLResolversParentTypes['Moment']> = ResolversObject<{
-  adStatus?: Resolver<GQLResolversTypes['AdStatus'], ParentType, ContextType>;
-  articles?: Resolver<Array<GQLResolversTypes['Article']>, ParentType, ContextType>;
-  assets?: Resolver<Array<GQLResolversTypes['Asset']>, ParentType, ContextType>;
-  author?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>;
-  commentCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  commentedFollowees?: Resolver<Array<GQLResolversTypes['User']>, ParentType, ContextType>;
-  comments?: Resolver<GQLResolversTypes['CommentConnection'], ParentType, ContextType, RequireFields<GQLMomentCommentsArgs, 'input'>>;
-  content?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  likeCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  liked?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  shortHash?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  spamStatus?: Resolver<GQLResolversTypes['SpamStatus'], ParentType, ContextType>;
-  state?: Resolver<GQLResolversTypes['MomentState'], ParentType, ContextType>;
-  tags?: Resolver<Array<Maybe<GQLResolversTypes['Tag']>>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLMomentConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['MomentConnection'] = GQLResolversParentTypes['MomentConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['MomentEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLMomentEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['MomentEdge'] = GQLResolversParentTypes['MomentEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Moment'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLMomentFeedApplicationResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['MomentFeedApplication'] = GQLResolversParentTypes['MomentFeedApplication']> = ResolversObject<{
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  reviewedBy?: Resolver<Maybe<GQLResolversTypes['MomentFeedUserReviewedBy']>, ParentType, ContextType>;
-  reviewer?: Resolver<Maybe<GQLResolversTypes['User']>, ParentType, ContextType>;
-  state?: Resolver<GQLResolversTypes['MomentFeedUserState'], ParentType, ContextType>;
-  updatedAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLMomentNoticeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['MomentNotice'] = GQLResolversParentTypes['MomentNotice']> = ResolversObject<{
-  actors?: Resolver<Maybe<Array<GQLResolversTypes['User']>>, ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  target?: Resolver<GQLResolversTypes['Moment'], ParentType, ContextType>;
-  type?: Resolver<GQLResolversTypes['MomentNoticeType'], ParentType, ContextType>;
-  unread?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLMonthlyDatumResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['MonthlyDatum'] = GQLResolversParentTypes['MonthlyDatum']> = ResolversObject<{
-  date?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  value?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLMutationResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Mutation'] = GQLResolversParentTypes['Mutation']> = ResolversObject<{
-  addBlockedSearchKeyword?: Resolver<GQLResolversTypes['BlockedSearchKeyword'], ParentType, ContextType, RequireFields<GQLMutationAddBlockedSearchKeywordArgs, 'input'>>;
-  addCollectionsArticles?: Resolver<Array<GQLResolversTypes['Collection']>, ParentType, ContextType, RequireFields<GQLMutationAddCollectionsArticlesArgs, 'input'>>;
-  addCredit?: Resolver<GQLResolversTypes['AddCreditResult'], ParentType, ContextType, RequireFields<GQLMutationAddCreditArgs, 'input'>>;
-  addCurationChannelArticles?: Resolver<GQLResolversTypes['CurationChannel'], ParentType, ContextType, RequireFields<GQLMutationAddCurationChannelArticlesArgs, 'input'>>;
-  addSocialLogin?: Resolver<GQLResolversTypes['User'], ParentType, ContextType, RequireFields<GQLMutationAddSocialLoginArgs, 'input'>>;
-  addWalletLogin?: Resolver<GQLResolversTypes['User'], ParentType, ContextType, RequireFields<GQLMutationAddWalletLoginArgs, 'input'>>;
-  applyCampaign?: Resolver<GQLResolversTypes['Campaign'], ParentType, ContextType, RequireFields<GQLMutationApplyCampaignArgs, 'input'>>;
-  applyMomentFeed?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>;
-  appreciateArticle?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType, RequireFields<GQLMutationAppreciateArticleArgs, 'input'>>;
-  archiveUsers?: Resolver<GQLResolversTypes['ArchiveUsersResult'], ParentType, ContextType, RequireFields<GQLMutationArchiveUsersArgs, 'input'>>;
-  banCampaignArticles?: Resolver<GQLResolversTypes['Campaign'], ParentType, ContextType, RequireFields<GQLMutationBanCampaignArticlesArgs, 'input'>>;
-  claimLogbooks?: Resolver<GQLResolversTypes['ClaimLogbooksResult'], ParentType, ContextType, RequireFields<GQLMutationClaimLogbooksArgs, 'input'>>;
-  claimPersonhoodBadge?: Resolver<GQLResolversTypes['User'], ParentType, ContextType, RequireFields<GQLMutationClaimPersonhoodBadgeArgs, 'input'>>;
-  classifyArticlesChannels?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType, RequireFields<GQLMutationClassifyArticlesChannelsArgs, 'input'>>;
-  clearCommunityWatchOriginalContent?: Resolver<GQLResolversTypes['CommunityWatchAction'], ParentType, ContextType, RequireFields<GQLMutationClearCommunityWatchOriginalContentArgs, 'input'>>;
-  clearReadHistory?: Resolver<GQLResolversTypes['User'], ParentType, ContextType, RequireFields<GQLMutationClearReadHistoryArgs, 'input'>>;
-  clearSearchHistory?: Resolver<Maybe<GQLResolversTypes['Boolean']>, ParentType, ContextType>;
-  communityWatchRemoveComment?: Resolver<GQLResolversTypes['Comment'], ParentType, ContextType, RequireFields<GQLMutationCommunityWatchRemoveCommentArgs, 'input'>>;
-  confirmVerificationCode?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType, RequireFields<GQLMutationConfirmVerificationCodeArgs, 'input'>>;
-  connectStripeAccount?: Resolver<GQLResolversTypes['ConnectStripeAccountResult'], ParentType, ContextType, RequireFields<GQLMutationConnectStripeAccountArgs, 'input'>>;
-  createPersonhoodHandoff?: Resolver<GQLResolversTypes['PersonhoodHandoff'], ParentType, ContextType, RequireFields<GQLMutationCreatePersonhoodHandoffArgs, 'input'>>;
-  deleteAnnouncements?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType, RequireFields<GQLMutationDeleteAnnouncementsArgs, 'input'>>;
-  deleteBlockedSearchKeywords?: Resolver<Maybe<GQLResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<GQLMutationDeleteBlockedSearchKeywordsArgs, 'input'>>;
-  deleteCollectionArticles?: Resolver<GQLResolversTypes['Collection'], ParentType, ContextType, RequireFields<GQLMutationDeleteCollectionArticlesArgs, 'input'>>;
-  deleteCollections?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType, RequireFields<GQLMutationDeleteCollectionsArgs, 'input'>>;
-  deleteComment?: Resolver<GQLResolversTypes['Comment'], ParentType, ContextType, RequireFields<GQLMutationDeleteCommentArgs, 'input'>>;
-  deleteCurationChannelArticles?: Resolver<GQLResolversTypes['CurationChannel'], ParentType, ContextType, RequireFields<GQLMutationDeleteCurationChannelArticlesArgs, 'input'>>;
-  deleteDraft?: Resolver<Maybe<GQLResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<GQLMutationDeleteDraftArgs, 'input'>>;
-  deleteMoment?: Resolver<GQLResolversTypes['Moment'], ParentType, ContextType, RequireFields<GQLMutationDeleteMomentArgs, 'input'>>;
-  deleteQuote?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType, RequireFields<GQLMutationDeleteQuoteArgs, 'input'>>;
-  deleteTags?: Resolver<Maybe<GQLResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<GQLMutationDeleteTagsArgs, 'input'>>;
-  directImageUpload?: Resolver<GQLResolversTypes['Asset'], ParentType, ContextType, RequireFields<GQLMutationDirectImageUploadArgs, 'input'>>;
-  dismissSpamRing?: Resolver<GQLResolversTypes['SpamRing'], ParentType, ContextType, RequireFields<GQLMutationDismissSpamRingArgs, 'input'>>;
-  editArticle?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType, RequireFields<GQLMutationEditArticleArgs, 'input'>>;
-  emailLogin?: Resolver<GQLResolversTypes['AuthResult'], ParentType, ContextType, RequireFields<GQLMutationEmailLoginArgs, 'input'>>;
-  freezeSpamRing?: Resolver<GQLResolversTypes['FreezeSpamRingResult'], ParentType, ContextType, RequireFields<GQLMutationFreezeSpamRingArgs, 'input'>>;
-  generateSigningMessage?: Resolver<GQLResolversTypes['SigningMessageResult'], ParentType, ContextType, RequireFields<GQLMutationGenerateSigningMessageArgs, 'input'>>;
-  invite?: Resolver<Maybe<Array<GQLResolversTypes['Invitation']>>, ParentType, ContextType, RequireFields<GQLMutationInviteArgs, 'input'>>;
-  likeCollection?: Resolver<GQLResolversTypes['Collection'], ParentType, ContextType, RequireFields<GQLMutationLikeCollectionArgs, 'input'>>;
-  likeMoment?: Resolver<GQLResolversTypes['Moment'], ParentType, ContextType, RequireFields<GQLMutationLikeMomentArgs, 'input'>>;
-  logRecord?: Resolver<Maybe<GQLResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<GQLMutationLogRecordArgs, 'input'>>;
-  markAllNoticesAsRead?: Resolver<Maybe<GQLResolversTypes['Boolean']>, ParentType, ContextType>;
-  mergeTags?: Resolver<GQLResolversTypes['Tag'], ParentType, ContextType, RequireFields<GQLMutationMergeTagsArgs, 'input'>>;
-  migration?: Resolver<Maybe<GQLResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<GQLMutationMigrationArgs, 'input'>>;
-  payTo?: Resolver<GQLResolversTypes['PayToResult'], ParentType, ContextType, RequireFields<GQLMutationPayToArgs, 'input'>>;
-  payout?: Resolver<GQLResolversTypes['Transaction'], ParentType, ContextType, RequireFields<GQLMutationPayoutArgs, 'input'>>;
-  pinComment?: Resolver<GQLResolversTypes['Comment'], ParentType, ContextType, RequireFields<GQLMutationPinCommentArgs, 'input'>>;
-  publishArticle?: Resolver<GQLResolversTypes['Draft'], ParentType, ContextType, RequireFields<GQLMutationPublishArticleArgs, 'input'>>;
-  putAnnouncement?: Resolver<GQLResolversTypes['Announcement'], ParentType, ContextType, RequireFields<GQLMutationPutAnnouncementArgs, 'input'>>;
-  putArticleFederationSetting?: Resolver<GQLResolversTypes['ArticleFederationSetting'], ParentType, ContextType, RequireFields<GQLMutationPutArticleFederationSettingArgs, 'input'>>;
-  putCircle?: Resolver<GQLResolversTypes['Circle'], ParentType, ContextType, RequireFields<GQLMutationPutCircleArgs, 'input'>>;
-  putCircleArticles?: Resolver<GQLResolversTypes['Circle'], ParentType, ContextType, RequireFields<GQLMutationPutCircleArticlesArgs, 'input'>>;
-  putCollection?: Resolver<GQLResolversTypes['Collection'], ParentType, ContextType, RequireFields<GQLMutationPutCollectionArgs, 'input'>>;
-  putComment?: Resolver<GQLResolversTypes['Comment'], ParentType, ContextType, RequireFields<GQLMutationPutCommentArgs, 'input'>>;
-  putCurationChannel?: Resolver<GQLResolversTypes['CurationChannel'], ParentType, ContextType, RequireFields<GQLMutationPutCurationChannelArgs, 'input'>>;
-  putDraft?: Resolver<GQLResolversTypes['Draft'], ParentType, ContextType, RequireFields<GQLMutationPutDraftArgs, 'input'>>;
-  putFeaturedTags?: Resolver<Maybe<Array<GQLResolversTypes['Tag']>>, ParentType, ContextType, RequireFields<GQLMutationPutFeaturedTagsArgs, 'input'>>;
-  putIcymiTopic?: Resolver<Maybe<GQLResolversTypes['IcymiTopic']>, ParentType, ContextType, RequireFields<GQLMutationPutIcymiTopicArgs, 'input'>>;
-  putMoment?: Resolver<GQLResolversTypes['Moment'], ParentType, ContextType, RequireFields<GQLMutationPutMomentArgs, 'input'>>;
-  putOAuthClient?: Resolver<Maybe<GQLResolversTypes['OAuthClient']>, ParentType, ContextType, RequireFields<GQLMutationPutOAuthClientArgs, 'input'>>;
-  putQuote?: Resolver<GQLResolversTypes['Quote'], ParentType, ContextType, RequireFields<GQLMutationPutQuoteArgs, 'input'>>;
-  putRemark?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType, RequireFields<GQLMutationPutRemarkArgs, 'input'>>;
-  putRestrictedUsers?: Resolver<Array<GQLResolversTypes['User']>, ParentType, ContextType, RequireFields<GQLMutationPutRestrictedUsersArgs, 'input'>>;
-  putSkippedListItem?: Resolver<Maybe<Array<GQLResolversTypes['SkippedListItem']>>, ParentType, ContextType, RequireFields<GQLMutationPutSkippedListItemArgs, 'input'>>;
-  putTagChannel?: Resolver<GQLResolversTypes['Tag'], ParentType, ContextType, RequireFields<GQLMutationPutTagChannelArgs, 'input'>>;
-  putTopicChannel?: Resolver<GQLResolversTypes['TopicChannel'], ParentType, ContextType, RequireFields<GQLMutationPutTopicChannelArgs, 'input'>>;
-  putUserFeatureFlags?: Resolver<Array<GQLResolversTypes['User']>, ParentType, ContextType, RequireFields<GQLMutationPutUserFeatureFlagsArgs, 'input'>>;
-  putUserFederationSetting?: Resolver<GQLResolversTypes['UserFederationSetting'], ParentType, ContextType, RequireFields<GQLMutationPutUserFederationSettingArgs, 'input'>>;
-  putWritingChallenge?: Resolver<GQLResolversTypes['WritingChallenge'], ParentType, ContextType, RequireFields<GQLMutationPutWritingChallengeArgs, 'input'>>;
-  readArticle?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType, RequireFields<GQLMutationReadArticleArgs, 'input'>>;
-  removeSocialLogin?: Resolver<GQLResolversTypes['User'], ParentType, ContextType, RequireFields<GQLMutationRemoveSocialLoginArgs, 'input'>>;
-  removeWalletLogin?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>;
-  renameTag?: Resolver<GQLResolversTypes['Tag'], ParentType, ContextType, RequireFields<GQLMutationRenameTagArgs, 'input'>>;
-  reorderChannels?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType, RequireFields<GQLMutationReorderChannelsArgs, 'input'>>;
-  reorderCollectionArticles?: Resolver<GQLResolversTypes['Collection'], ParentType, ContextType, RequireFields<GQLMutationReorderCollectionArticlesArgs, 'input'>>;
-  resetLikerId?: Resolver<GQLResolversTypes['User'], ParentType, ContextType, RequireFields<GQLMutationResetLikerIdArgs, 'input'>>;
-  resetPassword?: Resolver<Maybe<GQLResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<GQLMutationResetPasswordArgs, 'input'>>;
-  restoreCommunityWatchComment?: Resolver<GQLResolversTypes['CommunityWatchAction'], ParentType, ContextType, RequireFields<GQLMutationRestoreCommunityWatchCommentArgs, 'input'>>;
-  reviewTopicChannelFeedback?: Resolver<GQLResolversTypes['TopicChannelFeedback'], ParentType, ContextType, RequireFields<GQLMutationReviewTopicChannelFeedbackArgs, 'input'>>;
-  sendCampaignAnnouncement?: Resolver<Maybe<GQLResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<GQLMutationSendCampaignAnnouncementArgs, 'input'>>;
-  sendVerificationCode?: Resolver<Maybe<GQLResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<GQLMutationSendVerificationCodeArgs, 'input'>>;
-  setAdStatus?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType, RequireFields<GQLMutationSetAdStatusArgs, 'input'>>;
-  setArticleFederationSetting?: Resolver<GQLResolversTypes['ArticleFederationSetting'], ParentType, ContextType, RequireFields<GQLMutationSetArticleFederationSettingArgs, 'input'>>;
-  setArticleTopicChannels?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType, RequireFields<GQLMutationSetArticleTopicChannelsArgs, 'input'>>;
-  setBoost?: Resolver<GQLResolversTypes['Node'], ParentType, ContextType, RequireFields<GQLMutationSetBoostArgs, 'input'>>;
-  setCurrency?: Resolver<GQLResolversTypes['User'], ParentType, ContextType, RequireFields<GQLMutationSetCurrencyArgs, 'input'>>;
-  setEmail?: Resolver<GQLResolversTypes['User'], ParentType, ContextType, RequireFields<GQLMutationSetEmailArgs, 'input'>>;
-  setFeature?: Resolver<GQLResolversTypes['Feature'], ParentType, ContextType, RequireFields<GQLMutationSetFeatureArgs, 'input'>>;
-  setPassword?: Resolver<GQLResolversTypes['User'], ParentType, ContextType, RequireFields<GQLMutationSetPasswordArgs, 'input'>>;
-  setSpamStatus?: Resolver<GQLResolversTypes['Writing'], ParentType, ContextType, RequireFields<GQLMutationSetSpamStatusArgs, 'input'>>;
-  setUserName?: Resolver<GQLResolversTypes['User'], ParentType, ContextType, RequireFields<GQLMutationSetUserNameArgs, 'input'>>;
-  setViewerFederationSetting?: Resolver<GQLResolversTypes['UserFederationSetting'], ParentType, ContextType, RequireFields<GQLMutationSetViewerFederationSettingArgs, 'input'>>;
-  setWritingAdStatus?: Resolver<GQLResolversTypes['Writing'], ParentType, ContextType, RequireFields<GQLMutationSetWritingAdStatusArgs, 'input'>>;
-  singleFileUpload?: Resolver<GQLResolversTypes['Asset'], ParentType, ContextType, RequireFields<GQLMutationSingleFileUploadArgs, 'input'>>;
-  socialLogin?: Resolver<GQLResolversTypes['AuthResult'], ParentType, ContextType, RequireFields<GQLMutationSocialLoginArgs, 'input'>>;
-  submitReport?: Resolver<GQLResolversTypes['Report'], ParentType, ContextType, RequireFields<GQLMutationSubmitReportArgs, 'input'>>;
-  submitTopicChannelFeedback?: Resolver<GQLResolversTypes['TopicChannelFeedback'], ParentType, ContextType, RequireFields<GQLMutationSubmitTopicChannelFeedbackArgs, 'input'>>;
-  subscribeCircle?: Resolver<GQLResolversTypes['SubscribeCircleResult'], ParentType, ContextType, RequireFields<GQLMutationSubscribeCircleArgs, 'input'>>;
-  toggleArticleRecommend?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType, RequireFields<GQLMutationToggleArticleRecommendArgs, 'input'>>;
-  toggleBlockUser?: Resolver<GQLResolversTypes['User'], ParentType, ContextType, RequireFields<GQLMutationToggleBlockUserArgs, 'input'>>;
-  toggleBookmarkArticle?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType, RequireFields<GQLMutationToggleBookmarkArticleArgs, 'input'>>;
-  toggleBookmarkTag?: Resolver<GQLResolversTypes['Tag'], ParentType, ContextType, RequireFields<GQLMutationToggleBookmarkTagArgs, 'input'>>;
-  toggleFollowCircle?: Resolver<GQLResolversTypes['Circle'], ParentType, ContextType, RequireFields<GQLMutationToggleFollowCircleArgs, 'input'>>;
-  toggleFollowTag?: Resolver<GQLResolversTypes['Tag'], ParentType, ContextType, RequireFields<GQLMutationToggleFollowTagArgs, 'input'>>;
-  toggleFollowUser?: Resolver<GQLResolversTypes['User'], ParentType, ContextType, RequireFields<GQLMutationToggleFollowUserArgs, 'input'>>;
-  togglePinChannelArticles?: Resolver<Array<GQLResolversTypes['Channel']>, ParentType, ContextType, RequireFields<GQLMutationTogglePinChannelArticlesArgs, 'input'>>;
-  togglePinComment?: Resolver<GQLResolversTypes['Comment'], ParentType, ContextType, RequireFields<GQLMutationTogglePinCommentArgs, 'input'>>;
-  toggleSeedingUsers?: Resolver<Array<Maybe<GQLResolversTypes['User']>>, ParentType, ContextType, RequireFields<GQLMutationToggleSeedingUsersArgs, 'input'>>;
-  toggleSubscribeArticle?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType, RequireFields<GQLMutationToggleSubscribeArticleArgs, 'input'>>;
-  toggleUsersBadge?: Resolver<Array<Maybe<GQLResolversTypes['User']>>, ParentType, ContextType, RequireFields<GQLMutationToggleUsersBadgeArgs, 'input'>>;
-  toggleWritingChallengeFeaturedArticles?: Resolver<GQLResolversTypes['Campaign'], ParentType, ContextType, RequireFields<GQLMutationToggleWritingChallengeFeaturedArticlesArgs, 'input'>>;
-  unbindLikerId?: Resolver<GQLResolversTypes['User'], ParentType, ContextType, RequireFields<GQLMutationUnbindLikerIdArgs, 'input'>>;
-  unfreezeSpamRing?: Resolver<GQLResolversTypes['UnfreezeSpamRingResult'], ParentType, ContextType, RequireFields<GQLMutationUnfreezeSpamRingArgs, 'input'>>;
-  unlikeCollection?: Resolver<GQLResolversTypes['Collection'], ParentType, ContextType, RequireFields<GQLMutationUnlikeCollectionArgs, 'input'>>;
-  unlikeMoment?: Resolver<GQLResolversTypes['Moment'], ParentType, ContextType, RequireFields<GQLMutationUnlikeMomentArgs, 'input'>>;
-  unpinComment?: Resolver<GQLResolversTypes['Comment'], ParentType, ContextType, RequireFields<GQLMutationUnpinCommentArgs, 'input'>>;
-  unsubscribeCircle?: Resolver<GQLResolversTypes['Circle'], ParentType, ContextType, RequireFields<GQLMutationUnsubscribeCircleArgs, 'input'>>;
-  unvoteComment?: Resolver<GQLResolversTypes['Comment'], ParentType, ContextType, RequireFields<GQLMutationUnvoteCommentArgs, 'input'>>;
-  updateArticleSensitive?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType, RequireFields<GQLMutationUpdateArticleSensitiveArgs, 'input'>>;
-  updateArticleState?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType, RequireFields<GQLMutationUpdateArticleStateArgs, 'input'>>;
-  updateCampaignApplicationState?: Resolver<GQLResolversTypes['Campaign'], ParentType, ContextType, RequireFields<GQLMutationUpdateCampaignApplicationStateArgs, 'input'>>;
-  updateCommentsState?: Resolver<Array<GQLResolversTypes['Comment']>, ParentType, ContextType, RequireFields<GQLMutationUpdateCommentsStateArgs, 'input'>>;
-  updateCommunityWatchActionState?: Resolver<GQLResolversTypes['CommunityWatchAction'], ParentType, ContextType, RequireFields<GQLMutationUpdateCommunityWatchActionStateArgs, 'input'>>;
-  updateMomentFeedApplicationState?: Resolver<GQLResolversTypes['User'], ParentType, ContextType, RequireFields<GQLMutationUpdateMomentFeedApplicationStateArgs, 'input'>>;
-  updateNotificationSetting?: Resolver<GQLResolversTypes['User'], ParentType, ContextType, RequireFields<GQLMutationUpdateNotificationSettingArgs, 'input'>>;
-  updateUserExtra?: Resolver<GQLResolversTypes['User'], ParentType, ContextType, RequireFields<GQLMutationUpdateUserExtraArgs, 'input'>>;
-  updateUserInfo?: Resolver<GQLResolversTypes['User'], ParentType, ContextType, RequireFields<GQLMutationUpdateUserInfoArgs, 'input'>>;
-  updateUserRole?: Resolver<GQLResolversTypes['User'], ParentType, ContextType, RequireFields<GQLMutationUpdateUserRoleArgs, 'input'>>;
-  updateUserState?: Resolver<Maybe<Array<GQLResolversTypes['User']>>, ParentType, ContextType, RequireFields<GQLMutationUpdateUserStateArgs, 'input'>>;
-  upsertSpamRingCandidates?: Resolver<GQLResolversTypes['UpsertSpamRingCandidatesResult'], ParentType, ContextType, RequireFields<GQLMutationUpsertSpamRingCandidatesArgs, 'input'>>;
-  userLogout?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  verifyEmail?: Resolver<GQLResolversTypes['AuthResult'], ParentType, ContextType, RequireFields<GQLMutationVerifyEmailArgs, 'input'>>;
-  voteComment?: Resolver<GQLResolversTypes['Comment'], ParentType, ContextType, RequireFields<GQLMutationVoteCommentArgs, 'input'>>;
-  walletLogin?: Resolver<GQLResolversTypes['AuthResult'], ParentType, ContextType, RequireFields<GQLMutationWalletLoginArgs, 'input'>>;
-  withdrawLockedTokens?: Resolver<GQLResolversTypes['WithdrawLockedTokensResult'], ParentType, ContextType>;
-}>;
-
-export type GQLNftAssetResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['NFTAsset'] = GQLResolversParentTypes['NFTAsset']> = ResolversObject<{
-  collectionName?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  contractAddress?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  description?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  imagePreviewUrl?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  imageUrl?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  name?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLNodeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Node'] = GQLResolversParentTypes['Node']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'Article' | 'ArticleVersion' | 'Circle' | 'Collection' | 'Comment' | 'CurationChannel' | 'Draft' | 'IcymiTopic' | 'Moment' | 'Report' | 'SpamRing' | 'Tag' | 'TopicChannel' | 'User' | 'WritingChallenge', ParentType, ContextType>;
-}>;
-
-export type GQLNoticeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Notice'] = GQLResolversParentTypes['Notice']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'ArticleArticleNotice' | 'ArticleNotice' | 'CampaignArticleNotice' | 'CircleNotice' | 'CollectionNotice' | 'CommentCommentNotice' | 'CommentNotice' | 'MomentNotice' | 'OfficialAnnouncementNotice' | 'TransactionNotice' | 'UserNotice', ParentType, ContextType>;
-}>;
-
-export type GQLNoticeConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['NoticeConnection'] = GQLResolversParentTypes['NoticeConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['NoticeEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLNoticeEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['NoticeEdge'] = GQLResolversParentTypes['NoticeEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Notice'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLNotificationSettingResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['NotificationSetting'] = GQLResolversParentTypes['NotificationSetting']> = ResolversObject<{
-  articleNewAppreciation?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  articleNewCollected?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  articleNewComment?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  articleNewSubscription?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  circleMemberNewBroadcastReply?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  circleMemberNewDiscussion?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  circleMemberNewDiscussionReply?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  circleNewFollower?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  circleNewSubscriber?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  circleNewUnsubscriber?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  email?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  inCircleNewArticle?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  inCircleNewBroadcast?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  inCircleNewBroadcastReply?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  inCircleNewDiscussion?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  inCircleNewDiscussionReply?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  mention?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  newComment?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  newLike?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  userNewFollower?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLOAuthClientResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['OAuthClient'] = GQLResolversParentTypes['OAuthClient']> = ResolversObject<{
-  avatar?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  description?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  grantTypes?: Resolver<Maybe<Array<GQLResolversTypes['GrantType']>>, ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  name?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  redirectURIs?: Resolver<Maybe<Array<GQLResolversTypes['String']>>, ParentType, ContextType>;
-  scope?: Resolver<Maybe<Array<GQLResolversTypes['String']>>, ParentType, ContextType>;
-  secret?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  user?: Resolver<Maybe<GQLResolversTypes['User']>, ParentType, ContextType>;
-  website?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLOAuthClientConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['OAuthClientConnection'] = GQLResolversParentTypes['OAuthClientConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['OAuthClientEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLOAuthClientEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['OAuthClientEdge'] = GQLResolversParentTypes['OAuthClientEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['OAuthClient'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLOssResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['OSS'] = GQLResolversParentTypes['OSS']> = ResolversObject<{
-  articles?: Resolver<GQLResolversTypes['ArticleConnection'], ParentType, ContextType, RequireFields<GQLOssArticlesArgs, 'input'>>;
-  badgedUsers?: Resolver<GQLResolversTypes['UserConnection'], ParentType, ContextType, RequireFields<GQLOssBadgedUsersArgs, 'input'>>;
-  comments?: Resolver<GQLResolversTypes['CommentConnection'], ParentType, ContextType, RequireFields<GQLOssCommentsArgs, 'input'>>;
-  icymiTopics?: Resolver<GQLResolversTypes['IcymiTopicConnection'], ParentType, ContextType, RequireFields<GQLOssIcymiTopicsArgs, 'input'>>;
-  momentFeedUsers?: Resolver<GQLResolversTypes['UserConnection'], ParentType, ContextType, RequireFields<GQLOssMomentFeedUsersArgs, 'input'>>;
-  moments?: Resolver<GQLResolversTypes['MomentConnection'], ParentType, ContextType, RequireFields<GQLOssMomentsArgs, 'input'>>;
-  oauthClients?: Resolver<GQLResolversTypes['OAuthClientConnection'], ParentType, ContextType, RequireFields<GQLOssOauthClientsArgs, 'input'>>;
-  reports?: Resolver<GQLResolversTypes['ReportConnection'], ParentType, ContextType, RequireFields<GQLOssReportsArgs, 'input'>>;
-  restrictedUsers?: Resolver<GQLResolversTypes['UserConnection'], ParentType, ContextType, RequireFields<GQLOssRestrictedUsersArgs, 'input'>>;
-  seedingUsers?: Resolver<GQLResolversTypes['UserConnection'], ParentType, ContextType, RequireFields<GQLOssSeedingUsersArgs, 'input'>>;
-  skippedListItems?: Resolver<GQLResolversTypes['SkippedListItemsConnection'], ParentType, ContextType, RequireFields<GQLOssSkippedListItemsArgs, 'input'>>;
-  spamRings?: Resolver<GQLResolversTypes['SpamRingConnection'], ParentType, ContextType, RequireFields<GQLOssSpamRingsArgs, 'input'>>;
-  tags?: Resolver<GQLResolversTypes['TagConnection'], ParentType, ContextType, RequireFields<GQLOssTagsArgs, 'input'>>;
-  topicChannelFeedbacks?: Resolver<GQLResolversTypes['TopicChannelFeedbackConnection'], ParentType, ContextType, RequireFields<GQLOssTopicChannelFeedbacksArgs, 'input'>>;
-  users?: Resolver<GQLResolversTypes['UserConnection'], ParentType, ContextType, RequireFields<GQLOssUsersArgs, 'input'>>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLOfficialResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Official'] = GQLResolversParentTypes['Official']> = ResolversObject<{
-  announcements?: Resolver<Maybe<Array<GQLResolversTypes['Announcement']>>, ParentType, ContextType, RequireFields<GQLOfficialAnnouncementsArgs, 'input'>>;
-  features?: Resolver<Array<GQLResolversTypes['Feature']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLOfficialAnnouncementNoticeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['OfficialAnnouncementNotice'] = GQLResolversParentTypes['OfficialAnnouncementNotice']> = ResolversObject<{
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  link?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  message?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  unread?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLPageInfoResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['PageInfo'] = GQLResolversParentTypes['PageInfo']> = ResolversObject<{
-  endCursor?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  hasNextPage?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  hasPreviousPage?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  startCursor?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLPayToResultResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['PayToResult'] = GQLResolversParentTypes['PayToResult']> = ResolversObject<{
-  redirectUrl?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  transaction?: Resolver<GQLResolversTypes['Transaction'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLPersonResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Person'] = GQLResolversParentTypes['Person']> = ResolversObject<{
-  email?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLPersonhoodHandoffResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['PersonhoodHandoff'] = GQLResolversParentTypes['PersonhoodHandoff']> = ResolversObject<{
-  expiresAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  token?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLPinHistoryResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['PinHistory'] = GQLResolversParentTypes['PinHistory']> = ResolversObject<{
-  feed?: Resolver<GQLResolversTypes['Node'], ParentType, ContextType>;
-  pinnedAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLPinnableWorkResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['PinnableWork'] = GQLResolversParentTypes['PinnableWork']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'Article' | 'Collection', ParentType, ContextType>;
-}>;
-
-export type GQLPriceResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Price'] = GQLResolversParentTypes['Price']> = ResolversObject<{
-  amount?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>;
-  circle?: Resolver<GQLResolversTypes['Circle'], ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  currency?: Resolver<GQLResolversTypes['TransactionCurrency'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  state?: Resolver<GQLResolversTypes['PriceState'], ParentType, ContextType>;
-  updatedAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLQueryResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Query'] = GQLResolversParentTypes['Query']> = ResolversObject<{
-  article?: Resolver<Maybe<GQLResolversTypes['Article']>, ParentType, ContextType, RequireFields<GQLQueryArticleArgs, 'input'>>;
-  campaign?: Resolver<Maybe<GQLResolversTypes['Campaign']>, ParentType, ContextType, RequireFields<GQLQueryCampaignArgs, 'input'>>;
-  campaignOrganizers?: Resolver<GQLResolversTypes['UserConnection'], ParentType, ContextType, RequireFields<GQLQueryCampaignOrganizersArgs, 'input'>>;
-  campaigns?: Resolver<GQLResolversTypes['CampaignConnection'], ParentType, ContextType, RequireFields<GQLQueryCampaignsArgs, 'input'>>;
-  channel?: Resolver<Maybe<GQLResolversTypes['Channel']>, ParentType, ContextType, RequireFields<GQLQueryChannelArgs, 'input'>>;
-  channels?: Resolver<Array<GQLResolversTypes['Channel']>, ParentType, ContextType, Partial<GQLQueryChannelsArgs>>;
-  circle?: Resolver<Maybe<GQLResolversTypes['Circle']>, ParentType, ContextType, RequireFields<GQLQueryCircleArgs, 'input'>>;
-  communityWatchAction?: Resolver<Maybe<GQLResolversTypes['CommunityWatchAction']>, ParentType, ContextType, RequireFields<GQLQueryCommunityWatchActionArgs, 'input'>>;
-  communityWatchActions?: Resolver<GQLResolversTypes['CommunityWatchActionConnection'], ParentType, ContextType, RequireFields<GQLQueryCommunityWatchActionsArgs, 'input'>>;
-  exchangeRates?: Resolver<Maybe<Array<GQLResolversTypes['ExchangeRate']>>, ParentType, ContextType, Partial<GQLQueryExchangeRatesArgs>>;
-  frequentSearch?: Resolver<Maybe<Array<GQLResolversTypes['String']>>, ParentType, ContextType, RequireFields<GQLQueryFrequentSearchArgs, 'input'>>;
-  moment?: Resolver<Maybe<GQLResolversTypes['Moment']>, ParentType, ContextType, RequireFields<GQLQueryMomentArgs, 'input'>>;
-  node?: Resolver<Maybe<GQLResolversTypes['Node']>, ParentType, ContextType, RequireFields<GQLQueryNodeArgs, 'input'>>;
-  nodes?: Resolver<Maybe<Array<GQLResolversTypes['Node']>>, ParentType, ContextType, RequireFields<GQLQueryNodesArgs, 'input'>>;
-  oauthClient?: Resolver<Maybe<GQLResolversTypes['OAuthClient']>, ParentType, ContextType, RequireFields<GQLQueryOauthClientArgs, 'input'>>;
-  oauthRequestToken?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  official?: Resolver<GQLResolversTypes['Official'], ParentType, ContextType>;
-  oss?: Resolver<GQLResolversTypes['OSS'], ParentType, ContextType>;
-  search?: Resolver<GQLResolversTypes['SearchResultConnection'], ParentType, ContextType, RequireFields<GQLQuerySearchArgs, 'input'>>;
-  user?: Resolver<Maybe<GQLResolversTypes['User']>, ParentType, ContextType, RequireFields<GQLQueryUserArgs, 'input'>>;
-  viewer?: Resolver<Maybe<GQLResolversTypes['User']>, ParentType, ContextType>;
-}>;
-
-export type GQLQuoteResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Quote'] = GQLResolversParentTypes['Quote']> = ResolversObject<{
-  article?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>;
-  content?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  poster?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLQuoteConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['QuoteConnection'] = GQLResolversParentTypes['QuoteConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['QuoteEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLQuoteEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['QuoteEdge'] = GQLResolversParentTypes['QuoteEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Quote'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLReadHistoryResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ReadHistory'] = GQLResolversParentTypes['ReadHistory']> = ResolversObject<{
-  article?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>;
-  readAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLReadHistoryConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ReadHistoryConnection'] = GQLResolversParentTypes['ReadHistoryConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['ReadHistoryEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLReadHistoryEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ReadHistoryEdge'] = GQLResolversParentTypes['ReadHistoryEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['ReadHistory'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLRecentSearchConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['RecentSearchConnection'] = GQLResolversParentTypes['RecentSearchConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['RecentSearchEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLRecentSearchEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['RecentSearchEdge'] = GQLResolversParentTypes['RecentSearchEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLRecommendationResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Recommendation'] = GQLResolversParentTypes['Recommendation']> = ResolversObject<{
-  authors?: Resolver<GQLResolversTypes['UserConnection'], ParentType, ContextType, RequireFields<GQLRecommendationAuthorsArgs, 'input'>>;
-  following?: Resolver<GQLResolversTypes['FollowingActivityConnection'], ParentType, ContextType, RequireFields<GQLRecommendationFollowingArgs, 'input'>>;
-  hottest?: Resolver<GQLResolversTypes['ArticleConnection'], ParentType, ContextType, RequireFields<GQLRecommendationHottestArgs, 'input'>>;
-  hottestMoments?: Resolver<GQLResolversTypes['MomentConnection'], ParentType, ContextType, RequireFields<GQLRecommendationHottestMomentsArgs, 'input'>>;
-  icymi?: Resolver<GQLResolversTypes['ArticleConnection'], ParentType, ContextType, RequireFields<GQLRecommendationIcymiArgs, 'input'>>;
-  icymiTopic?: Resolver<Maybe<GQLResolversTypes['IcymiTopic']>, ParentType, ContextType>;
-  newest?: Resolver<GQLResolversTypes['ArticleConnection'], ParentType, ContextType, RequireFields<GQLRecommendationNewestArgs, 'input'>>;
-  tags?: Resolver<GQLResolversTypes['TagConnection'], ParentType, ContextType, RequireFields<GQLRecommendationTagsArgs, 'input'>>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLReportResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Report'] = GQLResolversParentTypes['Report']> = ResolversObject<{
-  communityWatchAction?: Resolver<Maybe<GQLResolversTypes['CommunityWatchAction']>, ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  reason?: Resolver<GQLResolversTypes['ReportReason'], ParentType, ContextType>;
-  reporter?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>;
-  source?: Resolver<GQLResolversTypes['ReportSource'], ParentType, ContextType>;
-  target?: Resolver<GQLResolversTypes['Node'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLReportConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ReportConnection'] = GQLResolversParentTypes['ReportConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['ReportEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLReportEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ReportEdge'] = GQLResolversParentTypes['ReportEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Report'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLResponseResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Response'] = GQLResolversParentTypes['Response']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'Article' | 'Comment', ParentType, ContextType>;
-}>;
-
-export type GQLResponseConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ResponseConnection'] = GQLResolversParentTypes['ResponseConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['ResponseEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLResponseEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['ResponseEdge'] = GQLResolversParentTypes['ResponseEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Response'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLSearchResultConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['SearchResultConnection'] = GQLResolversParentTypes['SearchResultConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['SearchResultEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLSearchResultEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['SearchResultEdge'] = GQLResolversParentTypes['SearchResultEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Node'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLSigningMessageResultResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['SigningMessageResult'] = GQLResolversParentTypes['SigningMessageResult']> = ResolversObject<{
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  expiredAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  nonce?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  purpose?: Resolver<GQLResolversTypes['SigningMessagePurpose'], ParentType, ContextType>;
-  signingMessage?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLSkippedListItemResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['SkippedListItem'] = GQLResolversParentTypes['SkippedListItem']> = ResolversObject<{
-  archived?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  type?: Resolver<GQLResolversTypes['SkippedListItemType'], ParentType, ContextType>;
-  updatedAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  uuid?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  value?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLSkippedListItemEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['SkippedListItemEdge'] = GQLResolversParentTypes['SkippedListItemEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<Maybe<GQLResolversTypes['SkippedListItem']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLSkippedListItemsConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['SkippedListItemsConnection'] = GQLResolversParentTypes['SkippedListItemsConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['SkippedListItemEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLSocialAccountResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['SocialAccount'] = GQLResolversParentTypes['SocialAccount']> = ResolversObject<{
-  email?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  type?: Resolver<GQLResolversTypes['SocialAccountType'], ParentType, ContextType>;
-  userName?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLSpamRingResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['SpamRing'] = GQLResolversParentTypes['SpamRing']> = ResolversObject<{
-  detectedAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  events?: Resolver<Array<GQLResolversTypes['SpamRingEvent']>, ParentType, ContextType>;
-  fingerprint?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  firstSeenAt?: Resolver<Maybe<GQLResolversTypes['DateTime']>, ParentType, ContextType>;
-  frozenAt?: Resolver<Maybe<GQLResolversTypes['DateTime']>, ParentType, ContextType>;
-  frozenBy?: Resolver<Maybe<GQLResolversTypes['User']>, ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  lastSeenAt?: Resolver<Maybe<GQLResolversTypes['DateTime']>, ParentType, ContextType>;
-  memberSample?: Resolver<Array<GQLResolversTypes['User']>, ParentType, ContextType, Partial<GQLSpamRingMemberSampleArgs>>;
-  members?: Resolver<GQLResolversTypes['SpamRingMemberConnection'], ParentType, ContextType, RequireFields<GQLSpamRingMembersArgs, 'input'>>;
-  nArticles?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  nAuthors?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  newAccountRatio?: Resolver<Maybe<GQLResolversTypes['Float']>, ParentType, ContextType>;
-  note?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  score?: Resolver<Maybe<GQLResolversTypes['Float']>, ParentType, ContextType>;
-  severity?: Resolver<Maybe<GQLResolversTypes['SpamRingSeverity']>, ParentType, ContextType>;
-  signals?: Resolver<GQLResolversTypes['SpamRingSignals'], ParentType, ContextType>;
-  status?: Resolver<GQLResolversTypes['SpamRingStatus'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLSpamRingConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['SpamRingConnection'] = GQLResolversParentTypes['SpamRingConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['SpamRingEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLSpamRingEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['SpamRingEdge'] = GQLResolversParentTypes['SpamRingEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['SpamRing'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLSpamRingEventResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['SpamRingEvent'] = GQLResolversParentTypes['SpamRingEvent']> = ResolversObject<{
-  action?: Resolver<GQLResolversTypes['SpamRingEventAction'], ParentType, ContextType>;
-  actor?: Resolver<Maybe<GQLResolversTypes['User']>, ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  detail?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLSpamRingMemberResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['SpamRingMember'] = GQLResolversParentTypes['SpamRingMember']> = ResolversObject<{
-  bannedByThisRing?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  skipReason?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  status?: Resolver<GQLResolversTypes['SpamRingMemberStatus'], ParentType, ContextType>;
-  user?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLSpamRingMemberConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['SpamRingMemberConnection'] = GQLResolversParentTypes['SpamRingMemberConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['SpamRingMemberEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLSpamRingMemberEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['SpamRingMemberEdge'] = GQLResolversParentTypes['SpamRingMemberEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['SpamRingMember'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLSpamRingSignalsResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['SpamRingSignals'] = GQLResolversParentTypes['SpamRingSignals']> = ResolversObject<{
-  botUsernameRatio?: Resolver<Maybe<GQLResolversTypes['Float']>, ParentType, ContextType>;
-  contentModelMax?: Resolver<Maybe<GQLResolversTypes['Float']>, ParentType, ContextType>;
-  entityRingSize?: Resolver<Maybe<GQLResolversTypes['Int']>, ParentType, ContextType>;
-  nearDupRingSize?: Resolver<Maybe<GQLResolversTypes['Int']>, ParentType, ContextType>;
-  sampleBrands?: Resolver<Maybe<Array<GQLResolversTypes['String']>>, ParentType, ContextType>;
-  sampleCodes?: Resolver<Maybe<Array<GQLResolversTypes['String']>>, ParentType, ContextType>;
-  topEntity?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLSpamRingSkipResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['SpamRingSkip'] = GQLResolversParentTypes['SpamRingSkip']> = ResolversObject<{
-  reason?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  user?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLSpamStatusResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['SpamStatus'] = GQLResolversParentTypes['SpamStatus']> = ResolversObject<{
-  isSpam?: Resolver<Maybe<GQLResolversTypes['Boolean']>, ParentType, ContextType>;
-  score?: Resolver<Maybe<GQLResolversTypes['Float']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLStripeAccountResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['StripeAccount'] = GQLResolversParentTypes['StripeAccount']> = ResolversObject<{
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  loginUrl?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLSubscribeCircleResultResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['SubscribeCircleResult'] = GQLResolversParentTypes['SubscribeCircleResult']> = ResolversObject<{
-  circle?: Resolver<GQLResolversTypes['Circle'], ParentType, ContextType>;
-  client_secret?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLTagResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Tag'] = GQLResolversParentTypes['Tag']> = ResolversObject<{
-  articles?: Resolver<GQLResolversTypes['ChannelArticleConnection'], ParentType, ContextType, RequireFields<GQLTagArticlesArgs, 'input'>>;
-  channelEnabled?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  content?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  deleted?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  isFollower?: Resolver<Maybe<GQLResolversTypes['Boolean']>, ParentType, ContextType>;
-  navbarTitle?: Resolver<GQLResolversTypes['String'], ParentType, ContextType, Partial<GQLTagNavbarTitleArgs>>;
-  numArticles?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  numAuthors?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  numMoments?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  oss?: Resolver<GQLResolversTypes['TagOSS'], ParentType, ContextType>;
-  recommended?: Resolver<GQLResolversTypes['TagConnection'], ParentType, ContextType, RequireFields<GQLTagRecommendedArgs, 'input'>>;
-  recommendedAuthors?: Resolver<GQLResolversTypes['UserConnection'], ParentType, ContextType, RequireFields<GQLTagRecommendedAuthorsArgs, 'input'>>;
-  remark?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  shortHash?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  writings?: Resolver<GQLResolversTypes['TagWritingConnection'], ParentType, ContextType, RequireFields<GQLTagWritingsArgs, 'input'>>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLTagConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['TagConnection'] = GQLResolversParentTypes['TagConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['TagEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLTagEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['TagEdge'] = GQLResolversParentTypes['TagEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Tag'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLTagOssResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['TagOSS'] = GQLResolversParentTypes['TagOSS']> = ResolversObject<{
-  boost?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>;
-  score?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLTagWritingConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['TagWritingConnection'] = GQLResolversParentTypes['TagWritingConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['TagWritingEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLTagWritingEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['TagWritingEdge'] = GQLResolversParentTypes['TagWritingEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Writing'], ParentType, ContextType>;
-  pinned?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLTopDonatorConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['TopDonatorConnection'] = GQLResolversParentTypes['TopDonatorConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['TopDonatorEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLTopDonatorEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['TopDonatorEdge'] = GQLResolversParentTypes['TopDonatorEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  donationCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Donator'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLTopicChannelResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['TopicChannel'] = GQLResolversParentTypes['TopicChannel']> = ResolversObject<{
-  articles?: Resolver<GQLResolversTypes['ChannelArticleConnection'], ParentType, ContextType, RequireFields<GQLTopicChannelArticlesArgs, 'input'>>;
-  enabled?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  name?: Resolver<GQLResolversTypes['String'], ParentType, ContextType, Partial<GQLTopicChannelNameArgs>>;
-  navbarTitle?: Resolver<GQLResolversTypes['String'], ParentType, ContextType, Partial<GQLTopicChannelNavbarTitleArgs>>;
-  note?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType, Partial<GQLTopicChannelNoteArgs>>;
-  parent?: Resolver<Maybe<GQLResolversTypes['TopicChannel']>, ParentType, ContextType>;
-  providerId?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  shortHash?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLTopicChannelClassificationResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['TopicChannelClassification'] = GQLResolversParentTypes['TopicChannelClassification']> = ResolversObject<{
-  channels?: Resolver<Maybe<Array<GQLResolversTypes['ArticleTopicChannel']>>, ParentType, ContextType>;
-  enabled?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  feedback?: Resolver<Maybe<GQLResolversTypes['TopicChannelFeedback']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLTopicChannelFeedbackResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['TopicChannelFeedback'] = GQLResolversParentTypes['TopicChannelFeedback']> = ResolversObject<{
-  article?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>;
-  channels?: Resolver<Maybe<Array<GQLResolversTypes['TopicChannel']>>, ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  state?: Resolver<Maybe<GQLResolversTypes['TopicChannelFeedbackState']>, ParentType, ContextType>;
-  type?: Resolver<GQLResolversTypes['TopicChannelFeedbackType'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLTopicChannelFeedbackConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['TopicChannelFeedbackConnection'] = GQLResolversParentTypes['TopicChannelFeedbackConnection']> = ResolversObject<{
-  edges?: Resolver<Array<GQLResolversTypes['TopicChannelFeedbackEdge']>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLTopicChannelFeedbackEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['TopicChannelFeedbackEdge'] = GQLResolversParentTypes['TopicChannelFeedbackEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['TopicChannelFeedback'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLTransactionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Transaction'] = GQLResolversParentTypes['Transaction']> = ResolversObject<{
-  amount?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>;
-  blockchainTx?: Resolver<Maybe<GQLResolversTypes['BlockchainTransaction']>, ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  currency?: Resolver<GQLResolversTypes['TransactionCurrency'], ParentType, ContextType>;
-  fee?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  message?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  purpose?: Resolver<GQLResolversTypes['TransactionPurpose'], ParentType, ContextType>;
-  recipient?: Resolver<Maybe<GQLResolversTypes['User']>, ParentType, ContextType>;
-  sender?: Resolver<Maybe<GQLResolversTypes['User']>, ParentType, ContextType>;
-  state?: Resolver<GQLResolversTypes['TransactionState'], ParentType, ContextType>;
-  target?: Resolver<Maybe<GQLResolversTypes['TransactionTarget']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLTransactionConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['TransactionConnection'] = GQLResolversParentTypes['TransactionConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['TransactionEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLTransactionEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['TransactionEdge'] = GQLResolversParentTypes['TransactionEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Transaction'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLTransactionNoticeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['TransactionNotice'] = GQLResolversParentTypes['TransactionNotice']> = ResolversObject<{
-  actors?: Resolver<Maybe<Array<GQLResolversTypes['User']>>, ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  target?: Resolver<GQLResolversTypes['Transaction'], ParentType, ContextType>;
-  type?: Resolver<GQLResolversTypes['TransactionNoticeType'], ParentType, ContextType>;
-  unread?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLTransactionTargetResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['TransactionTarget'] = GQLResolversParentTypes['TransactionTarget']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'Article' | 'Circle' | 'Transaction', ParentType, ContextType>;
-}>;
-
-export type GQLTranslatedAnnouncementResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['TranslatedAnnouncement'] = GQLResolversParentTypes['TranslatedAnnouncement']> = ResolversObject<{
-  content?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  cover?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  language?: Resolver<GQLResolversTypes['UserLanguage'], ParentType, ContextType>;
-  link?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  title?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type GQLUnfreezeSpamRingResultResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['UnfreezeSpamRingResult'] = GQLResolversParentTypes['UnfreezeSpamRingResult']> = ResolversObject<{
-  ring?: Resolver<GQLResolversTypes['SpamRing'], ParentType, ContextType>;
-  skipped?: Resolver<Array<GQLResolversTypes['SpamRingSkip']>, ParentType, ContextType>;
-  unbanned?: Resolver<Array<GQLResolversTypes['User']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export interface GQLUploadScalarConfig extends GraphQLScalarTypeConfig<GQLResolversTypes['Upload'], any> {
-  name: 'Upload';
+export type GQLRateLimitDirectiveResolver<
+  Result,
+  Parent,
+  ContextType = Context,
+  Args = GQLRateLimitDirectiveArgs
+> = DirectiveResolverFn<Result, Parent, ContextType, Args>
+
+export type GQLAdStatusResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['AdStatus'] = GQLResolversParentTypes['AdStatus']
+> = ResolversObject<{
+  isAd?: Resolver<Maybe<GQLResolversTypes['Boolean']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLAddCreditResultResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['AddCreditResult'] = GQLResolversParentTypes['AddCreditResult']
+> = ResolversObject<{
+  client_secret?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  transaction?: Resolver<
+    GQLResolversTypes['Transaction'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLAnnouncementResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Announcement'] = GQLResolversParentTypes['Announcement']
+> = ResolversObject<{
+  channels?: Resolver<
+    Array<GQLResolversTypes['AnnouncementChannel']>,
+    ParentType,
+    ContextType
+  >
+  content?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType,
+    Partial<GQLAnnouncementContentArgs>
+  >
+  cover?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  expiredAt?: Resolver<
+    Maybe<GQLResolversTypes['DateTime']>,
+    ParentType,
+    ContextType
+  >
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  link?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType,
+    Partial<GQLAnnouncementLinkArgs>
+  >
+  order?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  title?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType,
+    Partial<GQLAnnouncementTitleArgs>
+  >
+  translations?: Resolver<
+    Maybe<Array<GQLResolversTypes['TranslatedAnnouncement']>>,
+    ParentType,
+    ContextType
+  >
+  type?: Resolver<
+    GQLResolversTypes['AnnouncementType'],
+    ParentType,
+    ContextType
+  >
+  updatedAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  visible?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLAnnouncementChannelResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['AnnouncementChannel'] = GQLResolversParentTypes['AnnouncementChannel']
+> = ResolversObject<{
+  channel?: Resolver<GQLResolversTypes['Channel'], ParentType, ContextType>
+  order?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  visible?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLAppreciationResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Appreciation'] = GQLResolversParentTypes['Appreciation']
+> = ResolversObject<{
+  amount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  content?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  purpose?: Resolver<
+    GQLResolversTypes['AppreciationPurpose'],
+    ParentType,
+    ContextType
+  >
+  recipient?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
+  sender?: Resolver<Maybe<GQLResolversTypes['User']>, ParentType, ContextType>
+  target?: Resolver<
+    Maybe<GQLResolversTypes['Article']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLAppreciationConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['AppreciationConnection'] = GQLResolversParentTypes['AppreciationConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['AppreciationEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLAppreciationEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['AppreciationEdge'] = GQLResolversParentTypes['AppreciationEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Appreciation'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArchiveUserFailureResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArchiveUserFailure'] = GQLResolversParentTypes['ArchiveUserFailure']
+> = ResolversObject<{
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  message?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArchiveUsersResultResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArchiveUsersResult'] = GQLResolversParentTypes['ArchiveUsersResult']
+> = ResolversObject<{
+  archived?: Resolver<Array<GQLResolversTypes['User']>, ParentType, ContextType>
+  skipped?: Resolver<
+    Array<GQLResolversTypes['ArchiveUserFailure']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArticleResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Article'] = GQLResolversParentTypes['Article']
+> = ResolversObject<{
+  access?: Resolver<GQLResolversTypes['ArticleAccess'], ParentType, ContextType>
+  appreciateLeft?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  appreciateLimit?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  appreciationsReceived?: Resolver<
+    GQLResolversTypes['AppreciationConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLArticleAppreciationsReceivedArgs, 'input'>
+  >
+  appreciationsReceivedTotal?: Resolver<
+    GQLResolversTypes['Int'],
+    ParentType,
+    ContextType
+  >
+  assets?: Resolver<Array<GQLResolversTypes['Asset']>, ParentType, ContextType>
+  author?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
+  availableTranslations?: Resolver<
+    Maybe<Array<GQLResolversTypes['UserLanguage']>>,
+    ParentType,
+    ContextType
+  >
+  bookmarkCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  bookmarked?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  campaigns?: Resolver<
+    Array<GQLResolversTypes['ArticleCampaign']>,
+    ParentType,
+    ContextType
+  >
+  canComment?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  canSuperLike?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  classification?: Resolver<
+    GQLResolversTypes['ArticleClassification'],
+    ParentType,
+    ContextType
+  >
+  collection?: Resolver<
+    GQLResolversTypes['ArticleConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLArticleCollectionArgs, 'input'>
+  >
+  collections?: Resolver<
+    GQLResolversTypes['CollectionConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLArticleCollectionsArgs, 'input'>
+  >
+  commentCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  comments?: Resolver<
+    GQLResolversTypes['CommentConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLArticleCommentsArgs, 'input'>
+  >
+  connectedBy?: Resolver<
+    GQLResolversTypes['ArticleConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLArticleConnectedByArgs, 'input'>
+  >
+  connections?: Resolver<
+    GQLResolversTypes['ArticleConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLArticleConnectionsArgs, 'input'>
+  >
+  content?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  contents?: Resolver<
+    GQLResolversTypes['ArticleContents'],
+    ParentType,
+    ContextType
+  >
+  cover?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  dataHash?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  displayCover?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  donated?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  donationCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  donations?: Resolver<
+    GQLResolversTypes['ArticleDonationConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLArticleDonationsArgs, 'input'>
+  >
+  featuredComments?: Resolver<
+    GQLResolversTypes['CommentConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLArticleFeaturedCommentsArgs, 'input'>
+  >
+  federationEligibility?: Resolver<
+    GQLResolversTypes['ArticleFederationEligibility'],
+    ParentType,
+    ContextType
+  >
+  federationSetting?: Resolver<
+    Maybe<GQLResolversTypes['ArticleFederationSetting']>,
+    ParentType,
+    ContextType
+  >
+  hasAppreciate?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  indentFirstLine?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  iscnId?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  language?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  license?: Resolver<
+    GQLResolversTypes['ArticleLicenseType'],
+    ParentType,
+    ContextType
+  >
+  mediaHash?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  noindex?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  oss?: Resolver<GQLResolversTypes['ArticleOSS'], ParentType, ContextType>
+  pinCommentLeft?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  pinCommentLimit?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  pinned?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  pinnedComments?: Resolver<
+    Maybe<Array<GQLResolversTypes['Comment']>>,
+    ParentType,
+    ContextType
+  >
+  readTime?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>
+  readerCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  relatedArticles?: Resolver<
+    GQLResolversTypes['ArticleConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLArticleRelatedArticlesArgs, 'input'>
+  >
+  relatedDonationArticles?: Resolver<
+    GQLResolversTypes['ArticleConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLArticleRelatedDonationArticlesArgs, 'input'>
+  >
+  remark?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  replyToDonator?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  requestForDonation?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  responseCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  responses?: Resolver<
+    GQLResolversTypes['ResponseConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLArticleResponsesArgs, 'input'>
+  >
+  revisedAt?: Resolver<
+    Maybe<GQLResolversTypes['DateTime']>,
+    ParentType,
+    ContextType
+  >
+  revisionCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  sensitiveByAdmin?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  sensitiveByAuthor?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  shortHash?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  slug?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  state?: Resolver<GQLResolversTypes['ArticleState'], ParentType, ContextType>
+  subscribed?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  summary?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  summaryCustomized?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  tags?: Resolver<
+    Maybe<Array<GQLResolversTypes['Tag']>>,
+    ParentType,
+    ContextType
+  >
+  title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  transactionsReceivedBy?: Resolver<
+    GQLResolversTypes['UserConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLArticleTransactionsReceivedByArgs, 'input'>
+  >
+  translation?: Resolver<
+    Maybe<GQLResolversTypes['ArticleTranslation']>,
+    ParentType,
+    ContextType,
+    Partial<GQLArticleTranslationArgs>
+  >
+  versions?: Resolver<
+    GQLResolversTypes['ArticleVersionsConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLArticleVersionsArgs, 'input'>
+  >
+  wordCount?: Resolver<Maybe<GQLResolversTypes['Int']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArticleAccessResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArticleAccess'] = GQLResolversParentTypes['ArticleAccess']
+> = ResolversObject<{
+  circle?: Resolver<Maybe<GQLResolversTypes['Circle']>, ParentType, ContextType>
+  secret?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  type?: Resolver<
+    GQLResolversTypes['ArticleAccessType'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArticleArticleNoticeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArticleArticleNotice'] = GQLResolversParentTypes['ArticleArticleNotice']
+> = ResolversObject<{
+  actors?: Resolver<
+    Maybe<Array<GQLResolversTypes['User']>>,
+    ParentType,
+    ContextType
+  >
+  article?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  target?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>
+  type?: Resolver<
+    GQLResolversTypes['ArticleArticleNoticeType'],
+    ParentType,
+    ContextType
+  >
+  unread?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArticleCampaignResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArticleCampaign'] = GQLResolversParentTypes['ArticleCampaign']
+> = ResolversObject<{
+  campaign?: Resolver<GQLResolversTypes['Campaign'], ParentType, ContextType>
+  stage?: Resolver<
+    Maybe<GQLResolversTypes['CampaignStage']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArticleClassificationResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArticleClassification'] = GQLResolversParentTypes['ArticleClassification']
+> = ResolversObject<{
+  topicChannel?: Resolver<
+    GQLResolversTypes['TopicChannelClassification'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArticleConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArticleConnection'] = GQLResolversParentTypes['ArticleConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['ArticleEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArticleContentsResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArticleContents'] = GQLResolversParentTypes['ArticleContents']
+> = ResolversObject<{
+  html?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  markdown?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArticleDonationResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArticleDonation'] = GQLResolversParentTypes['ArticleDonation']
+> = ResolversObject<{
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  sender?: Resolver<Maybe<GQLResolversTypes['User']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArticleDonationConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArticleDonationConnection'] = GQLResolversParentTypes['ArticleDonationConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['ArticleDonationEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArticleDonationEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArticleDonationEdge'] = GQLResolversParentTypes['ArticleDonationEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['ArticleDonation'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArticleEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArticleEdge'] = GQLResolversParentTypes['ArticleEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArticleFederationEligibilityResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArticleFederationEligibility'] = GQLResolversParentTypes['ArticleFederationEligibility']
+> = ResolversObject<{
+  effectiveArticleSetting?: Resolver<
+    GQLResolversTypes['FederationArticleSettingState'],
+    ParentType,
+    ContextType
+  >
+  eligible?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  reason?: Resolver<
+    GQLResolversTypes['FederationExportDecisionReason'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArticleFederationSettingResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArticleFederationSetting'] = GQLResolversParentTypes['ArticleFederationSetting']
+> = ResolversObject<{
+  articleId?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  state?: Resolver<
+    GQLResolversTypes['FederationArticleSettingState'],
+    ParentType,
+    ContextType
+  >
+  updatedBy?: Resolver<Maybe<GQLResolversTypes['ID']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArticleNoticeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArticleNotice'] = GQLResolversParentTypes['ArticleNotice']
+> = ResolversObject<{
+  actors?: Resolver<
+    Maybe<Array<GQLResolversTypes['User']>>,
+    ParentType,
+    ContextType
+  >
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  entities?: Resolver<Array<GQLResolversTypes['Node']>, ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  target?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>
+  type?: Resolver<
+    GQLResolversTypes['ArticleNoticeType'],
+    ParentType,
+    ContextType
+  >
+  unread?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArticleOssResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArticleOSS'] = GQLResolversParentTypes['ArticleOSS']
+> = ResolversObject<{
+  adStatus?: Resolver<GQLResolversTypes['AdStatus'], ParentType, ContextType>
+  boost?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>
+  inRecommendHottest?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  inRecommendIcymi?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  inRecommendNewest?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  inSearch?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  pinHistory?: Resolver<
+    Array<Maybe<GQLResolversTypes['PinHistory']>>,
+    ParentType,
+    ContextType
+  >
+  score?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>
+  spamStatus?: Resolver<
+    GQLResolversTypes['SpamStatus'],
+    ParentType,
+    ContextType
+  >
+  topicChannels?: Resolver<
+    Maybe<Array<GQLResolversTypes['ArticleTopicChannel']>>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArticleRecommendationActivityResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArticleRecommendationActivity'] = GQLResolversParentTypes['ArticleRecommendationActivity']
+> = ResolversObject<{
+  nodes?: Resolver<
+    Maybe<Array<GQLResolversTypes['Article']>>,
+    ParentType,
+    ContextType
+  >
+  source?: Resolver<
+    Maybe<GQLResolversTypes['ArticleRecommendationActivitySource']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArticleTopicChannelResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArticleTopicChannel'] = GQLResolversParentTypes['ArticleTopicChannel']
+> = ResolversObject<{
+  antiFlooded?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  channel?: Resolver<GQLResolversTypes['TopicChannel'], ParentType, ContextType>
+  classicfiedAt?: Resolver<
+    GQLResolversTypes['DateTime'],
+    ParentType,
+    ContextType
+  >
+  enabled?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  isLabeled?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  pinned?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  score?: Resolver<Maybe<GQLResolversTypes['Float']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArticleTranslationResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArticleTranslation'] = GQLResolversParentTypes['ArticleTranslation']
+> = ResolversObject<{
+  content?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  language?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  model?: Resolver<
+    Maybe<GQLResolversTypes['TranslationModel']>,
+    ParentType,
+    ContextType
+  >
+  summary?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  title?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArticleVersionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArticleVersion'] = GQLResolversParentTypes['ArticleVersion']
+> = ResolversObject<{
+  contents?: Resolver<
+    GQLResolversTypes['ArticleContents'],
+    ParentType,
+    ContextType
+  >
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  dataHash?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  description?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  mediaHash?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  summary?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  translation?: Resolver<
+    Maybe<GQLResolversTypes['ArticleTranslation']>,
+    ParentType,
+    ContextType,
+    Partial<GQLArticleVersionTranslationArgs>
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArticleVersionEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArticleVersionEdge'] = GQLResolversParentTypes['ArticleVersionEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['ArticleVersion'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLArticleVersionsConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ArticleVersionsConnection'] = GQLResolversParentTypes['ArticleVersionsConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Array<Maybe<GQLResolversTypes['ArticleVersionEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLAssetResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Asset'] = GQLResolversParentTypes['Asset']
+> = ResolversObject<{
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  draft?: Resolver<Maybe<GQLResolversTypes['Boolean']>, ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  path?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  type?: Resolver<GQLResolversTypes['AssetType'], ParentType, ContextType>
+  uploadURL?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLAuthResultResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['AuthResult'] = GQLResolversParentTypes['AuthResult']
+> = ResolversObject<{
+  auth?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  token?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  type?: Resolver<GQLResolversTypes['AuthResultType'], ParentType, ContextType>
+  user?: Resolver<Maybe<GQLResolversTypes['User']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLBadgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Badge'] = GQLResolversParentTypes['Badge']
+> = ResolversObject<{
+  type?: Resolver<GQLResolversTypes['BadgeType'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLBalanceResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Balance'] = GQLResolversParentTypes['Balance']
+> = ResolversObject<{
+  HKD?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLBlockchainTransactionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['BlockchainTransaction'] = GQLResolversParentTypes['BlockchainTransaction']
+> = ResolversObject<{
+  chain?: Resolver<GQLResolversTypes['Chain'], ParentType, ContextType>
+  txHash?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLBlockedSearchKeywordResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['BlockedSearchKeyword'] = GQLResolversParentTypes['BlockedSearchKeyword']
+> = ResolversObject<{
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  searchKey?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCampaignResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Campaign'] = GQLResolversParentTypes['Campaign']
+> = ResolversObject<{
+  __resolveType: TypeResolveFn<'WritingChallenge', ParentType, ContextType>
+}>
+
+export type GQLCampaignApplicationResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CampaignApplication'] = GQLResolversParentTypes['CampaignApplication']
+> = ResolversObject<{
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  state?: Resolver<
+    GQLResolversTypes['CampaignApplicationState'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCampaignArticleConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CampaignArticleConnection'] = GQLResolversParentTypes['CampaignArticleConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Array<GQLResolversTypes['CampaignArticleEdge']>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCampaignArticleEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CampaignArticleEdge'] = GQLResolversParentTypes['CampaignArticleEdge']
+> = ResolversObject<{
+  announcement?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  featured?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCampaignArticleNoticeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CampaignArticleNotice'] = GQLResolversParentTypes['CampaignArticleNotice']
+> = ResolversObject<{
+  actors?: Resolver<
+    Maybe<Array<GQLResolversTypes['User']>>,
+    ParentType,
+    ContextType
+  >
+  article?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  target?: Resolver<GQLResolversTypes['Campaign'], ParentType, ContextType>
+  type?: Resolver<
+    GQLResolversTypes['CampaignArticleNoticeType'],
+    ParentType,
+    ContextType
+  >
+  unread?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCampaignConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CampaignConnection'] = GQLResolversParentTypes['CampaignConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['CampaignEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCampaignEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CampaignEdge'] = GQLResolversParentTypes['CampaignEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Campaign'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCampaignOssResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CampaignOSS'] = GQLResolversParentTypes['CampaignOSS']
+> = ResolversObject<{
+  boost?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>
+  exclusive?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  managers?: Resolver<Array<GQLResolversTypes['User']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCampaignParticipantConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CampaignParticipantConnection'] = GQLResolversParentTypes['CampaignParticipantConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['CampaignParticipantEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCampaignParticipantEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CampaignParticipantEdge'] = GQLResolversParentTypes['CampaignParticipantEdge']
+> = ResolversObject<{
+  application?: Resolver<
+    Maybe<GQLResolversTypes['CampaignApplication']>,
+    ParentType,
+    ContextType
+  >
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCampaignStageResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CampaignStage'] = GQLResolversParentTypes['CampaignStage']
+> = ResolversObject<{
+  description?: Resolver<
+    GQLResolversTypes['String'],
+    ParentType,
+    ContextType,
+    Partial<GQLCampaignStageDescriptionArgs>
+  >
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  name?: Resolver<
+    GQLResolversTypes['String'],
+    ParentType,
+    ContextType,
+    Partial<GQLCampaignStageNameArgs>
+  >
+  period?: Resolver<
+    Maybe<GQLResolversTypes['DatetimeRange']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLChannelResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Channel'] = GQLResolversParentTypes['Channel']
+> = ResolversObject<{
+  __resolveType: TypeResolveFn<
+    'CurationChannel' | 'Tag' | 'TopicChannel' | 'WritingChallenge',
+    ParentType,
+    ContextType
+  >
+}>
+
+export type GQLChannelArticleConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ChannelArticleConnection'] = GQLResolversParentTypes['ChannelArticleConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['ChannelArticleEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLChannelArticleEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ChannelArticleEdge'] = GQLResolversParentTypes['ChannelArticleEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>
+  pinned?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCircleResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Circle'] = GQLResolversParentTypes['Circle']
+> = ResolversObject<{
+  analytics?: Resolver<
+    GQLResolversTypes['CircleAnalytics'],
+    ParentType,
+    ContextType
+  >
+  avatar?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  broadcast?: Resolver<
+    GQLResolversTypes['CommentConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLCircleBroadcastArgs, 'input'>
+  >
+  cover?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  description?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  discussion?: Resolver<
+    GQLResolversTypes['CommentConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLCircleDiscussionArgs, 'input'>
+  >
+  discussionCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  discussionThreadCount?: Resolver<
+    GQLResolversTypes['Int'],
+    ParentType,
+    ContextType
+  >
+  displayName?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  followers?: Resolver<
+    GQLResolversTypes['UserConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLCircleFollowersArgs, 'input'>
+  >
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  invitedBy?: Resolver<
+    Maybe<GQLResolversTypes['Invitation']>,
+    ParentType,
+    ContextType
+  >
+  invites?: Resolver<GQLResolversTypes['Invites'], ParentType, ContextType>
+  isFollower?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  isMember?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  members?: Resolver<
+    GQLResolversTypes['MemberConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLCircleMembersArgs, 'input'>
+  >
+  name?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  owner?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
+  pinnedBroadcast?: Resolver<
+    Maybe<Array<GQLResolversTypes['Comment']>>,
+    ParentType,
+    ContextType
+  >
+  prices?: Resolver<
+    Maybe<Array<GQLResolversTypes['Price']>>,
+    ParentType,
+    ContextType
+  >
+  state?: Resolver<GQLResolversTypes['CircleState'], ParentType, ContextType>
+  updatedAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  works?: Resolver<
+    GQLResolversTypes['ArticleConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLCircleWorksArgs, 'input'>
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCircleAnalyticsResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CircleAnalytics'] = GQLResolversParentTypes['CircleAnalytics']
+> = ResolversObject<{
+  content?: Resolver<
+    GQLResolversTypes['CircleContentAnalytics'],
+    ParentType,
+    ContextType
+  >
+  follower?: Resolver<
+    GQLResolversTypes['CircleFollowerAnalytics'],
+    ParentType,
+    ContextType
+  >
+  income?: Resolver<
+    GQLResolversTypes['CircleIncomeAnalytics'],
+    ParentType,
+    ContextType
+  >
+  subscriber?: Resolver<
+    GQLResolversTypes['CircleSubscriberAnalytics'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCircleConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CircleConnection'] = GQLResolversParentTypes['CircleConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['CircleEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCircleContentAnalyticsResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CircleContentAnalytics'] = GQLResolversParentTypes['CircleContentAnalytics']
+> = ResolversObject<{
+  paywall?: Resolver<
+    Maybe<Array<GQLResolversTypes['CircleContentAnalyticsDatum']>>,
+    ParentType,
+    ContextType
+  >
+  public?: Resolver<
+    Maybe<Array<GQLResolversTypes['CircleContentAnalyticsDatum']>>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCircleContentAnalyticsDatumResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CircleContentAnalyticsDatum'] = GQLResolversParentTypes['CircleContentAnalyticsDatum']
+> = ResolversObject<{
+  node?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>
+  readCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCircleEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CircleEdge'] = GQLResolversParentTypes['CircleEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Circle'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCircleFollowerAnalyticsResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CircleFollowerAnalytics'] = GQLResolversParentTypes['CircleFollowerAnalytics']
+> = ResolversObject<{
+  current?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  followerPercentage?: Resolver<
+    GQLResolversTypes['Float'],
+    ParentType,
+    ContextType
+  >
+  history?: Resolver<
+    Array<GQLResolversTypes['MonthlyDatum']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCircleIncomeAnalyticsResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CircleIncomeAnalytics'] = GQLResolversParentTypes['CircleIncomeAnalytics']
+> = ResolversObject<{
+  history?: Resolver<
+    Array<GQLResolversTypes['MonthlyDatum']>,
+    ParentType,
+    ContextType
+  >
+  nextMonth?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>
+  thisMonth?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>
+  total?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCircleNoticeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CircleNotice'] = GQLResolversParentTypes['CircleNotice']
+> = ResolversObject<{
+  actors?: Resolver<
+    Maybe<Array<GQLResolversTypes['User']>>,
+    ParentType,
+    ContextType
+  >
+  comments?: Resolver<
+    Maybe<Array<GQLResolversTypes['Comment']>>,
+    ParentType,
+    ContextType
+  >
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  mentions?: Resolver<
+    Maybe<Array<GQLResolversTypes['Comment']>>,
+    ParentType,
+    ContextType
+  >
+  replies?: Resolver<
+    Maybe<Array<GQLResolversTypes['Comment']>>,
+    ParentType,
+    ContextType
+  >
+  target?: Resolver<GQLResolversTypes['Circle'], ParentType, ContextType>
+  type?: Resolver<
+    GQLResolversTypes['CircleNoticeType'],
+    ParentType,
+    ContextType
+  >
+  unread?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCircleRecommendationActivityResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CircleRecommendationActivity'] = GQLResolversParentTypes['CircleRecommendationActivity']
+> = ResolversObject<{
+  nodes?: Resolver<
+    Maybe<Array<GQLResolversTypes['Circle']>>,
+    ParentType,
+    ContextType
+  >
+  source?: Resolver<
+    Maybe<GQLResolversTypes['CircleRecommendationActivitySource']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCircleSubscriberAnalyticsResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CircleSubscriberAnalytics'] = GQLResolversParentTypes['CircleSubscriberAnalytics']
+> = ResolversObject<{
+  currentInvitee?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  currentSubscriber?: Resolver<
+    GQLResolversTypes['Int'],
+    ParentType,
+    ContextType
+  >
+  inviteeHistory?: Resolver<
+    Array<GQLResolversTypes['MonthlyDatum']>,
+    ParentType,
+    ContextType
+  >
+  subscriberHistory?: Resolver<
+    Array<GQLResolversTypes['MonthlyDatum']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLClaimLogbooksResultResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ClaimLogbooksResult'] = GQLResolversParentTypes['ClaimLogbooksResult']
+> = ResolversObject<{
+  ids?: Resolver<Maybe<Array<GQLResolversTypes['ID']>>, ParentType, ContextType>
+  txHash?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCollectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Collection'] = GQLResolversParentTypes['Collection']
+> = ResolversObject<{
+  articles?: Resolver<
+    GQLResolversTypes['ArticleConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLCollectionArticlesArgs, 'input'>
+  >
+  author?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
+  contains?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLCollectionContainsArgs, 'input'>
+  >
+  cover?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  description?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  likeCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  liked?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  pinned?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  updatedAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCollectionConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CollectionConnection'] = GQLResolversParentTypes['CollectionConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['CollectionEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCollectionEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CollectionEdge'] = GQLResolversParentTypes['CollectionEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Collection'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCollectionNoticeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CollectionNotice'] = GQLResolversParentTypes['CollectionNotice']
+> = ResolversObject<{
+  actors?: Resolver<
+    Maybe<Array<GQLResolversTypes['User']>>,
+    ParentType,
+    ContextType
+  >
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  target?: Resolver<GQLResolversTypes['Collection'], ParentType, ContextType>
+  unread?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCommentResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Comment'] = GQLResolversParentTypes['Comment']
+> = ResolversObject<{
+  author?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
+  comments?: Resolver<
+    GQLResolversTypes['CommentConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLCommentCommentsArgs, 'input'>
+  >
+  communityWatchAction?: Resolver<
+    Maybe<GQLResolversTypes['CommunityWatchAction']>,
+    ParentType,
+    ContextType
+  >
+  content?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  downvotes?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  fromDonator?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  myVote?: Resolver<Maybe<GQLResolversTypes['Vote']>, ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Node'], ParentType, ContextType>
+  parentComment?: Resolver<
+    Maybe<GQLResolversTypes['Comment']>,
+    ParentType,
+    ContextType
+  >
+  pinned?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  remark?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  replyTo?: Resolver<
+    Maybe<GQLResolversTypes['Comment']>,
+    ParentType,
+    ContextType
+  >
+  spamStatus?: Resolver<
+    GQLResolversTypes['SpamStatus'],
+    ParentType,
+    ContextType
+  >
+  state?: Resolver<GQLResolversTypes['CommentState'], ParentType, ContextType>
+  type?: Resolver<GQLResolversTypes['CommentType'], ParentType, ContextType>
+  upvotes?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCommentCommentNoticeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CommentCommentNotice'] = GQLResolversParentTypes['CommentCommentNotice']
+> = ResolversObject<{
+  actors?: Resolver<
+    Maybe<Array<GQLResolversTypes['User']>>,
+    ParentType,
+    ContextType
+  >
+  comment?: Resolver<GQLResolversTypes['Comment'], ParentType, ContextType>
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  target?: Resolver<GQLResolversTypes['Comment'], ParentType, ContextType>
+  type?: Resolver<
+    GQLResolversTypes['CommentCommentNoticeType'],
+    ParentType,
+    ContextType
+  >
+  unread?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCommentConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CommentConnection'] = GQLResolversParentTypes['CommentConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['CommentEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCommentEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CommentEdge'] = GQLResolversParentTypes['CommentEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Comment'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCommentNoticeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CommentNotice'] = GQLResolversParentTypes['CommentNotice']
+> = ResolversObject<{
+  actors?: Resolver<
+    Maybe<Array<GQLResolversTypes['User']>>,
+    ParentType,
+    ContextType
+  >
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  target?: Resolver<GQLResolversTypes['Comment'], ParentType, ContextType>
+  type?: Resolver<
+    GQLResolversTypes['CommentNoticeType'],
+    ParentType,
+    ContextType
+  >
+  unread?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCommunityWatchActionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CommunityWatchAction'] = GQLResolversParentTypes['CommunityWatchAction']
+> = ResolversObject<{
+  actionState?: Resolver<
+    GQLResolversTypes['CommunityWatchActionState'],
+    ParentType,
+    ContextType
+  >
+  actorDisplayName?: Resolver<
+    GQLResolversTypes['String'],
+    ParentType,
+    ContextType
+  >
+  appealState?: Resolver<
+    GQLResolversTypes['CommunityWatchAppealState'],
+    ParentType,
+    ContextType
+  >
+  commentId?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  contentCleared?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  contentHash?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  originalContent?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  reason?: Resolver<
+    GQLResolversTypes['CommunityWatchRemoveCommentReason'],
+    ParentType,
+    ContextType
+  >
+  reportSynced?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  reviewState?: Resolver<
+    GQLResolversTypes['CommunityWatchReviewState'],
+    ParentType,
+    ContextType
+  >
+  sourceId?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  sourceTitle?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  sourceType?: Resolver<
+    GQLResolversTypes['CommunityWatchActionSourceType'],
+    ParentType,
+    ContextType
+  >
+  sourceUrl?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  uuid?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCommunityWatchActionConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CommunityWatchActionConnection'] = GQLResolversParentTypes['CommunityWatchActionConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['CommunityWatchActionEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCommunityWatchActionEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CommunityWatchActionEdge'] = GQLResolversParentTypes['CommunityWatchActionEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<
+    GQLResolversTypes['CommunityWatchAction'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLConnectStripeAccountResultResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ConnectStripeAccountResult'] = GQLResolversParentTypes['ConnectStripeAccountResult']
+> = ResolversObject<{
+  redirectUrl?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Connection'] = GQLResolversParentTypes['Connection']
+> = ResolversObject<{
+  __resolveType: TypeResolveFn<
+    | 'AppreciationConnection'
+    | 'ArticleConnection'
+    | 'ArticleVersionsConnection'
+    | 'CampaignArticleConnection'
+    | 'CampaignConnection'
+    | 'CampaignParticipantConnection'
+    | 'ChannelArticleConnection'
+    | 'CircleConnection'
+    | 'CollectionConnection'
+    | 'CommentConnection'
+    | 'CommunityWatchActionConnection'
+    | 'DraftConnection'
+    | 'FollowingActivityConnection'
+    | 'IcymiTopicConnection'
+    | 'InvitationConnection'
+    | 'MemberConnection'
+    | 'MomentConnection'
+    | 'NoticeConnection'
+    | 'OAuthClientConnection'
+    | 'QuoteConnection'
+    | 'ReadHistoryConnection'
+    | 'RecentSearchConnection'
+    | 'ReportConnection'
+    | 'ResponseConnection'
+    | 'SearchResultConnection'
+    | 'SkippedListItemsConnection'
+    | 'SpamRingConnection'
+    | 'SpamRingMemberConnection'
+    | 'TagConnection'
+    | 'TagWritingConnection'
+    | 'TopDonatorConnection'
+    | 'TopicChannelFeedbackConnection'
+    | 'TransactionConnection'
+    | 'UserConnection'
+    | 'WritingConnection',
+    ParentType,
+    ContextType
+  >
+}>
+
+export type GQLCryptoWalletResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CryptoWallet'] = GQLResolversParentTypes['CryptoWallet']
+> = ResolversObject<{
+  address?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  hasNFTs?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  nfts?: Resolver<
+    Maybe<Array<GQLResolversTypes['NFTAsset']>>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLCurationChannelResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['CurationChannel'] = GQLResolversParentTypes['CurationChannel']
+> = ResolversObject<{
+  activePeriod?: Resolver<
+    GQLResolversTypes['DatetimeRange'],
+    ParentType,
+    ContextType
+  >
+  articles?: Resolver<
+    GQLResolversTypes['ChannelArticleConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLCurationChannelArticlesArgs, 'input'>
+  >
+  color?: Resolver<GQLResolversTypes['Color'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  name?: Resolver<
+    GQLResolversTypes['String'],
+    ParentType,
+    ContextType,
+    Partial<GQLCurationChannelNameArgs>
+  >
+  navbarTitle?: Resolver<
+    GQLResolversTypes['String'],
+    ParentType,
+    ContextType,
+    Partial<GQLCurationChannelNavbarTitleArgs>
+  >
+  note?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType,
+    Partial<GQLCurationChannelNoteArgs>
+  >
+  pinAmount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  shortHash?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  showRecommendation?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  state?: Resolver<
+    GQLResolversTypes['CurationChannelState'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export interface GQLDateTimeScalarConfig
+  extends GraphQLScalarTypeConfig<GQLResolversTypes['DateTime'], any> {
+  name: 'DateTime'
 }
 
-export type GQLUpsertSpamRingCandidatesResultResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['UpsertSpamRingCandidatesResult'] = GQLResolversParentTypes['UpsertSpamRingCandidatesResult']> = ResolversObject<{
-  created?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  rings?: Resolver<Array<GQLResolversTypes['SpamRing']>, ParentType, ContextType>;
-  skipped?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  updated?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLDatetimeRangeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['DatetimeRange'] = GQLResolversParentTypes['DatetimeRange']
+> = ResolversObject<{
+  end?: Resolver<Maybe<GQLResolversTypes['DateTime']>, ParentType, ContextType>
+  start?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
-export type GQLUserResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['User'] = GQLResolversParentTypes['User']> = ResolversObject<{
-  activity?: Resolver<GQLResolversTypes['UserActivity'], ParentType, ContextType>;
-  analytics?: Resolver<GQLResolversTypes['UserAnalytics'], ParentType, ContextType>;
-  articles?: Resolver<GQLResolversTypes['ArticleConnection'], ParentType, ContextType, RequireFields<GQLUserArticlesArgs, 'input'>>;
-  avatar?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  blockList?: Resolver<GQLResolversTypes['UserConnection'], ParentType, ContextType, RequireFields<GQLUserBlockListArgs, 'input'>>;
-  bookmarkedArticles?: Resolver<GQLResolversTypes['ArticleConnection'], ParentType, ContextType, RequireFields<GQLUserBookmarkedArticlesArgs, 'input'>>;
-  bookmarkedTags?: Resolver<GQLResolversTypes['TagConnection'], ParentType, ContextType, RequireFields<GQLUserBookmarkedTagsArgs, 'input'>>;
-  campaigns?: Resolver<GQLResolversTypes['CampaignConnection'], ParentType, ContextType, RequireFields<GQLUserCampaignsArgs, 'input'>>;
-  collections?: Resolver<GQLResolversTypes['CollectionConnection'], ParentType, ContextType, RequireFields<GQLUserCollectionsArgs, 'input'>>;
-  commentedArticles?: Resolver<GQLResolversTypes['ArticleConnection'], ParentType, ContextType, RequireFields<GQLUserCommentedArticlesArgs, 'input'>>;
-  displayName?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  drafts?: Resolver<GQLResolversTypes['DraftConnection'], ParentType, ContextType, RequireFields<GQLUserDraftsArgs, 'input'>>;
-  features?: Resolver<GQLResolversTypes['UserFeatures'], ParentType, ContextType>;
-  federationSetting?: Resolver<Maybe<GQLResolversTypes['UserFederationSetting']>, ParentType, ContextType>;
-  followers?: Resolver<GQLResolversTypes['UserConnection'], ParentType, ContextType, RequireFields<GQLUserFollowersArgs, 'input'>>;
-  following?: Resolver<GQLResolversTypes['Following'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  info?: Resolver<GQLResolversTypes['UserInfo'], ParentType, ContextType>;
-  isBlocked?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  isBlocking?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  isFollowee?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  isFollower?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  isMomentFeedApplied?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  latestWorks?: Resolver<Array<GQLResolversTypes['PinnableWork']>, ParentType, ContextType>;
-  liker?: Resolver<GQLResolversTypes['Liker'], ParentType, ContextType>;
-  likerId?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  notices?: Resolver<GQLResolversTypes['NoticeConnection'], ParentType, ContextType, RequireFields<GQLUserNoticesArgs, 'input'>>;
-  oss?: Resolver<GQLResolversTypes['UserOSS'], ParentType, ContextType>;
-  ownCircles?: Resolver<Maybe<Array<GQLResolversTypes['Circle']>>, ParentType, ContextType>;
-  paymentPointer?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  pinnedWorks?: Resolver<Array<GQLResolversTypes['PinnableWork']>, ParentType, ContextType>;
-  recommendation?: Resolver<GQLResolversTypes['Recommendation'], ParentType, ContextType>;
-  remark?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  settings?: Resolver<GQLResolversTypes['UserSettings'], ParentType, ContextType>;
-  status?: Resolver<Maybe<GQLResolversTypes['UserStatus']>, ParentType, ContextType>;
-  subscribedCircles?: Resolver<GQLResolversTypes['CircleConnection'], ParentType, ContextType, RequireFields<GQLUserSubscribedCirclesArgs, 'input'>>;
-  tags?: Resolver<GQLResolversTypes['TagConnection'], ParentType, ContextType, RequireFields<GQLUserTagsArgs, 'input'>>;
-  userName?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  wallet?: Resolver<GQLResolversTypes['Wallet'], ParentType, ContextType>;
-  writings?: Resolver<GQLResolversTypes['WritingConnection'], ParentType, ContextType, RequireFields<GQLUserWritingsArgs, 'input'>>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLDonatorResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Donator'] = GQLResolversParentTypes['Donator']
+> = ResolversObject<{
+  __resolveType: TypeResolveFn<'CryptoWallet' | 'User', ParentType, ContextType>
+}>
 
-export type GQLUserActivityResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['UserActivity'] = GQLResolversParentTypes['UserActivity']> = ResolversObject<{
-  appreciationsReceived?: Resolver<GQLResolversTypes['AppreciationConnection'], ParentType, ContextType, RequireFields<GQLUserActivityAppreciationsReceivedArgs, 'input'>>;
-  appreciationsReceivedTotal?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  appreciationsSent?: Resolver<GQLResolversTypes['AppreciationConnection'], ParentType, ContextType, RequireFields<GQLUserActivityAppreciationsSentArgs, 'input'>>;
-  appreciationsSentTotal?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  history?: Resolver<GQLResolversTypes['ReadHistoryConnection'], ParentType, ContextType, RequireFields<GQLUserActivityHistoryArgs, 'input'>>;
-  recentSearches?: Resolver<GQLResolversTypes['RecentSearchConnection'], ParentType, ContextType, RequireFields<GQLUserActivityRecentSearchesArgs, 'input'>>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLDraftResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Draft'] = GQLResolversParentTypes['Draft']
+> = ResolversObject<{
+  access?: Resolver<GQLResolversTypes['DraftAccess'], ParentType, ContextType>
+  article?: Resolver<
+    Maybe<GQLResolversTypes['Article']>,
+    ParentType,
+    ContextType
+  >
+  assets?: Resolver<Array<GQLResolversTypes['Asset']>, ParentType, ContextType>
+  campaigns?: Resolver<
+    Array<GQLResolversTypes['ArticleCampaign']>,
+    ParentType,
+    ContextType
+  >
+  canComment?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  collection?: Resolver<
+    GQLResolversTypes['ArticleConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLDraftCollectionArgs, 'input'>
+  >
+  collections?: Resolver<
+    GQLResolversTypes['CollectionConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLDraftCollectionsArgs, 'input'>
+  >
+  connections?: Resolver<
+    GQLResolversTypes['ArticleConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLDraftConnectionsArgs, 'input'>
+  >
+  content?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  cover?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  indentFirstLine?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  iscnPublish?: Resolver<
+    Maybe<GQLResolversTypes['Boolean']>,
+    ParentType,
+    ContextType
+  >
+  license?: Resolver<
+    GQLResolversTypes['ArticleLicenseType'],
+    ParentType,
+    ContextType
+  >
+  mediaHash?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  publishAt?: Resolver<
+    Maybe<GQLResolversTypes['DateTime']>,
+    ParentType,
+    ContextType
+  >
+  publishState?: Resolver<
+    GQLResolversTypes['PublishState'],
+    ParentType,
+    ContextType
+  >
+  replyToDonator?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  requestForDonation?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  sensitiveByAuthor?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  slug?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  summary?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  summaryCustomized?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  tags?: Resolver<
+    Maybe<Array<GQLResolversTypes['String']>>,
+    ParentType,
+    ContextType
+  >
+  title?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  updatedAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  wordCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
-export type GQLUserAddArticleTagActivityResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['UserAddArticleTagActivity'] = GQLResolversParentTypes['UserAddArticleTagActivity']> = ResolversObject<{
-  actor?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>;
-  target?: Resolver<GQLResolversTypes['Tag'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLDraftAccessResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['DraftAccess'] = GQLResolversParentTypes['DraftAccess']
+> = ResolversObject<{
+  circle?: Resolver<Maybe<GQLResolversTypes['Circle']>, ParentType, ContextType>
+  type?: Resolver<
+    GQLResolversTypes['ArticleAccessType'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
-export type GQLUserAnalyticsResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['UserAnalytics'] = GQLResolversParentTypes['UserAnalytics']> = ResolversObject<{
-  topDonators?: Resolver<GQLResolversTypes['TopDonatorConnection'], ParentType, ContextType, RequireFields<GQLUserAnalyticsTopDonatorsArgs, 'input'>>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLDraftConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['DraftConnection'] = GQLResolversParentTypes['DraftConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['DraftEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
-export type GQLUserBroadcastCircleActivityResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['UserBroadcastCircleActivity'] = GQLResolversParentTypes['UserBroadcastCircleActivity']> = ResolversObject<{
-  actor?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Comment'], ParentType, ContextType>;
-  target?: Resolver<GQLResolversTypes['Circle'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLDraftEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['DraftEdge'] = GQLResolversParentTypes['DraftEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Draft'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
-export type GQLUserConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['UserConnection'] = GQLResolversParentTypes['UserConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['UserEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLExchangeRateResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ExchangeRate'] = GQLResolversParentTypes['ExchangeRate']
+> = ResolversObject<{
+  from?: Resolver<
+    GQLResolversTypes['TransactionCurrency'],
+    ParentType,
+    ContextType
+  >
+  rate?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>
+  to?: Resolver<GQLResolversTypes['QuoteCurrency'], ParentType, ContextType>
+  updatedAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
-export type GQLUserCreateCircleActivityResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['UserCreateCircleActivity'] = GQLResolversParentTypes['UserCreateCircleActivity']> = ResolversObject<{
-  actor?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Circle'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLFeatureResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Feature'] = GQLResolversParentTypes['Feature']
+> = ResolversObject<{
+  enabled?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  name?: Resolver<GQLResolversTypes['FeatureName'], ParentType, ContextType>
+  value?: Resolver<Maybe<GQLResolversTypes['Float']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
-export type GQLUserEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['UserEdge'] = GQLResolversParentTypes['UserEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLFollowingResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Following'] = GQLResolversParentTypes['Following']
+> = ResolversObject<{
+  circles?: Resolver<
+    GQLResolversTypes['CircleConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLFollowingCirclesArgs, 'input'>
+  >
+  users?: Resolver<
+    GQLResolversTypes['UserConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLFollowingUsersArgs, 'input'>
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
-export type GQLUserFeatureFlagResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['UserFeatureFlag'] = GQLResolversParentTypes['UserFeatureFlag']> = ResolversObject<{
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  type?: Resolver<GQLResolversTypes['UserFeatureFlagType'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLFollowingActivityResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['FollowingActivity'] = GQLResolversParentTypes['FollowingActivity']
+> = ResolversObject<{
+  __resolveType: TypeResolveFn<
+    | 'ArticleRecommendationActivity'
+    | 'CircleRecommendationActivity'
+    | 'UserAddArticleTagActivity'
+    | 'UserBroadcastCircleActivity'
+    | 'UserCreateCircleActivity'
+    | 'UserPostMomentActivity'
+    | 'UserPublishArticleActivity'
+    | 'UserRecommendationActivity',
+    ParentType,
+    ContextType
+  >
+}>
 
-export type GQLUserFeaturesResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['UserFeatures'] = GQLResolversParentTypes['UserFeatures']> = ResolversObject<{
-  communityWatch?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  fediverseBeta?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLFollowingActivityConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['FollowingActivityConnection'] = GQLResolversParentTypes['FollowingActivityConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['FollowingActivityEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
-export type GQLUserFederationSettingResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['UserFederationSetting'] = GQLResolversParentTypes['UserFederationSetting']> = ResolversObject<{
-  state?: Resolver<GQLResolversTypes['FederationAuthorSettingState'], ParentType, ContextType>;
-  updatedBy?: Resolver<Maybe<GQLResolversTypes['ID']>, ParentType, ContextType>;
-  userId?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLFollowingActivityEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['FollowingActivityEdge'] = GQLResolversParentTypes['FollowingActivityEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<
+    GQLResolversTypes['FollowingActivity'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
-export type GQLUserInfoResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['UserInfo'] = GQLResolversParentTypes['UserInfo']> = ResolversObject<{
-  agreeOn?: Resolver<Maybe<GQLResolversTypes['DateTime']>, ParentType, ContextType>;
-  badges?: Resolver<Maybe<Array<GQLResolversTypes['Badge']>>, ParentType, ContextType>;
-  createdAt?: Resolver<Maybe<GQLResolversTypes['DateTime']>, ParentType, ContextType>;
-  cryptoWallet?: Resolver<Maybe<GQLResolversTypes['CryptoWallet']>, ParentType, ContextType>;
-  description?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  email?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  emailVerified?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  ethAddress?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  featuredTags?: Resolver<Maybe<Array<GQLResolversTypes['Tag']>>, ParentType, ContextType>;
-  group?: Resolver<GQLResolversTypes['UserGroup'], ParentType, ContextType>;
-  ipnsKey?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  isWalletAuth?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  profileCover?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  socialAccounts?: Resolver<Array<GQLResolversTypes['SocialAccount']>, ParentType, ContextType>;
-  userNameEditable?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLFreezeSpamRingResultResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['FreezeSpamRingResult'] = GQLResolversParentTypes['FreezeSpamRingResult']
+> = ResolversObject<{
+  frozen?: Resolver<Array<GQLResolversTypes['User']>, ParentType, ContextType>
+  ring?: Resolver<GQLResolversTypes['SpamRing'], ParentType, ContextType>
+  skipped?: Resolver<
+    Array<GQLResolversTypes['SpamRingSkip']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
-export type GQLUserNoticeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['UserNotice'] = GQLResolversParentTypes['UserNotice']> = ResolversObject<{
-  actors?: Resolver<Maybe<Array<GQLResolversTypes['User']>>, ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  target?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>;
-  type?: Resolver<GQLResolversTypes['UserNoticeType'], ParentType, ContextType>;
-  unread?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLIcymiTopicResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['IcymiTopic'] = GQLResolversParentTypes['IcymiTopic']
+> = ResolversObject<{
+  archivedAt?: Resolver<
+    Maybe<GQLResolversTypes['DateTime']>,
+    ParentType,
+    ContextType
+  >
+  articles?: Resolver<
+    Array<GQLResolversTypes['Article']>,
+    ParentType,
+    ContextType
+  >
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  note?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType,
+    Partial<GQLIcymiTopicNoteArgs>
+  >
+  pinAmount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  publishedAt?: Resolver<
+    Maybe<GQLResolversTypes['DateTime']>,
+    ParentType,
+    ContextType
+  >
+  state?: Resolver<
+    GQLResolversTypes['IcymiTopicState'],
+    ParentType,
+    ContextType
+  >
+  title?: Resolver<
+    GQLResolversTypes['String'],
+    ParentType,
+    ContextType,
+    Partial<GQLIcymiTopicTitleArgs>
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
-export type GQLUserOssResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['UserOSS'] = GQLResolversParentTypes['UserOSS']> = ResolversObject<{
-  boost?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>;
-  featureFlags?: Resolver<Array<GQLResolversTypes['UserFeatureFlag']>, ParentType, ContextType>;
-  momentFeedApplication?: Resolver<Maybe<GQLResolversTypes['MomentFeedApplication']>, ParentType, ContextType>;
-  restrictions?: Resolver<Array<GQLResolversTypes['UserRestriction']>, ParentType, ContextType>;
-  score?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLIcymiTopicConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['IcymiTopicConnection'] = GQLResolversParentTypes['IcymiTopicConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Array<GQLResolversTypes['IcymiTopicEdge']>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
-export type GQLUserPostMomentActivityResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['UserPostMomentActivity'] = GQLResolversParentTypes['UserPostMomentActivity']> = ResolversObject<{
-  actor?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  more?: Resolver<Array<GQLResolversTypes['Moment']>, ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Moment'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLIcymiTopicEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['IcymiTopicEdge'] = GQLResolversParentTypes['IcymiTopicEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['IcymiTopic'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
-export type GQLUserPublishArticleActivityResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['UserPublishArticleActivity'] = GQLResolversParentTypes['UserPublishArticleActivity']> = ResolversObject<{
-  actor?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>;
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLInvitationResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Invitation'] = GQLResolversParentTypes['Invitation']
+> = ResolversObject<{
+  acceptedAt?: Resolver<
+    Maybe<GQLResolversTypes['DateTime']>,
+    ParentType,
+    ContextType
+  >
+  circle?: Resolver<GQLResolversTypes['Circle'], ParentType, ContextType>
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  freePeriod?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  invitee?: Resolver<GQLResolversTypes['Invitee'], ParentType, ContextType>
+  inviter?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
+  sentAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  state?: Resolver<
+    GQLResolversTypes['InvitationState'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
-export type GQLUserRecommendationActivityResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['UserRecommendationActivity'] = GQLResolversParentTypes['UserRecommendationActivity']> = ResolversObject<{
-  nodes?: Resolver<Maybe<Array<GQLResolversTypes['User']>>, ParentType, ContextType>;
-  source?: Resolver<Maybe<GQLResolversTypes['UserRecommendationActivitySource']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLInvitationConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['InvitationConnection'] = GQLResolversParentTypes['InvitationConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['InvitationEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
-export type GQLUserRestrictionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['UserRestriction'] = GQLResolversParentTypes['UserRestriction']> = ResolversObject<{
-  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>;
-  type?: Resolver<GQLResolversTypes['UserRestrictionType'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLInvitationEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['InvitationEdge'] = GQLResolversParentTypes['InvitationEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Invitation'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
-export type GQLUserSettingsResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['UserSettings'] = GQLResolversParentTypes['UserSettings']> = ResolversObject<{
-  currency?: Resolver<GQLResolversTypes['QuoteCurrency'], ParentType, ContextType>;
-  language?: Resolver<GQLResolversTypes['UserLanguage'], ParentType, ContextType>;
-  notification?: Resolver<Maybe<GQLResolversTypes['NotificationSetting']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLInviteeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Invitee'] = GQLResolversParentTypes['Invitee']
+> = ResolversObject<{
+  __resolveType: TypeResolveFn<'Person' | 'User', ParentType, ContextType>
+}>
 
-export type GQLUserStatusResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['UserStatus'] = GQLResolversParentTypes['UserStatus']> = ResolversObject<{
-  articleCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  changeEmailTimesLeft?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  commentCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  donatedArticleCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  hasEmailLoginPassword?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  hasPaymentPassword?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  momentCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  receivedDonationCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  role?: Resolver<GQLResolversTypes['UserRole'], ParentType, ContextType>;
-  state?: Resolver<GQLResolversTypes['UserState'], ParentType, ContextType>;
-  totalReferredCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  totalWordCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  unreadFollowing?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  unreadNoticeCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLInvitesResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Invites'] = GQLResolversParentTypes['Invites']
+> = ResolversObject<{
+  accepted?: Resolver<
+    GQLResolversTypes['InvitationConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLInvitesAcceptedArgs, 'input'>
+  >
+  pending?: Resolver<
+    GQLResolversTypes['InvitationConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLInvitesPendingArgs, 'input'>
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
-export type GQLWalletResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Wallet'] = GQLResolversParentTypes['Wallet']> = ResolversObject<{
-  balance?: Resolver<GQLResolversTypes['Balance'], ParentType, ContextType>;
-  cardLast4?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  customerPortal?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  stripeAccount?: Resolver<Maybe<GQLResolversTypes['StripeAccount']>, ParentType, ContextType>;
-  transactions?: Resolver<GQLResolversTypes['TransactionConnection'], ParentType, ContextType, RequireFields<GQLWalletTransactionsArgs, 'input'>>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLLikerResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Liker'] = GQLResolversParentTypes['Liker']
+> = ResolversObject<{
+  civicLiker?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  likerId?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  total?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
-export type GQLWithdrawLockedTokensResultResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['WithdrawLockedTokensResult'] = GQLResolversParentTypes['WithdrawLockedTokensResult']> = ResolversObject<{
-  transaction?: Resolver<GQLResolversTypes['Transaction'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLMemberResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Member'] = GQLResolversParentTypes['Member']
+> = ResolversObject<{
+  price?: Resolver<GQLResolversTypes['Price'], ParentType, ContextType>
+  user?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
-export type GQLWritingResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['Writing'] = GQLResolversParentTypes['Writing']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'Article' | 'Comment' | 'Moment', ParentType, ContextType>;
-}>;
+export type GQLMemberConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['MemberConnection'] = GQLResolversParentTypes['MemberConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['MemberEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
-export type GQLWritingChallengeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['WritingChallenge'] = GQLResolversParentTypes['WritingChallenge']> = ResolversObject<{
-  announcements?: Resolver<Array<GQLResolversTypes['Article']>, ParentType, ContextType>;
-  application?: Resolver<Maybe<GQLResolversTypes['CampaignApplication']>, ParentType, ContextType>;
-  applicationPeriod?: Resolver<Maybe<GQLResolversTypes['DatetimeRange']>, ParentType, ContextType>;
-  articles?: Resolver<GQLResolversTypes['CampaignArticleConnection'], ParentType, ContextType, RequireFields<GQLWritingChallengeArticlesArgs, 'input'>>;
-  channelEnabled?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  cover?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  description?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType, Partial<GQLWritingChallengeDescriptionArgs>>;
-  discussion?: Resolver<GQLResolversTypes['CommentConnection'], ParentType, ContextType, RequireFields<GQLWritingChallengeDiscussionArgs, 'input'>>;
-  discussionCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  enableQuoteWall?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  featuredDescription?: Resolver<GQLResolversTypes['String'], ParentType, ContextType, Partial<GQLWritingChallengeFeaturedDescriptionArgs>>;
-  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>;
-  isManager?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  link?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  name?: Resolver<GQLResolversTypes['String'], ParentType, ContextType, Partial<GQLWritingChallengeNameArgs>>;
-  navbarTitle?: Resolver<GQLResolversTypes['String'], ParentType, ContextType, Partial<GQLWritingChallengeNavbarTitleArgs>>;
-  organizers?: Resolver<Array<GQLResolversTypes['User']>, ParentType, ContextType>;
-  oss?: Resolver<GQLResolversTypes['CampaignOSS'], ParentType, ContextType>;
-  participants?: Resolver<GQLResolversTypes['CampaignParticipantConnection'], ParentType, ContextType, RequireFields<GQLWritingChallengeParticipantsArgs, 'input'>>;
-  quoteCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  quotes?: Resolver<GQLResolversTypes['QuoteConnection'], ParentType, ContextType, RequireFields<GQLWritingChallengeQuotesArgs, 'input'>>;
-  shortHash?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  showAd?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  showOther?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  stages?: Resolver<Array<GQLResolversTypes['CampaignStage']>, ParentType, ContextType>;
-  state?: Resolver<GQLResolversTypes['CampaignState'], ParentType, ContextType>;
-  writingPeriod?: Resolver<Maybe<GQLResolversTypes['DatetimeRange']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLMemberEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['MemberEdge'] = GQLResolversParentTypes['MemberEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Member'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
-export type GQLWritingConnectionResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['WritingConnection'] = GQLResolversParentTypes['WritingConnection']> = ResolversObject<{
-  edges?: Resolver<Maybe<Array<GQLResolversTypes['WritingEdge']>>, ParentType, ContextType>;
-  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>;
-  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLModerationCaseResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ModerationCase'] = GQLResolversParentTypes['ModerationCase']
+> = ResolversObject<{
+  automationRole?: Resolver<
+    GQLResolversTypes['ModerationAutomationRole'],
+    ParentType,
+    ContextType
+  >
+  closedAt?: Resolver<
+    Maybe<GQLResolversTypes['DateTime']>,
+    ParentType,
+    ContextType
+  >
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  noticeState?: Resolver<
+    GQLResolversTypes['ModerationNoticeState'],
+    ParentType,
+    ContextType
+  >
+  outcome?: Resolver<
+    Maybe<GQLResolversTypes['ModerationCaseOutcome']>,
+    ParentType,
+    ContextType
+  >
+  publicReason?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  reason?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  resolvedAt?: Resolver<
+    Maybe<GQLResolversTypes['DateTime']>,
+    ParentType,
+    ContextType
+  >
+  source?: Resolver<
+    GQLResolversTypes['ModerationCaseSource'],
+    ParentType,
+    ContextType
+  >
+  status?: Resolver<
+    GQLResolversTypes['ModerationCaseStatus'],
+    ParentType,
+    ContextType
+  >
+  targetType?: Resolver<
+    GQLResolversTypes['ModerationTargetType'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
-export type GQLWritingEdgeResolvers<ContextType = Context, ParentType extends GQLResolversParentTypes['WritingEdge'] = GQLResolversParentTypes['WritingEdge']> = ResolversObject<{
-  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<GQLResolversTypes['Writing'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
+export type GQLMomentResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Moment'] = GQLResolversParentTypes['Moment']
+> = ResolversObject<{
+  adStatus?: Resolver<GQLResolversTypes['AdStatus'], ParentType, ContextType>
+  articles?: Resolver<
+    Array<GQLResolversTypes['Article']>,
+    ParentType,
+    ContextType
+  >
+  assets?: Resolver<Array<GQLResolversTypes['Asset']>, ParentType, ContextType>
+  author?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
+  commentCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  commentedFollowees?: Resolver<
+    Array<GQLResolversTypes['User']>,
+    ParentType,
+    ContextType
+  >
+  comments?: Resolver<
+    GQLResolversTypes['CommentConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMomentCommentsArgs, 'input'>
+  >
+  content?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  likeCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  liked?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  shortHash?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  spamStatus?: Resolver<
+    GQLResolversTypes['SpamStatus'],
+    ParentType,
+    ContextType
+  >
+  state?: Resolver<GQLResolversTypes['MomentState'], ParentType, ContextType>
+  tags?: Resolver<
+    Array<Maybe<GQLResolversTypes['Tag']>>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLMomentConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['MomentConnection'] = GQLResolversParentTypes['MomentConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['MomentEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLMomentEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['MomentEdge'] = GQLResolversParentTypes['MomentEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Moment'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLMomentFeedApplicationResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['MomentFeedApplication'] = GQLResolversParentTypes['MomentFeedApplication']
+> = ResolversObject<{
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  reviewedBy?: Resolver<
+    Maybe<GQLResolversTypes['MomentFeedUserReviewedBy']>,
+    ParentType,
+    ContextType
+  >
+  reviewer?: Resolver<Maybe<GQLResolversTypes['User']>, ParentType, ContextType>
+  state?: Resolver<
+    GQLResolversTypes['MomentFeedUserState'],
+    ParentType,
+    ContextType
+  >
+  updatedAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLMomentNoticeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['MomentNotice'] = GQLResolversParentTypes['MomentNotice']
+> = ResolversObject<{
+  actors?: Resolver<
+    Maybe<Array<GQLResolversTypes['User']>>,
+    ParentType,
+    ContextType
+  >
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  target?: Resolver<GQLResolversTypes['Moment'], ParentType, ContextType>
+  type?: Resolver<
+    GQLResolversTypes['MomentNoticeType'],
+    ParentType,
+    ContextType
+  >
+  unread?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLMonthlyDatumResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['MonthlyDatum'] = GQLResolversParentTypes['MonthlyDatum']
+> = ResolversObject<{
+  date?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  value?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLMutationResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Mutation'] = GQLResolversParentTypes['Mutation']
+> = ResolversObject<{
+  addBlockedSearchKeyword?: Resolver<
+    GQLResolversTypes['BlockedSearchKeyword'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationAddBlockedSearchKeywordArgs, 'input'>
+  >
+  addCollectionsArticles?: Resolver<
+    Array<GQLResolversTypes['Collection']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationAddCollectionsArticlesArgs, 'input'>
+  >
+  addCredit?: Resolver<
+    GQLResolversTypes['AddCreditResult'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationAddCreditArgs, 'input'>
+  >
+  addCurationChannelArticles?: Resolver<
+    GQLResolversTypes['CurationChannel'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationAddCurationChannelArticlesArgs, 'input'>
+  >
+  addSocialLogin?: Resolver<
+    GQLResolversTypes['User'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationAddSocialLoginArgs, 'input'>
+  >
+  addWalletLogin?: Resolver<
+    GQLResolversTypes['User'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationAddWalletLoginArgs, 'input'>
+  >
+  applyCampaign?: Resolver<
+    GQLResolversTypes['Campaign'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationApplyCampaignArgs, 'input'>
+  >
+  applyMomentFeed?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
+  appreciateArticle?: Resolver<
+    GQLResolversTypes['Article'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationAppreciateArticleArgs, 'input'>
+  >
+  archiveUsers?: Resolver<
+    GQLResolversTypes['ArchiveUsersResult'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationArchiveUsersArgs, 'input'>
+  >
+  banCampaignArticles?: Resolver<
+    GQLResolversTypes['Campaign'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationBanCampaignArticlesArgs, 'input'>
+  >
+  claimLogbooks?: Resolver<
+    GQLResolversTypes['ClaimLogbooksResult'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationClaimLogbooksArgs, 'input'>
+  >
+  claimPersonhoodBadge?: Resolver<
+    GQLResolversTypes['User'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationClaimPersonhoodBadgeArgs, 'input'>
+  >
+  classifyArticlesChannels?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationClassifyArticlesChannelsArgs, 'input'>
+  >
+  clearCommunityWatchOriginalContent?: Resolver<
+    GQLResolversTypes['CommunityWatchAction'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationClearCommunityWatchOriginalContentArgs, 'input'>
+  >
+  clearReadHistory?: Resolver<
+    GQLResolversTypes['User'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationClearReadHistoryArgs, 'input'>
+  >
+  clearSearchHistory?: Resolver<
+    Maybe<GQLResolversTypes['Boolean']>,
+    ParentType,
+    ContextType
+  >
+  communityWatchRemoveComment?: Resolver<
+    GQLResolversTypes['Comment'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationCommunityWatchRemoveCommentArgs, 'input'>
+  >
+  confirmVerificationCode?: Resolver<
+    GQLResolversTypes['ID'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationConfirmVerificationCodeArgs, 'input'>
+  >
+  connectStripeAccount?: Resolver<
+    GQLResolversTypes['ConnectStripeAccountResult'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationConnectStripeAccountArgs, 'input'>
+  >
+  createPersonhoodHandoff?: Resolver<
+    GQLResolversTypes['PersonhoodHandoff'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationCreatePersonhoodHandoffArgs, 'input'>
+  >
+  deleteAnnouncements?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationDeleteAnnouncementsArgs, 'input'>
+  >
+  deleteBlockedSearchKeywords?: Resolver<
+    Maybe<GQLResolversTypes['Boolean']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationDeleteBlockedSearchKeywordsArgs, 'input'>
+  >
+  deleteCollectionArticles?: Resolver<
+    GQLResolversTypes['Collection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationDeleteCollectionArticlesArgs, 'input'>
+  >
+  deleteCollections?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationDeleteCollectionsArgs, 'input'>
+  >
+  deleteComment?: Resolver<
+    GQLResolversTypes['Comment'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationDeleteCommentArgs, 'input'>
+  >
+  deleteCurationChannelArticles?: Resolver<
+    GQLResolversTypes['CurationChannel'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationDeleteCurationChannelArticlesArgs, 'input'>
+  >
+  deleteDraft?: Resolver<
+    Maybe<GQLResolversTypes['Boolean']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationDeleteDraftArgs, 'input'>
+  >
+  deleteMoment?: Resolver<
+    GQLResolversTypes['Moment'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationDeleteMomentArgs, 'input'>
+  >
+  deleteQuote?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationDeleteQuoteArgs, 'input'>
+  >
+  deleteTags?: Resolver<
+    Maybe<GQLResolversTypes['Boolean']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationDeleteTagsArgs, 'input'>
+  >
+  directImageUpload?: Resolver<
+    GQLResolversTypes['Asset'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationDirectImageUploadArgs, 'input'>
+  >
+  dismissSpamRing?: Resolver<
+    GQLResolversTypes['SpamRing'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationDismissSpamRingArgs, 'input'>
+  >
+  editArticle?: Resolver<
+    GQLResolversTypes['Article'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationEditArticleArgs, 'input'>
+  >
+  emailLogin?: Resolver<
+    GQLResolversTypes['AuthResult'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationEmailLoginArgs, 'input'>
+  >
+  freezeSpamRing?: Resolver<
+    GQLResolversTypes['FreezeSpamRingResult'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationFreezeSpamRingArgs, 'input'>
+  >
+  generateSigningMessage?: Resolver<
+    GQLResolversTypes['SigningMessageResult'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationGenerateSigningMessageArgs, 'input'>
+  >
+  invite?: Resolver<
+    Maybe<Array<GQLResolversTypes['Invitation']>>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationInviteArgs, 'input'>
+  >
+  likeCollection?: Resolver<
+    GQLResolversTypes['Collection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationLikeCollectionArgs, 'input'>
+  >
+  likeMoment?: Resolver<
+    GQLResolversTypes['Moment'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationLikeMomentArgs, 'input'>
+  >
+  logRecord?: Resolver<
+    Maybe<GQLResolversTypes['Boolean']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationLogRecordArgs, 'input'>
+  >
+  markAllNoticesAsRead?: Resolver<
+    Maybe<GQLResolversTypes['Boolean']>,
+    ParentType,
+    ContextType
+  >
+  mergeTags?: Resolver<
+    GQLResolversTypes['Tag'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationMergeTagsArgs, 'input'>
+  >
+  migration?: Resolver<
+    Maybe<GQLResolversTypes['Boolean']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationMigrationArgs, 'input'>
+  >
+  payTo?: Resolver<
+    GQLResolversTypes['PayToResult'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPayToArgs, 'input'>
+  >
+  payout?: Resolver<
+    GQLResolversTypes['Transaction'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPayoutArgs, 'input'>
+  >
+  pinComment?: Resolver<
+    GQLResolversTypes['Comment'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPinCommentArgs, 'input'>
+  >
+  publishArticle?: Resolver<
+    GQLResolversTypes['Draft'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPublishArticleArgs, 'input'>
+  >
+  putAnnouncement?: Resolver<
+    GQLResolversTypes['Announcement'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPutAnnouncementArgs, 'input'>
+  >
+  putArticleFederationSetting?: Resolver<
+    GQLResolversTypes['ArticleFederationSetting'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPutArticleFederationSettingArgs, 'input'>
+  >
+  putCircle?: Resolver<
+    GQLResolversTypes['Circle'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPutCircleArgs, 'input'>
+  >
+  putCircleArticles?: Resolver<
+    GQLResolversTypes['Circle'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPutCircleArticlesArgs, 'input'>
+  >
+  putCollection?: Resolver<
+    GQLResolversTypes['Collection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPutCollectionArgs, 'input'>
+  >
+  putComment?: Resolver<
+    GQLResolversTypes['Comment'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPutCommentArgs, 'input'>
+  >
+  putCurationChannel?: Resolver<
+    GQLResolversTypes['CurationChannel'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPutCurationChannelArgs, 'input'>
+  >
+  putDraft?: Resolver<
+    GQLResolversTypes['Draft'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPutDraftArgs, 'input'>
+  >
+  putFeaturedTags?: Resolver<
+    Maybe<Array<GQLResolversTypes['Tag']>>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPutFeaturedTagsArgs, 'input'>
+  >
+  putIcymiTopic?: Resolver<
+    Maybe<GQLResolversTypes['IcymiTopic']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPutIcymiTopicArgs, 'input'>
+  >
+  putMoment?: Resolver<
+    GQLResolversTypes['Moment'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPutMomentArgs, 'input'>
+  >
+  putOAuthClient?: Resolver<
+    Maybe<GQLResolversTypes['OAuthClient']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPutOAuthClientArgs, 'input'>
+  >
+  putQuote?: Resolver<
+    GQLResolversTypes['Quote'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPutQuoteArgs, 'input'>
+  >
+  putRemark?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPutRemarkArgs, 'input'>
+  >
+  putRestrictedUsers?: Resolver<
+    Array<GQLResolversTypes['User']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPutRestrictedUsersArgs, 'input'>
+  >
+  putSkippedListItem?: Resolver<
+    Maybe<Array<GQLResolversTypes['SkippedListItem']>>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPutSkippedListItemArgs, 'input'>
+  >
+  putTagChannel?: Resolver<
+    GQLResolversTypes['Tag'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPutTagChannelArgs, 'input'>
+  >
+  putTopicChannel?: Resolver<
+    GQLResolversTypes['TopicChannel'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPutTopicChannelArgs, 'input'>
+  >
+  putUserFeatureFlags?: Resolver<
+    Array<GQLResolversTypes['User']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPutUserFeatureFlagsArgs, 'input'>
+  >
+  putUserFederationSetting?: Resolver<
+    GQLResolversTypes['UserFederationSetting'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPutUserFederationSettingArgs, 'input'>
+  >
+  putWritingChallenge?: Resolver<
+    GQLResolversTypes['WritingChallenge'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationPutWritingChallengeArgs, 'input'>
+  >
+  readArticle?: Resolver<
+    GQLResolversTypes['Article'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationReadArticleArgs, 'input'>
+  >
+  removeSocialLogin?: Resolver<
+    GQLResolversTypes['User'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationRemoveSocialLoginArgs, 'input'>
+  >
+  removeWalletLogin?: Resolver<
+    GQLResolversTypes['User'],
+    ParentType,
+    ContextType
+  >
+  renameTag?: Resolver<
+    GQLResolversTypes['Tag'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationRenameTagArgs, 'input'>
+  >
+  reorderChannels?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationReorderChannelsArgs, 'input'>
+  >
+  reorderCollectionArticles?: Resolver<
+    GQLResolversTypes['Collection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationReorderCollectionArticlesArgs, 'input'>
+  >
+  resetLikerId?: Resolver<
+    GQLResolversTypes['User'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationResetLikerIdArgs, 'input'>
+  >
+  resetPassword?: Resolver<
+    Maybe<GQLResolversTypes['Boolean']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationResetPasswordArgs, 'input'>
+  >
+  restoreCommunityWatchComment?: Resolver<
+    GQLResolversTypes['CommunityWatchAction'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationRestoreCommunityWatchCommentArgs, 'input'>
+  >
+  reviewTopicChannelFeedback?: Resolver<
+    GQLResolversTypes['TopicChannelFeedback'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationReviewTopicChannelFeedbackArgs, 'input'>
+  >
+  sendCampaignAnnouncement?: Resolver<
+    Maybe<GQLResolversTypes['Boolean']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationSendCampaignAnnouncementArgs, 'input'>
+  >
+  sendVerificationCode?: Resolver<
+    Maybe<GQLResolversTypes['Boolean']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationSendVerificationCodeArgs, 'input'>
+  >
+  setAdStatus?: Resolver<
+    GQLResolversTypes['Article'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationSetAdStatusArgs, 'input'>
+  >
+  setArticleFederationSetting?: Resolver<
+    GQLResolversTypes['ArticleFederationSetting'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationSetArticleFederationSettingArgs, 'input'>
+  >
+  setArticleTopicChannels?: Resolver<
+    GQLResolversTypes['Article'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationSetArticleTopicChannelsArgs, 'input'>
+  >
+  setBoost?: Resolver<
+    GQLResolversTypes['Node'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationSetBoostArgs, 'input'>
+  >
+  setCurrency?: Resolver<
+    GQLResolversTypes['User'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationSetCurrencyArgs, 'input'>
+  >
+  setEmail?: Resolver<
+    GQLResolversTypes['User'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationSetEmailArgs, 'input'>
+  >
+  setFeature?: Resolver<
+    GQLResolversTypes['Feature'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationSetFeatureArgs, 'input'>
+  >
+  setPassword?: Resolver<
+    GQLResolversTypes['User'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationSetPasswordArgs, 'input'>
+  >
+  setSpamStatus?: Resolver<
+    GQLResolversTypes['Writing'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationSetSpamStatusArgs, 'input'>
+  >
+  setUserName?: Resolver<
+    GQLResolversTypes['User'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationSetUserNameArgs, 'input'>
+  >
+  setViewerFederationSetting?: Resolver<
+    GQLResolversTypes['UserFederationSetting'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationSetViewerFederationSettingArgs, 'input'>
+  >
+  setWritingAdStatus?: Resolver<
+    GQLResolversTypes['Writing'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationSetWritingAdStatusArgs, 'input'>
+  >
+  singleFileUpload?: Resolver<
+    GQLResolversTypes['Asset'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationSingleFileUploadArgs, 'input'>
+  >
+  socialLogin?: Resolver<
+    GQLResolversTypes['AuthResult'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationSocialLoginArgs, 'input'>
+  >
+  submitReport?: Resolver<
+    GQLResolversTypes['Report'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationSubmitReportArgs, 'input'>
+  >
+  submitTopicChannelFeedback?: Resolver<
+    GQLResolversTypes['TopicChannelFeedback'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationSubmitTopicChannelFeedbackArgs, 'input'>
+  >
+  subscribeCircle?: Resolver<
+    GQLResolversTypes['SubscribeCircleResult'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationSubscribeCircleArgs, 'input'>
+  >
+  toggleArticleRecommend?: Resolver<
+    GQLResolversTypes['Article'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationToggleArticleRecommendArgs, 'input'>
+  >
+  toggleBlockUser?: Resolver<
+    GQLResolversTypes['User'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationToggleBlockUserArgs, 'input'>
+  >
+  toggleBookmarkArticle?: Resolver<
+    GQLResolversTypes['Article'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationToggleBookmarkArticleArgs, 'input'>
+  >
+  toggleBookmarkTag?: Resolver<
+    GQLResolversTypes['Tag'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationToggleBookmarkTagArgs, 'input'>
+  >
+  toggleFollowCircle?: Resolver<
+    GQLResolversTypes['Circle'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationToggleFollowCircleArgs, 'input'>
+  >
+  toggleFollowTag?: Resolver<
+    GQLResolversTypes['Tag'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationToggleFollowTagArgs, 'input'>
+  >
+  toggleFollowUser?: Resolver<
+    GQLResolversTypes['User'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationToggleFollowUserArgs, 'input'>
+  >
+  togglePinChannelArticles?: Resolver<
+    Array<GQLResolversTypes['Channel']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationTogglePinChannelArticlesArgs, 'input'>
+  >
+  togglePinComment?: Resolver<
+    GQLResolversTypes['Comment'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationTogglePinCommentArgs, 'input'>
+  >
+  toggleSeedingUsers?: Resolver<
+    Array<Maybe<GQLResolversTypes['User']>>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationToggleSeedingUsersArgs, 'input'>
+  >
+  toggleSubscribeArticle?: Resolver<
+    GQLResolversTypes['Article'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationToggleSubscribeArticleArgs, 'input'>
+  >
+  toggleUsersBadge?: Resolver<
+    Array<Maybe<GQLResolversTypes['User']>>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationToggleUsersBadgeArgs, 'input'>
+  >
+  toggleWritingChallengeFeaturedArticles?: Resolver<
+    GQLResolversTypes['Campaign'],
+    ParentType,
+    ContextType,
+    RequireFields<
+      GQLMutationToggleWritingChallengeFeaturedArticlesArgs,
+      'input'
+    >
+  >
+  unbindLikerId?: Resolver<
+    GQLResolversTypes['User'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationUnbindLikerIdArgs, 'input'>
+  >
+  unfreezeSpamRing?: Resolver<
+    GQLResolversTypes['UnfreezeSpamRingResult'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationUnfreezeSpamRingArgs, 'input'>
+  >
+  unlikeCollection?: Resolver<
+    GQLResolversTypes['Collection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationUnlikeCollectionArgs, 'input'>
+  >
+  unlikeMoment?: Resolver<
+    GQLResolversTypes['Moment'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationUnlikeMomentArgs, 'input'>
+  >
+  unpinComment?: Resolver<
+    GQLResolversTypes['Comment'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationUnpinCommentArgs, 'input'>
+  >
+  unsubscribeCircle?: Resolver<
+    GQLResolversTypes['Circle'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationUnsubscribeCircleArgs, 'input'>
+  >
+  unvoteComment?: Resolver<
+    GQLResolversTypes['Comment'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationUnvoteCommentArgs, 'input'>
+  >
+  updateArticleSensitive?: Resolver<
+    GQLResolversTypes['Article'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationUpdateArticleSensitiveArgs, 'input'>
+  >
+  updateArticleState?: Resolver<
+    GQLResolversTypes['Article'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationUpdateArticleStateArgs, 'input'>
+  >
+  updateCampaignApplicationState?: Resolver<
+    GQLResolversTypes['Campaign'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationUpdateCampaignApplicationStateArgs, 'input'>
+  >
+  updateCommentsState?: Resolver<
+    Array<GQLResolversTypes['Comment']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationUpdateCommentsStateArgs, 'input'>
+  >
+  updateCommunityWatchActionState?: Resolver<
+    GQLResolversTypes['CommunityWatchAction'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationUpdateCommunityWatchActionStateArgs, 'input'>
+  >
+  updateModerationCase?: Resolver<
+    GQLResolversTypes['ModerationCase'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationUpdateModerationCaseArgs, 'input'>
+  >
+  updateMomentFeedApplicationState?: Resolver<
+    GQLResolversTypes['User'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationUpdateMomentFeedApplicationStateArgs, 'input'>
+  >
+  updateNotificationSetting?: Resolver<
+    GQLResolversTypes['User'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationUpdateNotificationSettingArgs, 'input'>
+  >
+  updateUserExtra?: Resolver<
+    GQLResolversTypes['User'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationUpdateUserExtraArgs, 'input'>
+  >
+  updateUserInfo?: Resolver<
+    GQLResolversTypes['User'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationUpdateUserInfoArgs, 'input'>
+  >
+  updateUserRole?: Resolver<
+    GQLResolversTypes['User'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationUpdateUserRoleArgs, 'input'>
+  >
+  updateUserState?: Resolver<
+    Maybe<Array<GQLResolversTypes['User']>>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationUpdateUserStateArgs, 'input'>
+  >
+  upsertSpamRingCandidates?: Resolver<
+    GQLResolversTypes['UpsertSpamRingCandidatesResult'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationUpsertSpamRingCandidatesArgs, 'input'>
+  >
+  userLogout?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  verifyEmail?: Resolver<
+    GQLResolversTypes['AuthResult'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationVerifyEmailArgs, 'input'>
+  >
+  voteComment?: Resolver<
+    GQLResolversTypes['Comment'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationVoteCommentArgs, 'input'>
+  >
+  walletLogin?: Resolver<
+    GQLResolversTypes['AuthResult'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLMutationWalletLoginArgs, 'input'>
+  >
+  withdrawLockedTokens?: Resolver<
+    GQLResolversTypes['WithdrawLockedTokensResult'],
+    ParentType,
+    ContextType
+  >
+}>
+
+export type GQLNftAssetResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['NFTAsset'] = GQLResolversParentTypes['NFTAsset']
+> = ResolversObject<{
+  collectionName?: Resolver<
+    GQLResolversTypes['String'],
+    ParentType,
+    ContextType
+  >
+  contractAddress?: Resolver<
+    GQLResolversTypes['String'],
+    ParentType,
+    ContextType
+  >
+  description?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  imagePreviewUrl?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  imageUrl?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  name?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLNodeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Node'] = GQLResolversParentTypes['Node']
+> = ResolversObject<{
+  __resolveType: TypeResolveFn<
+    | 'Article'
+    | 'ArticleVersion'
+    | 'Circle'
+    | 'Collection'
+    | 'Comment'
+    | 'CurationChannel'
+    | 'Draft'
+    | 'IcymiTopic'
+    | 'Moment'
+    | 'Report'
+    | 'SpamRing'
+    | 'Tag'
+    | 'TopicChannel'
+    | 'User'
+    | 'WritingChallenge',
+    ParentType,
+    ContextType
+  >
+}>
+
+export type GQLNoticeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Notice'] = GQLResolversParentTypes['Notice']
+> = ResolversObject<{
+  __resolveType: TypeResolveFn<
+    | 'ArticleArticleNotice'
+    | 'ArticleNotice'
+    | 'CampaignArticleNotice'
+    | 'CircleNotice'
+    | 'CollectionNotice'
+    | 'CommentCommentNotice'
+    | 'CommentNotice'
+    | 'MomentNotice'
+    | 'OfficialAnnouncementNotice'
+    | 'TransactionNotice'
+    | 'UserNotice',
+    ParentType,
+    ContextType
+  >
+}>
+
+export type GQLNoticeConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['NoticeConnection'] = GQLResolversParentTypes['NoticeConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['NoticeEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLNoticeEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['NoticeEdge'] = GQLResolversParentTypes['NoticeEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Notice'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLNotificationSettingResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['NotificationSetting'] = GQLResolversParentTypes['NotificationSetting']
+> = ResolversObject<{
+  articleNewAppreciation?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  articleNewCollected?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  articleNewComment?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  articleNewSubscription?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  circleMemberNewBroadcastReply?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  circleMemberNewDiscussion?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  circleMemberNewDiscussionReply?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  circleNewFollower?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  circleNewSubscriber?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  circleNewUnsubscriber?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  email?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  inCircleNewArticle?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  inCircleNewBroadcast?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  inCircleNewBroadcastReply?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  inCircleNewDiscussion?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  inCircleNewDiscussionReply?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  mention?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  newComment?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  newLike?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  userNewFollower?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLOAuthClientResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['OAuthClient'] = GQLResolversParentTypes['OAuthClient']
+> = ResolversObject<{
+  avatar?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  description?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  grantTypes?: Resolver<
+    Maybe<Array<GQLResolversTypes['GrantType']>>,
+    ParentType,
+    ContextType
+  >
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  name?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  redirectURIs?: Resolver<
+    Maybe<Array<GQLResolversTypes['String']>>,
+    ParentType,
+    ContextType
+  >
+  scope?: Resolver<
+    Maybe<Array<GQLResolversTypes['String']>>,
+    ParentType,
+    ContextType
+  >
+  secret?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  user?: Resolver<Maybe<GQLResolversTypes['User']>, ParentType, ContextType>
+  website?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLOAuthClientConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['OAuthClientConnection'] = GQLResolversParentTypes['OAuthClientConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['OAuthClientEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLOAuthClientEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['OAuthClientEdge'] = GQLResolversParentTypes['OAuthClientEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['OAuthClient'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLOssResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['OSS'] = GQLResolversParentTypes['OSS']
+> = ResolversObject<{
+  articles?: Resolver<
+    GQLResolversTypes['ArticleConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLOssArticlesArgs, 'input'>
+  >
+  badgedUsers?: Resolver<
+    GQLResolversTypes['UserConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLOssBadgedUsersArgs, 'input'>
+  >
+  comments?: Resolver<
+    GQLResolversTypes['CommentConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLOssCommentsArgs, 'input'>
+  >
+  icymiTopics?: Resolver<
+    GQLResolversTypes['IcymiTopicConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLOssIcymiTopicsArgs, 'input'>
+  >
+  momentFeedUsers?: Resolver<
+    GQLResolversTypes['UserConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLOssMomentFeedUsersArgs, 'input'>
+  >
+  moments?: Resolver<
+    GQLResolversTypes['MomentConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLOssMomentsArgs, 'input'>
+  >
+  oauthClients?: Resolver<
+    GQLResolversTypes['OAuthClientConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLOssOauthClientsArgs, 'input'>
+  >
+  reports?: Resolver<
+    GQLResolversTypes['ReportConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLOssReportsArgs, 'input'>
+  >
+  restrictedUsers?: Resolver<
+    GQLResolversTypes['UserConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLOssRestrictedUsersArgs, 'input'>
+  >
+  seedingUsers?: Resolver<
+    GQLResolversTypes['UserConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLOssSeedingUsersArgs, 'input'>
+  >
+  skippedListItems?: Resolver<
+    GQLResolversTypes['SkippedListItemsConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLOssSkippedListItemsArgs, 'input'>
+  >
+  spamRings?: Resolver<
+    GQLResolversTypes['SpamRingConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLOssSpamRingsArgs, 'input'>
+  >
+  tags?: Resolver<
+    GQLResolversTypes['TagConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLOssTagsArgs, 'input'>
+  >
+  topicChannelFeedbacks?: Resolver<
+    GQLResolversTypes['TopicChannelFeedbackConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLOssTopicChannelFeedbacksArgs, 'input'>
+  >
+  users?: Resolver<
+    GQLResolversTypes['UserConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLOssUsersArgs, 'input'>
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLOfficialResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Official'] = GQLResolversParentTypes['Official']
+> = ResolversObject<{
+  announcements?: Resolver<
+    Maybe<Array<GQLResolversTypes['Announcement']>>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLOfficialAnnouncementsArgs, 'input'>
+  >
+  features?: Resolver<
+    Array<GQLResolversTypes['Feature']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLOfficialAnnouncementNoticeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['OfficialAnnouncementNotice'] = GQLResolversParentTypes['OfficialAnnouncementNotice']
+> = ResolversObject<{
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  link?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  message?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  unread?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLPageInfoResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['PageInfo'] = GQLResolversParentTypes['PageInfo']
+> = ResolversObject<{
+  endCursor?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  hasNextPage?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  hasPreviousPage?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  startCursor?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLPayToResultResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['PayToResult'] = GQLResolversParentTypes['PayToResult']
+> = ResolversObject<{
+  redirectUrl?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  transaction?: Resolver<
+    GQLResolversTypes['Transaction'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLPersonResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Person'] = GQLResolversParentTypes['Person']
+> = ResolversObject<{
+  email?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLPersonhoodHandoffResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['PersonhoodHandoff'] = GQLResolversParentTypes['PersonhoodHandoff']
+> = ResolversObject<{
+  expiresAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  token?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLPinHistoryResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['PinHistory'] = GQLResolversParentTypes['PinHistory']
+> = ResolversObject<{
+  feed?: Resolver<GQLResolversTypes['Node'], ParentType, ContextType>
+  pinnedAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLPinnableWorkResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['PinnableWork'] = GQLResolversParentTypes['PinnableWork']
+> = ResolversObject<{
+  __resolveType: TypeResolveFn<
+    'Article' | 'Collection',
+    ParentType,
+    ContextType
+  >
+}>
+
+export type GQLPriceResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Price'] = GQLResolversParentTypes['Price']
+> = ResolversObject<{
+  amount?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>
+  circle?: Resolver<GQLResolversTypes['Circle'], ParentType, ContextType>
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  currency?: Resolver<
+    GQLResolversTypes['TransactionCurrency'],
+    ParentType,
+    ContextType
+  >
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  state?: Resolver<GQLResolversTypes['PriceState'], ParentType, ContextType>
+  updatedAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLQueryResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Query'] = GQLResolversParentTypes['Query']
+> = ResolversObject<{
+  article?: Resolver<
+    Maybe<GQLResolversTypes['Article']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLQueryArticleArgs, 'input'>
+  >
+  campaign?: Resolver<
+    Maybe<GQLResolversTypes['Campaign']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLQueryCampaignArgs, 'input'>
+  >
+  campaignOrganizers?: Resolver<
+    GQLResolversTypes['UserConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLQueryCampaignOrganizersArgs, 'input'>
+  >
+  campaigns?: Resolver<
+    GQLResolversTypes['CampaignConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLQueryCampaignsArgs, 'input'>
+  >
+  channel?: Resolver<
+    Maybe<GQLResolversTypes['Channel']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLQueryChannelArgs, 'input'>
+  >
+  channels?: Resolver<
+    Array<GQLResolversTypes['Channel']>,
+    ParentType,
+    ContextType,
+    Partial<GQLQueryChannelsArgs>
+  >
+  circle?: Resolver<
+    Maybe<GQLResolversTypes['Circle']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLQueryCircleArgs, 'input'>
+  >
+  communityWatchAction?: Resolver<
+    Maybe<GQLResolversTypes['CommunityWatchAction']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLQueryCommunityWatchActionArgs, 'input'>
+  >
+  communityWatchActions?: Resolver<
+    GQLResolversTypes['CommunityWatchActionConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLQueryCommunityWatchActionsArgs, 'input'>
+  >
+  exchangeRates?: Resolver<
+    Maybe<Array<GQLResolversTypes['ExchangeRate']>>,
+    ParentType,
+    ContextType,
+    Partial<GQLQueryExchangeRatesArgs>
+  >
+  frequentSearch?: Resolver<
+    Maybe<Array<GQLResolversTypes['String']>>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLQueryFrequentSearchArgs, 'input'>
+  >
+  moment?: Resolver<
+    Maybe<GQLResolversTypes['Moment']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLQueryMomentArgs, 'input'>
+  >
+  node?: Resolver<
+    Maybe<GQLResolversTypes['Node']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLQueryNodeArgs, 'input'>
+  >
+  nodes?: Resolver<
+    Maybe<Array<GQLResolversTypes['Node']>>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLQueryNodesArgs, 'input'>
+  >
+  oauthClient?: Resolver<
+    Maybe<GQLResolversTypes['OAuthClient']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLQueryOauthClientArgs, 'input'>
+  >
+  oauthRequestToken?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  official?: Resolver<GQLResolversTypes['Official'], ParentType, ContextType>
+  oss?: Resolver<GQLResolversTypes['OSS'], ParentType, ContextType>
+  search?: Resolver<
+    GQLResolversTypes['SearchResultConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLQuerySearchArgs, 'input'>
+  >
+  user?: Resolver<
+    Maybe<GQLResolversTypes['User']>,
+    ParentType,
+    ContextType,
+    RequireFields<GQLQueryUserArgs, 'input'>
+  >
+  viewer?: Resolver<Maybe<GQLResolversTypes['User']>, ParentType, ContextType>
+}>
+
+export type GQLQuoteResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Quote'] = GQLResolversParentTypes['Quote']
+> = ResolversObject<{
+  article?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>
+  content?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  poster?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLQuoteConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['QuoteConnection'] = GQLResolversParentTypes['QuoteConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['QuoteEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLQuoteEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['QuoteEdge'] = GQLResolversParentTypes['QuoteEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Quote'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLReadHistoryResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ReadHistory'] = GQLResolversParentTypes['ReadHistory']
+> = ResolversObject<{
+  article?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>
+  readAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLReadHistoryConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ReadHistoryConnection'] = GQLResolversParentTypes['ReadHistoryConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['ReadHistoryEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLReadHistoryEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ReadHistoryEdge'] = GQLResolversParentTypes['ReadHistoryEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['ReadHistory'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLRecentSearchConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['RecentSearchConnection'] = GQLResolversParentTypes['RecentSearchConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['RecentSearchEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLRecentSearchEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['RecentSearchEdge'] = GQLResolversParentTypes['RecentSearchEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLRecommendationResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Recommendation'] = GQLResolversParentTypes['Recommendation']
+> = ResolversObject<{
+  authors?: Resolver<
+    GQLResolversTypes['UserConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLRecommendationAuthorsArgs, 'input'>
+  >
+  following?: Resolver<
+    GQLResolversTypes['FollowingActivityConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLRecommendationFollowingArgs, 'input'>
+  >
+  hottest?: Resolver<
+    GQLResolversTypes['ArticleConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLRecommendationHottestArgs, 'input'>
+  >
+  hottestMoments?: Resolver<
+    GQLResolversTypes['MomentConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLRecommendationHottestMomentsArgs, 'input'>
+  >
+  icymi?: Resolver<
+    GQLResolversTypes['ArticleConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLRecommendationIcymiArgs, 'input'>
+  >
+  icymiTopic?: Resolver<
+    Maybe<GQLResolversTypes['IcymiTopic']>,
+    ParentType,
+    ContextType
+  >
+  newest?: Resolver<
+    GQLResolversTypes['ArticleConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLRecommendationNewestArgs, 'input'>
+  >
+  tags?: Resolver<
+    GQLResolversTypes['TagConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLRecommendationTagsArgs, 'input'>
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLReportResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Report'] = GQLResolversParentTypes['Report']
+> = ResolversObject<{
+  communityWatchAction?: Resolver<
+    Maybe<GQLResolversTypes['CommunityWatchAction']>,
+    ParentType,
+    ContextType
+  >
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  moderationCase?: Resolver<
+    Maybe<GQLResolversTypes['ModerationCase']>,
+    ParentType,
+    ContextType
+  >
+  reason?: Resolver<GQLResolversTypes['ReportReason'], ParentType, ContextType>
+  reporter?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
+  source?: Resolver<GQLResolversTypes['ReportSource'], ParentType, ContextType>
+  target?: Resolver<GQLResolversTypes['Node'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLReportConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ReportConnection'] = GQLResolversParentTypes['ReportConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['ReportEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLReportEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ReportEdge'] = GQLResolversParentTypes['ReportEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Report'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLResponseResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Response'] = GQLResolversParentTypes['Response']
+> = ResolversObject<{
+  __resolveType: TypeResolveFn<'Article' | 'Comment', ParentType, ContextType>
+}>
+
+export type GQLResponseConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ResponseConnection'] = GQLResolversParentTypes['ResponseConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['ResponseEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLResponseEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['ResponseEdge'] = GQLResolversParentTypes['ResponseEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Response'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLSearchResultConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['SearchResultConnection'] = GQLResolversParentTypes['SearchResultConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['SearchResultEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLSearchResultEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['SearchResultEdge'] = GQLResolversParentTypes['SearchResultEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Node'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLSigningMessageResultResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['SigningMessageResult'] = GQLResolversParentTypes['SigningMessageResult']
+> = ResolversObject<{
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  expiredAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  nonce?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  purpose?: Resolver<
+    GQLResolversTypes['SigningMessagePurpose'],
+    ParentType,
+    ContextType
+  >
+  signingMessage?: Resolver<
+    GQLResolversTypes['String'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLSkippedListItemResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['SkippedListItem'] = GQLResolversParentTypes['SkippedListItem']
+> = ResolversObject<{
+  archived?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  type?: Resolver<
+    GQLResolversTypes['SkippedListItemType'],
+    ParentType,
+    ContextType
+  >
+  updatedAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  uuid?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  value?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLSkippedListItemEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['SkippedListItemEdge'] = GQLResolversParentTypes['SkippedListItemEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<
+    Maybe<GQLResolversTypes['SkippedListItem']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLSkippedListItemsConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['SkippedListItemsConnection'] = GQLResolversParentTypes['SkippedListItemsConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['SkippedListItemEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLSocialAccountResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['SocialAccount'] = GQLResolversParentTypes['SocialAccount']
+> = ResolversObject<{
+  email?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  type?: Resolver<
+    GQLResolversTypes['SocialAccountType'],
+    ParentType,
+    ContextType
+  >
+  userName?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLSpamRingResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['SpamRing'] = GQLResolversParentTypes['SpamRing']
+> = ResolversObject<{
+  detectedAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  events?: Resolver<
+    Array<GQLResolversTypes['SpamRingEvent']>,
+    ParentType,
+    ContextType
+  >
+  fingerprint?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  firstSeenAt?: Resolver<
+    Maybe<GQLResolversTypes['DateTime']>,
+    ParentType,
+    ContextType
+  >
+  frozenAt?: Resolver<
+    Maybe<GQLResolversTypes['DateTime']>,
+    ParentType,
+    ContextType
+  >
+  frozenBy?: Resolver<Maybe<GQLResolversTypes['User']>, ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  lastSeenAt?: Resolver<
+    Maybe<GQLResolversTypes['DateTime']>,
+    ParentType,
+    ContextType
+  >
+  memberSample?: Resolver<
+    Array<GQLResolversTypes['User']>,
+    ParentType,
+    ContextType,
+    Partial<GQLSpamRingMemberSampleArgs>
+  >
+  members?: Resolver<
+    GQLResolversTypes['SpamRingMemberConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLSpamRingMembersArgs, 'input'>
+  >
+  nArticles?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  nAuthors?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  newAccountRatio?: Resolver<
+    Maybe<GQLResolversTypes['Float']>,
+    ParentType,
+    ContextType
+  >
+  note?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  score?: Resolver<Maybe<GQLResolversTypes['Float']>, ParentType, ContextType>
+  severity?: Resolver<
+    Maybe<GQLResolversTypes['SpamRingSeverity']>,
+    ParentType,
+    ContextType
+  >
+  signals?: Resolver<
+    GQLResolversTypes['SpamRingSignals'],
+    ParentType,
+    ContextType
+  >
+  status?: Resolver<
+    GQLResolversTypes['SpamRingStatus'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLSpamRingConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['SpamRingConnection'] = GQLResolversParentTypes['SpamRingConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['SpamRingEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLSpamRingEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['SpamRingEdge'] = GQLResolversParentTypes['SpamRingEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['SpamRing'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLSpamRingEventResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['SpamRingEvent'] = GQLResolversParentTypes['SpamRingEvent']
+> = ResolversObject<{
+  action?: Resolver<
+    GQLResolversTypes['SpamRingEventAction'],
+    ParentType,
+    ContextType
+  >
+  actor?: Resolver<Maybe<GQLResolversTypes['User']>, ParentType, ContextType>
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  detail?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLSpamRingMemberResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['SpamRingMember'] = GQLResolversParentTypes['SpamRingMember']
+> = ResolversObject<{
+  bannedByThisRing?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  skipReason?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  status?: Resolver<
+    GQLResolversTypes['SpamRingMemberStatus'],
+    ParentType,
+    ContextType
+  >
+  user?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLSpamRingMemberConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['SpamRingMemberConnection'] = GQLResolversParentTypes['SpamRingMemberConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['SpamRingMemberEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLSpamRingMemberEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['SpamRingMemberEdge'] = GQLResolversParentTypes['SpamRingMemberEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['SpamRingMember'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLSpamRingSignalsResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['SpamRingSignals'] = GQLResolversParentTypes['SpamRingSignals']
+> = ResolversObject<{
+  botUsernameRatio?: Resolver<
+    Maybe<GQLResolversTypes['Float']>,
+    ParentType,
+    ContextType
+  >
+  contentModelMax?: Resolver<
+    Maybe<GQLResolversTypes['Float']>,
+    ParentType,
+    ContextType
+  >
+  entityRingSize?: Resolver<
+    Maybe<GQLResolversTypes['Int']>,
+    ParentType,
+    ContextType
+  >
+  nearDupRingSize?: Resolver<
+    Maybe<GQLResolversTypes['Int']>,
+    ParentType,
+    ContextType
+  >
+  sampleBrands?: Resolver<
+    Maybe<Array<GQLResolversTypes['String']>>,
+    ParentType,
+    ContextType
+  >
+  sampleCodes?: Resolver<
+    Maybe<Array<GQLResolversTypes['String']>>,
+    ParentType,
+    ContextType
+  >
+  topEntity?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLSpamRingSkipResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['SpamRingSkip'] = GQLResolversParentTypes['SpamRingSkip']
+> = ResolversObject<{
+  reason?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  user?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLSpamStatusResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['SpamStatus'] = GQLResolversParentTypes['SpamStatus']
+> = ResolversObject<{
+  isSpam?: Resolver<
+    Maybe<GQLResolversTypes['Boolean']>,
+    ParentType,
+    ContextType
+  >
+  score?: Resolver<Maybe<GQLResolversTypes['Float']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLStripeAccountResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['StripeAccount'] = GQLResolversParentTypes['StripeAccount']
+> = ResolversObject<{
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  loginUrl?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLSubscribeCircleResultResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['SubscribeCircleResult'] = GQLResolversParentTypes['SubscribeCircleResult']
+> = ResolversObject<{
+  circle?: Resolver<GQLResolversTypes['Circle'], ParentType, ContextType>
+  client_secret?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLTagResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Tag'] = GQLResolversParentTypes['Tag']
+> = ResolversObject<{
+  articles?: Resolver<
+    GQLResolversTypes['ChannelArticleConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLTagArticlesArgs, 'input'>
+  >
+  channelEnabled?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  content?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  deleted?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  isFollower?: Resolver<
+    Maybe<GQLResolversTypes['Boolean']>,
+    ParentType,
+    ContextType
+  >
+  navbarTitle?: Resolver<
+    GQLResolversTypes['String'],
+    ParentType,
+    ContextType,
+    Partial<GQLTagNavbarTitleArgs>
+  >
+  numArticles?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  numAuthors?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  numMoments?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  oss?: Resolver<GQLResolversTypes['TagOSS'], ParentType, ContextType>
+  recommended?: Resolver<
+    GQLResolversTypes['TagConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLTagRecommendedArgs, 'input'>
+  >
+  recommendedAuthors?: Resolver<
+    GQLResolversTypes['UserConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLTagRecommendedAuthorsArgs, 'input'>
+  >
+  remark?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  shortHash?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  writings?: Resolver<
+    GQLResolversTypes['TagWritingConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLTagWritingsArgs, 'input'>
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLTagConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['TagConnection'] = GQLResolversParentTypes['TagConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['TagEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLTagEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['TagEdge'] = GQLResolversParentTypes['TagEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Tag'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLTagOssResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['TagOSS'] = GQLResolversParentTypes['TagOSS']
+> = ResolversObject<{
+  boost?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>
+  score?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLTagWritingConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['TagWritingConnection'] = GQLResolversParentTypes['TagWritingConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['TagWritingEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLTagWritingEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['TagWritingEdge'] = GQLResolversParentTypes['TagWritingEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Writing'], ParentType, ContextType>
+  pinned?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLTopDonatorConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['TopDonatorConnection'] = GQLResolversParentTypes['TopDonatorConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['TopDonatorEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLTopDonatorEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['TopDonatorEdge'] = GQLResolversParentTypes['TopDonatorEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  donationCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Donator'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLTopicChannelResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['TopicChannel'] = GQLResolversParentTypes['TopicChannel']
+> = ResolversObject<{
+  articles?: Resolver<
+    GQLResolversTypes['ChannelArticleConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLTopicChannelArticlesArgs, 'input'>
+  >
+  enabled?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  name?: Resolver<
+    GQLResolversTypes['String'],
+    ParentType,
+    ContextType,
+    Partial<GQLTopicChannelNameArgs>
+  >
+  navbarTitle?: Resolver<
+    GQLResolversTypes['String'],
+    ParentType,
+    ContextType,
+    Partial<GQLTopicChannelNavbarTitleArgs>
+  >
+  note?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType,
+    Partial<GQLTopicChannelNoteArgs>
+  >
+  parent?: Resolver<
+    Maybe<GQLResolversTypes['TopicChannel']>,
+    ParentType,
+    ContextType
+  >
+  providerId?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  shortHash?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLTopicChannelClassificationResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['TopicChannelClassification'] = GQLResolversParentTypes['TopicChannelClassification']
+> = ResolversObject<{
+  channels?: Resolver<
+    Maybe<Array<GQLResolversTypes['ArticleTopicChannel']>>,
+    ParentType,
+    ContextType
+  >
+  enabled?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  feedback?: Resolver<
+    Maybe<GQLResolversTypes['TopicChannelFeedback']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLTopicChannelFeedbackResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['TopicChannelFeedback'] = GQLResolversParentTypes['TopicChannelFeedback']
+> = ResolversObject<{
+  article?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>
+  channels?: Resolver<
+    Maybe<Array<GQLResolversTypes['TopicChannel']>>,
+    ParentType,
+    ContextType
+  >
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  state?: Resolver<
+    Maybe<GQLResolversTypes['TopicChannelFeedbackState']>,
+    ParentType,
+    ContextType
+  >
+  type?: Resolver<
+    GQLResolversTypes['TopicChannelFeedbackType'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLTopicChannelFeedbackConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['TopicChannelFeedbackConnection'] = GQLResolversParentTypes['TopicChannelFeedbackConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Array<GQLResolversTypes['TopicChannelFeedbackEdge']>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLTopicChannelFeedbackEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['TopicChannelFeedbackEdge'] = GQLResolversParentTypes['TopicChannelFeedbackEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<
+    GQLResolversTypes['TopicChannelFeedback'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLTransactionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Transaction'] = GQLResolversParentTypes['Transaction']
+> = ResolversObject<{
+  amount?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>
+  blockchainTx?: Resolver<
+    Maybe<GQLResolversTypes['BlockchainTransaction']>,
+    ParentType,
+    ContextType
+  >
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  currency?: Resolver<
+    GQLResolversTypes['TransactionCurrency'],
+    ParentType,
+    ContextType
+  >
+  fee?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  message?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  purpose?: Resolver<
+    GQLResolversTypes['TransactionPurpose'],
+    ParentType,
+    ContextType
+  >
+  recipient?: Resolver<
+    Maybe<GQLResolversTypes['User']>,
+    ParentType,
+    ContextType
+  >
+  sender?: Resolver<Maybe<GQLResolversTypes['User']>, ParentType, ContextType>
+  state?: Resolver<
+    GQLResolversTypes['TransactionState'],
+    ParentType,
+    ContextType
+  >
+  target?: Resolver<
+    Maybe<GQLResolversTypes['TransactionTarget']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLTransactionConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['TransactionConnection'] = GQLResolversParentTypes['TransactionConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['TransactionEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLTransactionEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['TransactionEdge'] = GQLResolversParentTypes['TransactionEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Transaction'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLTransactionNoticeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['TransactionNotice'] = GQLResolversParentTypes['TransactionNotice']
+> = ResolversObject<{
+  actors?: Resolver<
+    Maybe<Array<GQLResolversTypes['User']>>,
+    ParentType,
+    ContextType
+  >
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  target?: Resolver<GQLResolversTypes['Transaction'], ParentType, ContextType>
+  type?: Resolver<
+    GQLResolversTypes['TransactionNoticeType'],
+    ParentType,
+    ContextType
+  >
+  unread?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLTransactionTargetResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['TransactionTarget'] = GQLResolversParentTypes['TransactionTarget']
+> = ResolversObject<{
+  __resolveType: TypeResolveFn<
+    'Article' | 'Circle' | 'Transaction',
+    ParentType,
+    ContextType
+  >
+}>
+
+export type GQLTranslatedAnnouncementResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['TranslatedAnnouncement'] = GQLResolversParentTypes['TranslatedAnnouncement']
+> = ResolversObject<{
+  content?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  cover?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  language?: Resolver<
+    GQLResolversTypes['UserLanguage'],
+    ParentType,
+    ContextType
+  >
+  link?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  title?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLUnfreezeSpamRingResultResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UnfreezeSpamRingResult'] = GQLResolversParentTypes['UnfreezeSpamRingResult']
+> = ResolversObject<{
+  ring?: Resolver<GQLResolversTypes['SpamRing'], ParentType, ContextType>
+  skipped?: Resolver<
+    Array<GQLResolversTypes['SpamRingSkip']>,
+    ParentType,
+    ContextType
+  >
+  unbanned?: Resolver<Array<GQLResolversTypes['User']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export interface GQLUploadScalarConfig
+  extends GraphQLScalarTypeConfig<GQLResolversTypes['Upload'], any> {
+  name: 'Upload'
+}
+
+export type GQLUpsertSpamRingCandidatesResultResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UpsertSpamRingCandidatesResult'] = GQLResolversParentTypes['UpsertSpamRingCandidatesResult']
+> = ResolversObject<{
+  created?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  rings?: Resolver<
+    Array<GQLResolversTypes['SpamRing']>,
+    ParentType,
+    ContextType
+  >
+  skipped?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  updated?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLUserResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['User'] = GQLResolversParentTypes['User']
+> = ResolversObject<{
+  activity?: Resolver<
+    GQLResolversTypes['UserActivity'],
+    ParentType,
+    ContextType
+  >
+  analytics?: Resolver<
+    GQLResolversTypes['UserAnalytics'],
+    ParentType,
+    ContextType
+  >
+  articles?: Resolver<
+    GQLResolversTypes['ArticleConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLUserArticlesArgs, 'input'>
+  >
+  avatar?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  blockList?: Resolver<
+    GQLResolversTypes['UserConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLUserBlockListArgs, 'input'>
+  >
+  bookmarkedArticles?: Resolver<
+    GQLResolversTypes['ArticleConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLUserBookmarkedArticlesArgs, 'input'>
+  >
+  bookmarkedTags?: Resolver<
+    GQLResolversTypes['TagConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLUserBookmarkedTagsArgs, 'input'>
+  >
+  campaigns?: Resolver<
+    GQLResolversTypes['CampaignConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLUserCampaignsArgs, 'input'>
+  >
+  collections?: Resolver<
+    GQLResolversTypes['CollectionConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLUserCollectionsArgs, 'input'>
+  >
+  commentedArticles?: Resolver<
+    GQLResolversTypes['ArticleConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLUserCommentedArticlesArgs, 'input'>
+  >
+  displayName?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  drafts?: Resolver<
+    GQLResolversTypes['DraftConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLUserDraftsArgs, 'input'>
+  >
+  features?: Resolver<
+    GQLResolversTypes['UserFeatures'],
+    ParentType,
+    ContextType
+  >
+  federationSetting?: Resolver<
+    Maybe<GQLResolversTypes['UserFederationSetting']>,
+    ParentType,
+    ContextType
+  >
+  followers?: Resolver<
+    GQLResolversTypes['UserConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLUserFollowersArgs, 'input'>
+  >
+  following?: Resolver<GQLResolversTypes['Following'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  info?: Resolver<GQLResolversTypes['UserInfo'], ParentType, ContextType>
+  isBlocked?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  isBlocking?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  isFollowee?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  isFollower?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  isMomentFeedApplied?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  latestWorks?: Resolver<
+    Array<GQLResolversTypes['PinnableWork']>,
+    ParentType,
+    ContextType
+  >
+  liker?: Resolver<GQLResolversTypes['Liker'], ParentType, ContextType>
+  likerId?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  notices?: Resolver<
+    GQLResolversTypes['NoticeConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLUserNoticesArgs, 'input'>
+  >
+  oss?: Resolver<GQLResolversTypes['UserOSS'], ParentType, ContextType>
+  ownCircles?: Resolver<
+    Maybe<Array<GQLResolversTypes['Circle']>>,
+    ParentType,
+    ContextType
+  >
+  paymentPointer?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  pinnedWorks?: Resolver<
+    Array<GQLResolversTypes['PinnableWork']>,
+    ParentType,
+    ContextType
+  >
+  recommendation?: Resolver<
+    GQLResolversTypes['Recommendation'],
+    ParentType,
+    ContextType
+  >
+  remark?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  settings?: Resolver<
+    GQLResolversTypes['UserSettings'],
+    ParentType,
+    ContextType
+  >
+  status?: Resolver<
+    Maybe<GQLResolversTypes['UserStatus']>,
+    ParentType,
+    ContextType
+  >
+  subscribedCircles?: Resolver<
+    GQLResolversTypes['CircleConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLUserSubscribedCirclesArgs, 'input'>
+  >
+  tags?: Resolver<
+    GQLResolversTypes['TagConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLUserTagsArgs, 'input'>
+  >
+  userName?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  wallet?: Resolver<GQLResolversTypes['Wallet'], ParentType, ContextType>
+  writings?: Resolver<
+    GQLResolversTypes['WritingConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLUserWritingsArgs, 'input'>
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLUserActivityResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UserActivity'] = GQLResolversParentTypes['UserActivity']
+> = ResolversObject<{
+  appreciationsReceived?: Resolver<
+    GQLResolversTypes['AppreciationConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLUserActivityAppreciationsReceivedArgs, 'input'>
+  >
+  appreciationsReceivedTotal?: Resolver<
+    GQLResolversTypes['Int'],
+    ParentType,
+    ContextType
+  >
+  appreciationsSent?: Resolver<
+    GQLResolversTypes['AppreciationConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLUserActivityAppreciationsSentArgs, 'input'>
+  >
+  appreciationsSentTotal?: Resolver<
+    GQLResolversTypes['Int'],
+    ParentType,
+    ContextType
+  >
+  history?: Resolver<
+    GQLResolversTypes['ReadHistoryConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLUserActivityHistoryArgs, 'input'>
+  >
+  recentSearches?: Resolver<
+    GQLResolversTypes['RecentSearchConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLUserActivityRecentSearchesArgs, 'input'>
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLUserAddArticleTagActivityResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UserAddArticleTagActivity'] = GQLResolversParentTypes['UserAddArticleTagActivity']
+> = ResolversObject<{
+  actor?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>
+  target?: Resolver<GQLResolversTypes['Tag'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLUserAnalyticsResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UserAnalytics'] = GQLResolversParentTypes['UserAnalytics']
+> = ResolversObject<{
+  topDonators?: Resolver<
+    GQLResolversTypes['TopDonatorConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLUserAnalyticsTopDonatorsArgs, 'input'>
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLUserBroadcastCircleActivityResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UserBroadcastCircleActivity'] = GQLResolversParentTypes['UserBroadcastCircleActivity']
+> = ResolversObject<{
+  actor?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Comment'], ParentType, ContextType>
+  target?: Resolver<GQLResolversTypes['Circle'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLUserConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UserConnection'] = GQLResolversParentTypes['UserConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['UserEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLUserCreateCircleActivityResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UserCreateCircleActivity'] = GQLResolversParentTypes['UserCreateCircleActivity']
+> = ResolversObject<{
+  actor?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Circle'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLUserEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UserEdge'] = GQLResolversParentTypes['UserEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLUserFeatureFlagResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UserFeatureFlag'] = GQLResolversParentTypes['UserFeatureFlag']
+> = ResolversObject<{
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  type?: Resolver<
+    GQLResolversTypes['UserFeatureFlagType'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLUserFeaturesResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UserFeatures'] = GQLResolversParentTypes['UserFeatures']
+> = ResolversObject<{
+  communityWatch?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  fediverseBeta?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLUserFederationSettingResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UserFederationSetting'] = GQLResolversParentTypes['UserFederationSetting']
+> = ResolversObject<{
+  state?: Resolver<
+    GQLResolversTypes['FederationAuthorSettingState'],
+    ParentType,
+    ContextType
+  >
+  updatedBy?: Resolver<Maybe<GQLResolversTypes['ID']>, ParentType, ContextType>
+  userId?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLUserInfoResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UserInfo'] = GQLResolversParentTypes['UserInfo']
+> = ResolversObject<{
+  agreeOn?: Resolver<
+    Maybe<GQLResolversTypes['DateTime']>,
+    ParentType,
+    ContextType
+  >
+  badges?: Resolver<
+    Maybe<Array<GQLResolversTypes['Badge']>>,
+    ParentType,
+    ContextType
+  >
+  createdAt?: Resolver<
+    Maybe<GQLResolversTypes['DateTime']>,
+    ParentType,
+    ContextType
+  >
+  cryptoWallet?: Resolver<
+    Maybe<GQLResolversTypes['CryptoWallet']>,
+    ParentType,
+    ContextType
+  >
+  description?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  email?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  emailVerified?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  ethAddress?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  featuredTags?: Resolver<
+    Maybe<Array<GQLResolversTypes['Tag']>>,
+    ParentType,
+    ContextType
+  >
+  group?: Resolver<GQLResolversTypes['UserGroup'], ParentType, ContextType>
+  ipnsKey?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  isWalletAuth?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  profileCover?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  socialAccounts?: Resolver<
+    Array<GQLResolversTypes['SocialAccount']>,
+    ParentType,
+    ContextType
+  >
+  userNameEditable?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLUserNoticeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UserNotice'] = GQLResolversParentTypes['UserNotice']
+> = ResolversObject<{
+  actors?: Resolver<
+    Maybe<Array<GQLResolversTypes['User']>>,
+    ParentType,
+    ContextType
+  >
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  target?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
+  type?: Resolver<GQLResolversTypes['UserNoticeType'], ParentType, ContextType>
+  unread?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLUserOssResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UserOSS'] = GQLResolversParentTypes['UserOSS']
+> = ResolversObject<{
+  boost?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>
+  featureFlags?: Resolver<
+    Array<GQLResolversTypes['UserFeatureFlag']>,
+    ParentType,
+    ContextType
+  >
+  momentFeedApplication?: Resolver<
+    Maybe<GQLResolversTypes['MomentFeedApplication']>,
+    ParentType,
+    ContextType
+  >
+  restrictions?: Resolver<
+    Array<GQLResolversTypes['UserRestriction']>,
+    ParentType,
+    ContextType
+  >
+  score?: Resolver<GQLResolversTypes['Float'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLUserPostMomentActivityResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UserPostMomentActivity'] = GQLResolversParentTypes['UserPostMomentActivity']
+> = ResolversObject<{
+  actor?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  more?: Resolver<Array<GQLResolversTypes['Moment']>, ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Moment'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLUserPublishArticleActivityResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UserPublishArticleActivity'] = GQLResolversParentTypes['UserPublishArticleActivity']
+> = ResolversObject<{
+  actor?: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Article'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLUserRecommendationActivityResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UserRecommendationActivity'] = GQLResolversParentTypes['UserRecommendationActivity']
+> = ResolversObject<{
+  nodes?: Resolver<
+    Maybe<Array<GQLResolversTypes['User']>>,
+    ParentType,
+    ContextType
+  >
+  source?: Resolver<
+    Maybe<GQLResolversTypes['UserRecommendationActivitySource']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLUserRestrictionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UserRestriction'] = GQLResolversParentTypes['UserRestriction']
+> = ResolversObject<{
+  createdAt?: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+  type?: Resolver<
+    GQLResolversTypes['UserRestrictionType'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLUserSettingsResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UserSettings'] = GQLResolversParentTypes['UserSettings']
+> = ResolversObject<{
+  currency?: Resolver<
+    GQLResolversTypes['QuoteCurrency'],
+    ParentType,
+    ContextType
+  >
+  language?: Resolver<
+    GQLResolversTypes['UserLanguage'],
+    ParentType,
+    ContextType
+  >
+  notification?: Resolver<
+    Maybe<GQLResolversTypes['NotificationSetting']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLUserStatusResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['UserStatus'] = GQLResolversParentTypes['UserStatus']
+> = ResolversObject<{
+  articleCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  changeEmailTimesLeft?: Resolver<
+    GQLResolversTypes['Int'],
+    ParentType,
+    ContextType
+  >
+  commentCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  donatedArticleCount?: Resolver<
+    GQLResolversTypes['Int'],
+    ParentType,
+    ContextType
+  >
+  hasEmailLoginPassword?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  hasPaymentPassword?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  momentCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  receivedDonationCount?: Resolver<
+    GQLResolversTypes['Int'],
+    ParentType,
+    ContextType
+  >
+  role?: Resolver<GQLResolversTypes['UserRole'], ParentType, ContextType>
+  state?: Resolver<GQLResolversTypes['UserState'], ParentType, ContextType>
+  totalReferredCount?: Resolver<
+    GQLResolversTypes['Int'],
+    ParentType,
+    ContextType
+  >
+  totalWordCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  unreadFollowing?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  unreadNoticeCount?: Resolver<
+    GQLResolversTypes['Int'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLWalletResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Wallet'] = GQLResolversParentTypes['Wallet']
+> = ResolversObject<{
+  balance?: Resolver<GQLResolversTypes['Balance'], ParentType, ContextType>
+  cardLast4?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  customerPortal?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  stripeAccount?: Resolver<
+    Maybe<GQLResolversTypes['StripeAccount']>,
+    ParentType,
+    ContextType
+  >
+  transactions?: Resolver<
+    GQLResolversTypes['TransactionConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLWalletTransactionsArgs, 'input'>
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLWithdrawLockedTokensResultResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['WithdrawLockedTokensResult'] = GQLResolversParentTypes['WithdrawLockedTokensResult']
+> = ResolversObject<{
+  transaction?: Resolver<
+    GQLResolversTypes['Transaction'],
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLWritingResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['Writing'] = GQLResolversParentTypes['Writing']
+> = ResolversObject<{
+  __resolveType: TypeResolveFn<
+    'Article' | 'Comment' | 'Moment',
+    ParentType,
+    ContextType
+  >
+}>
+
+export type GQLWritingChallengeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['WritingChallenge'] = GQLResolversParentTypes['WritingChallenge']
+> = ResolversObject<{
+  announcements?: Resolver<
+    Array<GQLResolversTypes['Article']>,
+    ParentType,
+    ContextType
+  >
+  application?: Resolver<
+    Maybe<GQLResolversTypes['CampaignApplication']>,
+    ParentType,
+    ContextType
+  >
+  applicationPeriod?: Resolver<
+    Maybe<GQLResolversTypes['DatetimeRange']>,
+    ParentType,
+    ContextType
+  >
+  articles?: Resolver<
+    GQLResolversTypes['CampaignArticleConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLWritingChallengeArticlesArgs, 'input'>
+  >
+  channelEnabled?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  cover?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
+  description?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType,
+    Partial<GQLWritingChallengeDescriptionArgs>
+  >
+  discussion?: Resolver<
+    GQLResolversTypes['CommentConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLWritingChallengeDiscussionArgs, 'input'>
+  >
+  discussionCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  enableQuoteWall?: Resolver<
+    GQLResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >
+  featuredDescription?: Resolver<
+    GQLResolversTypes['String'],
+    ParentType,
+    ContextType,
+    Partial<GQLWritingChallengeFeaturedDescriptionArgs>
+  >
+  id?: Resolver<GQLResolversTypes['ID'], ParentType, ContextType>
+  isManager?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  link?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  name?: Resolver<
+    GQLResolversTypes['String'],
+    ParentType,
+    ContextType,
+    Partial<GQLWritingChallengeNameArgs>
+  >
+  navbarTitle?: Resolver<
+    GQLResolversTypes['String'],
+    ParentType,
+    ContextType,
+    Partial<GQLWritingChallengeNavbarTitleArgs>
+  >
+  organizers?: Resolver<
+    Array<GQLResolversTypes['User']>,
+    ParentType,
+    ContextType
+  >
+  oss?: Resolver<GQLResolversTypes['CampaignOSS'], ParentType, ContextType>
+  participants?: Resolver<
+    GQLResolversTypes['CampaignParticipantConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLWritingChallengeParticipantsArgs, 'input'>
+  >
+  quoteCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  quotes?: Resolver<
+    GQLResolversTypes['QuoteConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<GQLWritingChallengeQuotesArgs, 'input'>
+  >
+  shortHash?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  showAd?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  showOther?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
+  stages?: Resolver<
+    Array<GQLResolversTypes['CampaignStage']>,
+    ParentType,
+    ContextType
+  >
+  state?: Resolver<GQLResolversTypes['CampaignState'], ParentType, ContextType>
+  writingPeriod?: Resolver<
+    Maybe<GQLResolversTypes['DatetimeRange']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLWritingConnectionResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['WritingConnection'] = GQLResolversParentTypes['WritingConnection']
+> = ResolversObject<{
+  edges?: Resolver<
+    Maybe<Array<GQLResolversTypes['WritingEdge']>>,
+    ParentType,
+    ContextType
+  >
+  pageInfo?: Resolver<GQLResolversTypes['PageInfo'], ParentType, ContextType>
+  totalCount?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
+
+export type GQLWritingEdgeResolvers<
+  ContextType = Context,
+  ParentType extends GQLResolversParentTypes['WritingEdge'] = GQLResolversParentTypes['WritingEdge']
+> = ResolversObject<{
+  cursor?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>
+  node?: Resolver<GQLResolversTypes['Writing'], ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}>
 
 export type GQLResolvers<ContextType = Context> = ResolversObject<{
-  AdStatus?: GQLAdStatusResolvers<ContextType>;
-  AddCreditResult?: GQLAddCreditResultResolvers<ContextType>;
-  Announcement?: GQLAnnouncementResolvers<ContextType>;
-  AnnouncementChannel?: GQLAnnouncementChannelResolvers<ContextType>;
-  Appreciation?: GQLAppreciationResolvers<ContextType>;
-  AppreciationConnection?: GQLAppreciationConnectionResolvers<ContextType>;
-  AppreciationEdge?: GQLAppreciationEdgeResolvers<ContextType>;
-  ArchiveUserFailure?: GQLArchiveUserFailureResolvers<ContextType>;
-  ArchiveUsersResult?: GQLArchiveUsersResultResolvers<ContextType>;
-  Article?: GQLArticleResolvers<ContextType>;
-  ArticleAccess?: GQLArticleAccessResolvers<ContextType>;
-  ArticleArticleNotice?: GQLArticleArticleNoticeResolvers<ContextType>;
-  ArticleCampaign?: GQLArticleCampaignResolvers<ContextType>;
-  ArticleClassification?: GQLArticleClassificationResolvers<ContextType>;
-  ArticleConnection?: GQLArticleConnectionResolvers<ContextType>;
-  ArticleContents?: GQLArticleContentsResolvers<ContextType>;
-  ArticleDonation?: GQLArticleDonationResolvers<ContextType>;
-  ArticleDonationConnection?: GQLArticleDonationConnectionResolvers<ContextType>;
-  ArticleDonationEdge?: GQLArticleDonationEdgeResolvers<ContextType>;
-  ArticleEdge?: GQLArticleEdgeResolvers<ContextType>;
-  ArticleFederationEligibility?: GQLArticleFederationEligibilityResolvers<ContextType>;
-  ArticleFederationSetting?: GQLArticleFederationSettingResolvers<ContextType>;
-  ArticleNotice?: GQLArticleNoticeResolvers<ContextType>;
-  ArticleOSS?: GQLArticleOssResolvers<ContextType>;
-  ArticleRecommendationActivity?: GQLArticleRecommendationActivityResolvers<ContextType>;
-  ArticleTopicChannel?: GQLArticleTopicChannelResolvers<ContextType>;
-  ArticleTranslation?: GQLArticleTranslationResolvers<ContextType>;
-  ArticleVersion?: GQLArticleVersionResolvers<ContextType>;
-  ArticleVersionEdge?: GQLArticleVersionEdgeResolvers<ContextType>;
-  ArticleVersionsConnection?: GQLArticleVersionsConnectionResolvers<ContextType>;
-  Asset?: GQLAssetResolvers<ContextType>;
-  AuthResult?: GQLAuthResultResolvers<ContextType>;
-  Badge?: GQLBadgeResolvers<ContextType>;
-  Balance?: GQLBalanceResolvers<ContextType>;
-  BlockchainTransaction?: GQLBlockchainTransactionResolvers<ContextType>;
-  BlockedSearchKeyword?: GQLBlockedSearchKeywordResolvers<ContextType>;
-  Campaign?: GQLCampaignResolvers<ContextType>;
-  CampaignApplication?: GQLCampaignApplicationResolvers<ContextType>;
-  CampaignArticleConnection?: GQLCampaignArticleConnectionResolvers<ContextType>;
-  CampaignArticleEdge?: GQLCampaignArticleEdgeResolvers<ContextType>;
-  CampaignArticleNotice?: GQLCampaignArticleNoticeResolvers<ContextType>;
-  CampaignConnection?: GQLCampaignConnectionResolvers<ContextType>;
-  CampaignEdge?: GQLCampaignEdgeResolvers<ContextType>;
-  CampaignOSS?: GQLCampaignOssResolvers<ContextType>;
-  CampaignParticipantConnection?: GQLCampaignParticipantConnectionResolvers<ContextType>;
-  CampaignParticipantEdge?: GQLCampaignParticipantEdgeResolvers<ContextType>;
-  CampaignStage?: GQLCampaignStageResolvers<ContextType>;
-  Channel?: GQLChannelResolvers<ContextType>;
-  ChannelArticleConnection?: GQLChannelArticleConnectionResolvers<ContextType>;
-  ChannelArticleEdge?: GQLChannelArticleEdgeResolvers<ContextType>;
-  Circle?: GQLCircleResolvers<ContextType>;
-  CircleAnalytics?: GQLCircleAnalyticsResolvers<ContextType>;
-  CircleConnection?: GQLCircleConnectionResolvers<ContextType>;
-  CircleContentAnalytics?: GQLCircleContentAnalyticsResolvers<ContextType>;
-  CircleContentAnalyticsDatum?: GQLCircleContentAnalyticsDatumResolvers<ContextType>;
-  CircleEdge?: GQLCircleEdgeResolvers<ContextType>;
-  CircleFollowerAnalytics?: GQLCircleFollowerAnalyticsResolvers<ContextType>;
-  CircleIncomeAnalytics?: GQLCircleIncomeAnalyticsResolvers<ContextType>;
-  CircleNotice?: GQLCircleNoticeResolvers<ContextType>;
-  CircleRecommendationActivity?: GQLCircleRecommendationActivityResolvers<ContextType>;
-  CircleSubscriberAnalytics?: GQLCircleSubscriberAnalyticsResolvers<ContextType>;
-  ClaimLogbooksResult?: GQLClaimLogbooksResultResolvers<ContextType>;
-  Collection?: GQLCollectionResolvers<ContextType>;
-  CollectionConnection?: GQLCollectionConnectionResolvers<ContextType>;
-  CollectionEdge?: GQLCollectionEdgeResolvers<ContextType>;
-  CollectionNotice?: GQLCollectionNoticeResolvers<ContextType>;
-  Comment?: GQLCommentResolvers<ContextType>;
-  CommentCommentNotice?: GQLCommentCommentNoticeResolvers<ContextType>;
-  CommentConnection?: GQLCommentConnectionResolvers<ContextType>;
-  CommentEdge?: GQLCommentEdgeResolvers<ContextType>;
-  CommentNotice?: GQLCommentNoticeResolvers<ContextType>;
-  CommunityWatchAction?: GQLCommunityWatchActionResolvers<ContextType>;
-  CommunityWatchActionConnection?: GQLCommunityWatchActionConnectionResolvers<ContextType>;
-  CommunityWatchActionEdge?: GQLCommunityWatchActionEdgeResolvers<ContextType>;
-  ConnectStripeAccountResult?: GQLConnectStripeAccountResultResolvers<ContextType>;
-  Connection?: GQLConnectionResolvers<ContextType>;
-  CryptoWallet?: GQLCryptoWalletResolvers<ContextType>;
-  CurationChannel?: GQLCurationChannelResolvers<ContextType>;
-  DateTime?: GraphQLScalarType;
-  DatetimeRange?: GQLDatetimeRangeResolvers<ContextType>;
-  Donator?: GQLDonatorResolvers<ContextType>;
-  Draft?: GQLDraftResolvers<ContextType>;
-  DraftAccess?: GQLDraftAccessResolvers<ContextType>;
-  DraftConnection?: GQLDraftConnectionResolvers<ContextType>;
-  DraftEdge?: GQLDraftEdgeResolvers<ContextType>;
-  ExchangeRate?: GQLExchangeRateResolvers<ContextType>;
-  Feature?: GQLFeatureResolvers<ContextType>;
-  Following?: GQLFollowingResolvers<ContextType>;
-  FollowingActivity?: GQLFollowingActivityResolvers<ContextType>;
-  FollowingActivityConnection?: GQLFollowingActivityConnectionResolvers<ContextType>;
-  FollowingActivityEdge?: GQLFollowingActivityEdgeResolvers<ContextType>;
-  FreezeSpamRingResult?: GQLFreezeSpamRingResultResolvers<ContextType>;
-  IcymiTopic?: GQLIcymiTopicResolvers<ContextType>;
-  IcymiTopicConnection?: GQLIcymiTopicConnectionResolvers<ContextType>;
-  IcymiTopicEdge?: GQLIcymiTopicEdgeResolvers<ContextType>;
-  Invitation?: GQLInvitationResolvers<ContextType>;
-  InvitationConnection?: GQLInvitationConnectionResolvers<ContextType>;
-  InvitationEdge?: GQLInvitationEdgeResolvers<ContextType>;
-  Invitee?: GQLInviteeResolvers<ContextType>;
-  Invites?: GQLInvitesResolvers<ContextType>;
-  Liker?: GQLLikerResolvers<ContextType>;
-  Member?: GQLMemberResolvers<ContextType>;
-  MemberConnection?: GQLMemberConnectionResolvers<ContextType>;
-  MemberEdge?: GQLMemberEdgeResolvers<ContextType>;
-  Moment?: GQLMomentResolvers<ContextType>;
-  MomentConnection?: GQLMomentConnectionResolvers<ContextType>;
-  MomentEdge?: GQLMomentEdgeResolvers<ContextType>;
-  MomentFeedApplication?: GQLMomentFeedApplicationResolvers<ContextType>;
-  MomentNotice?: GQLMomentNoticeResolvers<ContextType>;
-  MonthlyDatum?: GQLMonthlyDatumResolvers<ContextType>;
-  Mutation?: GQLMutationResolvers<ContextType>;
-  NFTAsset?: GQLNftAssetResolvers<ContextType>;
-  Node?: GQLNodeResolvers<ContextType>;
-  Notice?: GQLNoticeResolvers<ContextType>;
-  NoticeConnection?: GQLNoticeConnectionResolvers<ContextType>;
-  NoticeEdge?: GQLNoticeEdgeResolvers<ContextType>;
-  NotificationSetting?: GQLNotificationSettingResolvers<ContextType>;
-  OAuthClient?: GQLOAuthClientResolvers<ContextType>;
-  OAuthClientConnection?: GQLOAuthClientConnectionResolvers<ContextType>;
-  OAuthClientEdge?: GQLOAuthClientEdgeResolvers<ContextType>;
-  OSS?: GQLOssResolvers<ContextType>;
-  Official?: GQLOfficialResolvers<ContextType>;
-  OfficialAnnouncementNotice?: GQLOfficialAnnouncementNoticeResolvers<ContextType>;
-  PageInfo?: GQLPageInfoResolvers<ContextType>;
-  PayToResult?: GQLPayToResultResolvers<ContextType>;
-  Person?: GQLPersonResolvers<ContextType>;
-  PersonhoodHandoff?: GQLPersonhoodHandoffResolvers<ContextType>;
-  PinHistory?: GQLPinHistoryResolvers<ContextType>;
-  PinnableWork?: GQLPinnableWorkResolvers<ContextType>;
-  Price?: GQLPriceResolvers<ContextType>;
-  Query?: GQLQueryResolvers<ContextType>;
-  Quote?: GQLQuoteResolvers<ContextType>;
-  QuoteConnection?: GQLQuoteConnectionResolvers<ContextType>;
-  QuoteEdge?: GQLQuoteEdgeResolvers<ContextType>;
-  ReadHistory?: GQLReadHistoryResolvers<ContextType>;
-  ReadHistoryConnection?: GQLReadHistoryConnectionResolvers<ContextType>;
-  ReadHistoryEdge?: GQLReadHistoryEdgeResolvers<ContextType>;
-  RecentSearchConnection?: GQLRecentSearchConnectionResolvers<ContextType>;
-  RecentSearchEdge?: GQLRecentSearchEdgeResolvers<ContextType>;
-  Recommendation?: GQLRecommendationResolvers<ContextType>;
-  Report?: GQLReportResolvers<ContextType>;
-  ReportConnection?: GQLReportConnectionResolvers<ContextType>;
-  ReportEdge?: GQLReportEdgeResolvers<ContextType>;
-  Response?: GQLResponseResolvers<ContextType>;
-  ResponseConnection?: GQLResponseConnectionResolvers<ContextType>;
-  ResponseEdge?: GQLResponseEdgeResolvers<ContextType>;
-  SearchResultConnection?: GQLSearchResultConnectionResolvers<ContextType>;
-  SearchResultEdge?: GQLSearchResultEdgeResolvers<ContextType>;
-  SigningMessageResult?: GQLSigningMessageResultResolvers<ContextType>;
-  SkippedListItem?: GQLSkippedListItemResolvers<ContextType>;
-  SkippedListItemEdge?: GQLSkippedListItemEdgeResolvers<ContextType>;
-  SkippedListItemsConnection?: GQLSkippedListItemsConnectionResolvers<ContextType>;
-  SocialAccount?: GQLSocialAccountResolvers<ContextType>;
-  SpamRing?: GQLSpamRingResolvers<ContextType>;
-  SpamRingConnection?: GQLSpamRingConnectionResolvers<ContextType>;
-  SpamRingEdge?: GQLSpamRingEdgeResolvers<ContextType>;
-  SpamRingEvent?: GQLSpamRingEventResolvers<ContextType>;
-  SpamRingMember?: GQLSpamRingMemberResolvers<ContextType>;
-  SpamRingMemberConnection?: GQLSpamRingMemberConnectionResolvers<ContextType>;
-  SpamRingMemberEdge?: GQLSpamRingMemberEdgeResolvers<ContextType>;
-  SpamRingSignals?: GQLSpamRingSignalsResolvers<ContextType>;
-  SpamRingSkip?: GQLSpamRingSkipResolvers<ContextType>;
-  SpamStatus?: GQLSpamStatusResolvers<ContextType>;
-  StripeAccount?: GQLStripeAccountResolvers<ContextType>;
-  SubscribeCircleResult?: GQLSubscribeCircleResultResolvers<ContextType>;
-  Tag?: GQLTagResolvers<ContextType>;
-  TagConnection?: GQLTagConnectionResolvers<ContextType>;
-  TagEdge?: GQLTagEdgeResolvers<ContextType>;
-  TagOSS?: GQLTagOssResolvers<ContextType>;
-  TagWritingConnection?: GQLTagWritingConnectionResolvers<ContextType>;
-  TagWritingEdge?: GQLTagWritingEdgeResolvers<ContextType>;
-  TopDonatorConnection?: GQLTopDonatorConnectionResolvers<ContextType>;
-  TopDonatorEdge?: GQLTopDonatorEdgeResolvers<ContextType>;
-  TopicChannel?: GQLTopicChannelResolvers<ContextType>;
-  TopicChannelClassification?: GQLTopicChannelClassificationResolvers<ContextType>;
-  TopicChannelFeedback?: GQLTopicChannelFeedbackResolvers<ContextType>;
-  TopicChannelFeedbackConnection?: GQLTopicChannelFeedbackConnectionResolvers<ContextType>;
-  TopicChannelFeedbackEdge?: GQLTopicChannelFeedbackEdgeResolvers<ContextType>;
-  Transaction?: GQLTransactionResolvers<ContextType>;
-  TransactionConnection?: GQLTransactionConnectionResolvers<ContextType>;
-  TransactionEdge?: GQLTransactionEdgeResolvers<ContextType>;
-  TransactionNotice?: GQLTransactionNoticeResolvers<ContextType>;
-  TransactionTarget?: GQLTransactionTargetResolvers<ContextType>;
-  TranslatedAnnouncement?: GQLTranslatedAnnouncementResolvers<ContextType>;
-  UnfreezeSpamRingResult?: GQLUnfreezeSpamRingResultResolvers<ContextType>;
-  Upload?: GraphQLScalarType;
-  UpsertSpamRingCandidatesResult?: GQLUpsertSpamRingCandidatesResultResolvers<ContextType>;
-  User?: GQLUserResolvers<ContextType>;
-  UserActivity?: GQLUserActivityResolvers<ContextType>;
-  UserAddArticleTagActivity?: GQLUserAddArticleTagActivityResolvers<ContextType>;
-  UserAnalytics?: GQLUserAnalyticsResolvers<ContextType>;
-  UserBroadcastCircleActivity?: GQLUserBroadcastCircleActivityResolvers<ContextType>;
-  UserConnection?: GQLUserConnectionResolvers<ContextType>;
-  UserCreateCircleActivity?: GQLUserCreateCircleActivityResolvers<ContextType>;
-  UserEdge?: GQLUserEdgeResolvers<ContextType>;
-  UserFeatureFlag?: GQLUserFeatureFlagResolvers<ContextType>;
-  UserFeatures?: GQLUserFeaturesResolvers<ContextType>;
-  UserFederationSetting?: GQLUserFederationSettingResolvers<ContextType>;
-  UserInfo?: GQLUserInfoResolvers<ContextType>;
-  UserNotice?: GQLUserNoticeResolvers<ContextType>;
-  UserOSS?: GQLUserOssResolvers<ContextType>;
-  UserPostMomentActivity?: GQLUserPostMomentActivityResolvers<ContextType>;
-  UserPublishArticleActivity?: GQLUserPublishArticleActivityResolvers<ContextType>;
-  UserRecommendationActivity?: GQLUserRecommendationActivityResolvers<ContextType>;
-  UserRestriction?: GQLUserRestrictionResolvers<ContextType>;
-  UserSettings?: GQLUserSettingsResolvers<ContextType>;
-  UserStatus?: GQLUserStatusResolvers<ContextType>;
-  Wallet?: GQLWalletResolvers<ContextType>;
-  WithdrawLockedTokensResult?: GQLWithdrawLockedTokensResultResolvers<ContextType>;
-  Writing?: GQLWritingResolvers<ContextType>;
-  WritingChallenge?: GQLWritingChallengeResolvers<ContextType>;
-  WritingConnection?: GQLWritingConnectionResolvers<ContextType>;
-  WritingEdge?: GQLWritingEdgeResolvers<ContextType>;
-}>;
+  AdStatus?: GQLAdStatusResolvers<ContextType>
+  AddCreditResult?: GQLAddCreditResultResolvers<ContextType>
+  Announcement?: GQLAnnouncementResolvers<ContextType>
+  AnnouncementChannel?: GQLAnnouncementChannelResolvers<ContextType>
+  Appreciation?: GQLAppreciationResolvers<ContextType>
+  AppreciationConnection?: GQLAppreciationConnectionResolvers<ContextType>
+  AppreciationEdge?: GQLAppreciationEdgeResolvers<ContextType>
+  ArchiveUserFailure?: GQLArchiveUserFailureResolvers<ContextType>
+  ArchiveUsersResult?: GQLArchiveUsersResultResolvers<ContextType>
+  Article?: GQLArticleResolvers<ContextType>
+  ArticleAccess?: GQLArticleAccessResolvers<ContextType>
+  ArticleArticleNotice?: GQLArticleArticleNoticeResolvers<ContextType>
+  ArticleCampaign?: GQLArticleCampaignResolvers<ContextType>
+  ArticleClassification?: GQLArticleClassificationResolvers<ContextType>
+  ArticleConnection?: GQLArticleConnectionResolvers<ContextType>
+  ArticleContents?: GQLArticleContentsResolvers<ContextType>
+  ArticleDonation?: GQLArticleDonationResolvers<ContextType>
+  ArticleDonationConnection?: GQLArticleDonationConnectionResolvers<ContextType>
+  ArticleDonationEdge?: GQLArticleDonationEdgeResolvers<ContextType>
+  ArticleEdge?: GQLArticleEdgeResolvers<ContextType>
+  ArticleFederationEligibility?: GQLArticleFederationEligibilityResolvers<ContextType>
+  ArticleFederationSetting?: GQLArticleFederationSettingResolvers<ContextType>
+  ArticleNotice?: GQLArticleNoticeResolvers<ContextType>
+  ArticleOSS?: GQLArticleOssResolvers<ContextType>
+  ArticleRecommendationActivity?: GQLArticleRecommendationActivityResolvers<ContextType>
+  ArticleTopicChannel?: GQLArticleTopicChannelResolvers<ContextType>
+  ArticleTranslation?: GQLArticleTranslationResolvers<ContextType>
+  ArticleVersion?: GQLArticleVersionResolvers<ContextType>
+  ArticleVersionEdge?: GQLArticleVersionEdgeResolvers<ContextType>
+  ArticleVersionsConnection?: GQLArticleVersionsConnectionResolvers<ContextType>
+  Asset?: GQLAssetResolvers<ContextType>
+  AuthResult?: GQLAuthResultResolvers<ContextType>
+  Badge?: GQLBadgeResolvers<ContextType>
+  Balance?: GQLBalanceResolvers<ContextType>
+  BlockchainTransaction?: GQLBlockchainTransactionResolvers<ContextType>
+  BlockedSearchKeyword?: GQLBlockedSearchKeywordResolvers<ContextType>
+  Campaign?: GQLCampaignResolvers<ContextType>
+  CampaignApplication?: GQLCampaignApplicationResolvers<ContextType>
+  CampaignArticleConnection?: GQLCampaignArticleConnectionResolvers<ContextType>
+  CampaignArticleEdge?: GQLCampaignArticleEdgeResolvers<ContextType>
+  CampaignArticleNotice?: GQLCampaignArticleNoticeResolvers<ContextType>
+  CampaignConnection?: GQLCampaignConnectionResolvers<ContextType>
+  CampaignEdge?: GQLCampaignEdgeResolvers<ContextType>
+  CampaignOSS?: GQLCampaignOssResolvers<ContextType>
+  CampaignParticipantConnection?: GQLCampaignParticipantConnectionResolvers<ContextType>
+  CampaignParticipantEdge?: GQLCampaignParticipantEdgeResolvers<ContextType>
+  CampaignStage?: GQLCampaignStageResolvers<ContextType>
+  Channel?: GQLChannelResolvers<ContextType>
+  ChannelArticleConnection?: GQLChannelArticleConnectionResolvers<ContextType>
+  ChannelArticleEdge?: GQLChannelArticleEdgeResolvers<ContextType>
+  Circle?: GQLCircleResolvers<ContextType>
+  CircleAnalytics?: GQLCircleAnalyticsResolvers<ContextType>
+  CircleConnection?: GQLCircleConnectionResolvers<ContextType>
+  CircleContentAnalytics?: GQLCircleContentAnalyticsResolvers<ContextType>
+  CircleContentAnalyticsDatum?: GQLCircleContentAnalyticsDatumResolvers<ContextType>
+  CircleEdge?: GQLCircleEdgeResolvers<ContextType>
+  CircleFollowerAnalytics?: GQLCircleFollowerAnalyticsResolvers<ContextType>
+  CircleIncomeAnalytics?: GQLCircleIncomeAnalyticsResolvers<ContextType>
+  CircleNotice?: GQLCircleNoticeResolvers<ContextType>
+  CircleRecommendationActivity?: GQLCircleRecommendationActivityResolvers<ContextType>
+  CircleSubscriberAnalytics?: GQLCircleSubscriberAnalyticsResolvers<ContextType>
+  ClaimLogbooksResult?: GQLClaimLogbooksResultResolvers<ContextType>
+  Collection?: GQLCollectionResolvers<ContextType>
+  CollectionConnection?: GQLCollectionConnectionResolvers<ContextType>
+  CollectionEdge?: GQLCollectionEdgeResolvers<ContextType>
+  CollectionNotice?: GQLCollectionNoticeResolvers<ContextType>
+  Comment?: GQLCommentResolvers<ContextType>
+  CommentCommentNotice?: GQLCommentCommentNoticeResolvers<ContextType>
+  CommentConnection?: GQLCommentConnectionResolvers<ContextType>
+  CommentEdge?: GQLCommentEdgeResolvers<ContextType>
+  CommentNotice?: GQLCommentNoticeResolvers<ContextType>
+  CommunityWatchAction?: GQLCommunityWatchActionResolvers<ContextType>
+  CommunityWatchActionConnection?: GQLCommunityWatchActionConnectionResolvers<ContextType>
+  CommunityWatchActionEdge?: GQLCommunityWatchActionEdgeResolvers<ContextType>
+  ConnectStripeAccountResult?: GQLConnectStripeAccountResultResolvers<ContextType>
+  Connection?: GQLConnectionResolvers<ContextType>
+  CryptoWallet?: GQLCryptoWalletResolvers<ContextType>
+  CurationChannel?: GQLCurationChannelResolvers<ContextType>
+  DateTime?: GraphQLScalarType
+  DatetimeRange?: GQLDatetimeRangeResolvers<ContextType>
+  Donator?: GQLDonatorResolvers<ContextType>
+  Draft?: GQLDraftResolvers<ContextType>
+  DraftAccess?: GQLDraftAccessResolvers<ContextType>
+  DraftConnection?: GQLDraftConnectionResolvers<ContextType>
+  DraftEdge?: GQLDraftEdgeResolvers<ContextType>
+  ExchangeRate?: GQLExchangeRateResolvers<ContextType>
+  Feature?: GQLFeatureResolvers<ContextType>
+  Following?: GQLFollowingResolvers<ContextType>
+  FollowingActivity?: GQLFollowingActivityResolvers<ContextType>
+  FollowingActivityConnection?: GQLFollowingActivityConnectionResolvers<ContextType>
+  FollowingActivityEdge?: GQLFollowingActivityEdgeResolvers<ContextType>
+  FreezeSpamRingResult?: GQLFreezeSpamRingResultResolvers<ContextType>
+  IcymiTopic?: GQLIcymiTopicResolvers<ContextType>
+  IcymiTopicConnection?: GQLIcymiTopicConnectionResolvers<ContextType>
+  IcymiTopicEdge?: GQLIcymiTopicEdgeResolvers<ContextType>
+  Invitation?: GQLInvitationResolvers<ContextType>
+  InvitationConnection?: GQLInvitationConnectionResolvers<ContextType>
+  InvitationEdge?: GQLInvitationEdgeResolvers<ContextType>
+  Invitee?: GQLInviteeResolvers<ContextType>
+  Invites?: GQLInvitesResolvers<ContextType>
+  Liker?: GQLLikerResolvers<ContextType>
+  Member?: GQLMemberResolvers<ContextType>
+  MemberConnection?: GQLMemberConnectionResolvers<ContextType>
+  MemberEdge?: GQLMemberEdgeResolvers<ContextType>
+  ModerationCase?: GQLModerationCaseResolvers<ContextType>
+  Moment?: GQLMomentResolvers<ContextType>
+  MomentConnection?: GQLMomentConnectionResolvers<ContextType>
+  MomentEdge?: GQLMomentEdgeResolvers<ContextType>
+  MomentFeedApplication?: GQLMomentFeedApplicationResolvers<ContextType>
+  MomentNotice?: GQLMomentNoticeResolvers<ContextType>
+  MonthlyDatum?: GQLMonthlyDatumResolvers<ContextType>
+  Mutation?: GQLMutationResolvers<ContextType>
+  NFTAsset?: GQLNftAssetResolvers<ContextType>
+  Node?: GQLNodeResolvers<ContextType>
+  Notice?: GQLNoticeResolvers<ContextType>
+  NoticeConnection?: GQLNoticeConnectionResolvers<ContextType>
+  NoticeEdge?: GQLNoticeEdgeResolvers<ContextType>
+  NotificationSetting?: GQLNotificationSettingResolvers<ContextType>
+  OAuthClient?: GQLOAuthClientResolvers<ContextType>
+  OAuthClientConnection?: GQLOAuthClientConnectionResolvers<ContextType>
+  OAuthClientEdge?: GQLOAuthClientEdgeResolvers<ContextType>
+  OSS?: GQLOssResolvers<ContextType>
+  Official?: GQLOfficialResolvers<ContextType>
+  OfficialAnnouncementNotice?: GQLOfficialAnnouncementNoticeResolvers<ContextType>
+  PageInfo?: GQLPageInfoResolvers<ContextType>
+  PayToResult?: GQLPayToResultResolvers<ContextType>
+  Person?: GQLPersonResolvers<ContextType>
+  PersonhoodHandoff?: GQLPersonhoodHandoffResolvers<ContextType>
+  PinHistory?: GQLPinHistoryResolvers<ContextType>
+  PinnableWork?: GQLPinnableWorkResolvers<ContextType>
+  Price?: GQLPriceResolvers<ContextType>
+  Query?: GQLQueryResolvers<ContextType>
+  Quote?: GQLQuoteResolvers<ContextType>
+  QuoteConnection?: GQLQuoteConnectionResolvers<ContextType>
+  QuoteEdge?: GQLQuoteEdgeResolvers<ContextType>
+  ReadHistory?: GQLReadHistoryResolvers<ContextType>
+  ReadHistoryConnection?: GQLReadHistoryConnectionResolvers<ContextType>
+  ReadHistoryEdge?: GQLReadHistoryEdgeResolvers<ContextType>
+  RecentSearchConnection?: GQLRecentSearchConnectionResolvers<ContextType>
+  RecentSearchEdge?: GQLRecentSearchEdgeResolvers<ContextType>
+  Recommendation?: GQLRecommendationResolvers<ContextType>
+  Report?: GQLReportResolvers<ContextType>
+  ReportConnection?: GQLReportConnectionResolvers<ContextType>
+  ReportEdge?: GQLReportEdgeResolvers<ContextType>
+  Response?: GQLResponseResolvers<ContextType>
+  ResponseConnection?: GQLResponseConnectionResolvers<ContextType>
+  ResponseEdge?: GQLResponseEdgeResolvers<ContextType>
+  SearchResultConnection?: GQLSearchResultConnectionResolvers<ContextType>
+  SearchResultEdge?: GQLSearchResultEdgeResolvers<ContextType>
+  SigningMessageResult?: GQLSigningMessageResultResolvers<ContextType>
+  SkippedListItem?: GQLSkippedListItemResolvers<ContextType>
+  SkippedListItemEdge?: GQLSkippedListItemEdgeResolvers<ContextType>
+  SkippedListItemsConnection?: GQLSkippedListItemsConnectionResolvers<ContextType>
+  SocialAccount?: GQLSocialAccountResolvers<ContextType>
+  SpamRing?: GQLSpamRingResolvers<ContextType>
+  SpamRingConnection?: GQLSpamRingConnectionResolvers<ContextType>
+  SpamRingEdge?: GQLSpamRingEdgeResolvers<ContextType>
+  SpamRingEvent?: GQLSpamRingEventResolvers<ContextType>
+  SpamRingMember?: GQLSpamRingMemberResolvers<ContextType>
+  SpamRingMemberConnection?: GQLSpamRingMemberConnectionResolvers<ContextType>
+  SpamRingMemberEdge?: GQLSpamRingMemberEdgeResolvers<ContextType>
+  SpamRingSignals?: GQLSpamRingSignalsResolvers<ContextType>
+  SpamRingSkip?: GQLSpamRingSkipResolvers<ContextType>
+  SpamStatus?: GQLSpamStatusResolvers<ContextType>
+  StripeAccount?: GQLStripeAccountResolvers<ContextType>
+  SubscribeCircleResult?: GQLSubscribeCircleResultResolvers<ContextType>
+  Tag?: GQLTagResolvers<ContextType>
+  TagConnection?: GQLTagConnectionResolvers<ContextType>
+  TagEdge?: GQLTagEdgeResolvers<ContextType>
+  TagOSS?: GQLTagOssResolvers<ContextType>
+  TagWritingConnection?: GQLTagWritingConnectionResolvers<ContextType>
+  TagWritingEdge?: GQLTagWritingEdgeResolvers<ContextType>
+  TopDonatorConnection?: GQLTopDonatorConnectionResolvers<ContextType>
+  TopDonatorEdge?: GQLTopDonatorEdgeResolvers<ContextType>
+  TopicChannel?: GQLTopicChannelResolvers<ContextType>
+  TopicChannelClassification?: GQLTopicChannelClassificationResolvers<ContextType>
+  TopicChannelFeedback?: GQLTopicChannelFeedbackResolvers<ContextType>
+  TopicChannelFeedbackConnection?: GQLTopicChannelFeedbackConnectionResolvers<ContextType>
+  TopicChannelFeedbackEdge?: GQLTopicChannelFeedbackEdgeResolvers<ContextType>
+  Transaction?: GQLTransactionResolvers<ContextType>
+  TransactionConnection?: GQLTransactionConnectionResolvers<ContextType>
+  TransactionEdge?: GQLTransactionEdgeResolvers<ContextType>
+  TransactionNotice?: GQLTransactionNoticeResolvers<ContextType>
+  TransactionTarget?: GQLTransactionTargetResolvers<ContextType>
+  TranslatedAnnouncement?: GQLTranslatedAnnouncementResolvers<ContextType>
+  UnfreezeSpamRingResult?: GQLUnfreezeSpamRingResultResolvers<ContextType>
+  Upload?: GraphQLScalarType
+  UpsertSpamRingCandidatesResult?: GQLUpsertSpamRingCandidatesResultResolvers<ContextType>
+  User?: GQLUserResolvers<ContextType>
+  UserActivity?: GQLUserActivityResolvers<ContextType>
+  UserAddArticleTagActivity?: GQLUserAddArticleTagActivityResolvers<ContextType>
+  UserAnalytics?: GQLUserAnalyticsResolvers<ContextType>
+  UserBroadcastCircleActivity?: GQLUserBroadcastCircleActivityResolvers<ContextType>
+  UserConnection?: GQLUserConnectionResolvers<ContextType>
+  UserCreateCircleActivity?: GQLUserCreateCircleActivityResolvers<ContextType>
+  UserEdge?: GQLUserEdgeResolvers<ContextType>
+  UserFeatureFlag?: GQLUserFeatureFlagResolvers<ContextType>
+  UserFeatures?: GQLUserFeaturesResolvers<ContextType>
+  UserFederationSetting?: GQLUserFederationSettingResolvers<ContextType>
+  UserInfo?: GQLUserInfoResolvers<ContextType>
+  UserNotice?: GQLUserNoticeResolvers<ContextType>
+  UserOSS?: GQLUserOssResolvers<ContextType>
+  UserPostMomentActivity?: GQLUserPostMomentActivityResolvers<ContextType>
+  UserPublishArticleActivity?: GQLUserPublishArticleActivityResolvers<ContextType>
+  UserRecommendationActivity?: GQLUserRecommendationActivityResolvers<ContextType>
+  UserRestriction?: GQLUserRestrictionResolvers<ContextType>
+  UserSettings?: GQLUserSettingsResolvers<ContextType>
+  UserStatus?: GQLUserStatusResolvers<ContextType>
+  Wallet?: GQLWalletResolvers<ContextType>
+  WithdrawLockedTokensResult?: GQLWithdrawLockedTokensResultResolvers<ContextType>
+  Writing?: GQLWritingResolvers<ContextType>
+  WritingChallenge?: GQLWritingChallengeResolvers<ContextType>
+  WritingConnection?: GQLWritingConnectionResolvers<ContextType>
+  WritingEdge?: GQLWritingEdgeResolvers<ContextType>
+}>
 
 export type GQLDirectiveResolvers<ContextType = Context> = ResolversObject<{
-  auth?: GQLAuthDirectiveResolver<any, any, ContextType>;
-  cacheControl?: GQLCacheControlDirectiveResolver<any, any, ContextType>;
-  complexity?: GQLComplexityDirectiveResolver<any, any, ContextType>;
-  constraint?: GQLConstraintDirectiveResolver<any, any, ContextType>;
-  logCache?: GQLLogCacheDirectiveResolver<any, any, ContextType>;
-  objectCache?: GQLObjectCacheDirectiveResolver<any, any, ContextType>;
-  privateCache?: GQLPrivateCacheDirectiveResolver<any, any, ContextType>;
-  purgeCache?: GQLPurgeCacheDirectiveResolver<any, any, ContextType>;
-  rateLimit?: GQLRateLimitDirectiveResolver<any, any, ContextType>;
-}>;
+  auth?: GQLAuthDirectiveResolver<any, any, ContextType>
+  cacheControl?: GQLCacheControlDirectiveResolver<any, any, ContextType>
+  complexity?: GQLComplexityDirectiveResolver<any, any, ContextType>
+  constraint?: GQLConstraintDirectiveResolver<any, any, ContextType>
+  logCache?: GQLLogCacheDirectiveResolver<any, any, ContextType>
+  objectCache?: GQLObjectCacheDirectiveResolver<any, any, ContextType>
+  privateCache?: GQLPrivateCacheDirectiveResolver<any, any, ContextType>
+  purgeCache?: GQLPurgeCacheDirectiveResolver<any, any, ContextType>
+  rateLimit?: GQLRateLimitDirectiveResolver<any, any, ContextType>
+}>

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -4423,6 +4423,7 @@ export type GQLSpamRingSignals = {
   nearDupRingSize?: Maybe<Scalars['Int']['output']>
   sampleBrands?: Maybe<Array<Scalars['String']['output']>>
   sampleCodes?: Maybe<Array<Scalars['String']['output']>>
+  sampleTexts?: Maybe<Array<Scalars['String']['output']>>
   topEntity?: Maybe<Scalars['String']['output']>
 }
 
@@ -4433,6 +4434,7 @@ export type GQLSpamRingSignalsInput = {
   nearDupRingSize?: InputMaybe<Scalars['Int']['input']>
   sampleBrands?: InputMaybe<Array<Scalars['String']['input']>>
   sampleCodes?: InputMaybe<Array<Scalars['String']['input']>>
+  sampleTexts?: InputMaybe<Array<Scalars['String']['input']>>
   topEntity?: InputMaybe<Scalars['String']['input']>
 }
 
@@ -4444,7 +4446,7 @@ export type GQLSpamRingSkip = {
 
 export type GQLSpamRingStatus = 'dismissed' | 'frozen' | 'pending' | 'restored'
 
-export type GQLSpamRingsSort = 'detectedAt' | 'nAuthors' | 'score'
+export type GQLSpamRingsSort = 'detectedAt' | 'frozenAt' | 'nAuthors' | 'score'
 
 export type GQLSpamStatus = {
   __typename?: 'SpamStatus'
@@ -11793,6 +11795,11 @@ export type GQLSpamRingSignalsResolvers<
     ContextType
   >
   sampleCodes?: Resolver<
+    Maybe<Array<GQLResolversTypes['String']>>,
+    ParentType,
+    ContextType
+  >
+  sampleTexts?: Resolver<
     Maybe<Array<GQLResolversTypes['String']>>,
     ParentType,
     ContextType

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -1898,6 +1898,7 @@ export type GQLFeatureName =
   | 'payout'
   | 'spam_detection'
   | 'tag_adoption'
+  | 'topic_channel_spam_filter'
   | 'verify_appreciate'
 
 export type GQLFeaturedCommentsInput = {

--- a/src/definitions/spamRing.d.ts
+++ b/src/definitions/spamRing.d.ts
@@ -1,9 +1,5 @@
 export type SpamRingStatus = 'pending' | 'frozen' | 'dismissed' | 'restored'
-export type SpamRingMemberStatus =
-  | 'pending'
-  | 'frozen'
-  | 'skipped'
-  | 'restored'
+export type SpamRingMemberStatus = 'pending' | 'frozen' | 'skipped' | 'restored'
 export type SpamRingSeverity = 'low' | 'medium' | 'high' | 'critical'
 export type SpamRingEventAction =
   | 'detected'
@@ -22,6 +18,7 @@ export interface SpamRingSignals {
   topEntity?: string | null
   sampleCodes?: string[] | null
   sampleBrands?: string[] | null
+  sampleTexts?: string[] | null
   contentModelMax?: number | null
 }
 

--- a/src/handlers/bin/exportTransparencyMetrics.ts
+++ b/src/handlers/bin/exportTransparencyMetrics.ts
@@ -1,0 +1,121 @@
+import { TransparencyService } from '#connectors/transparencyService.js'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { connections } from '../../connections.js'
+
+interface CliArgs {
+  start?: string
+  end?: string
+  timezone?: 'Asia/Taipei' | 'UTC'
+  outDir: string
+  slug?: string
+  externalMetrics?: string
+}
+
+const usage = `
+Usage:
+  npm run build
+  npm run transparency:export -- --start=2026-01-01 --end=2026-06-30 --timezone=Asia/Taipei --out-dir=./tmp
+  npm run transparency:export -- --start=2026-01-01 --end=2026-06-30 --external-metrics=./private/aggregate-transparency-metrics.json
+`
+
+const parseArgs = (argv: string[]): CliArgs => {
+  const args: CliArgs = {
+    outDir: './tmp/transparency-metrics',
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index]
+    if (!token.startsWith('--')) {
+      continue
+    }
+
+    const [rawKey, inlineValue] = token.slice(2).split('=', 2)
+    const value = inlineValue ?? argv[index + 1]
+    if (!inlineValue) {
+      index += 1
+    }
+
+    switch (rawKey) {
+      case 'start':
+        args.start = value
+        break
+      case 'end':
+        args.end = value
+        break
+      case 'timezone':
+        if (value !== 'Asia/Taipei' && value !== 'UTC') {
+          throw new Error('timezone must be Asia/Taipei or UTC')
+        }
+        args.timezone = value
+        break
+      case 'out-dir':
+        args.outDir = value
+        break
+      case 'slug':
+        args.slug = value
+        break
+      case 'external-metrics':
+        args.externalMetrics = value
+        break
+      default:
+        throw new Error(`unknown argument: --${rawKey}`)
+    }
+  }
+
+  if (!args.start || !args.end) {
+    throw new Error('start and end are required')
+  }
+
+  return args
+}
+
+const shutdown = async () => {
+  await Promise.allSettled([
+    connections.knex.destroy(),
+    connections.knexRO.destroy(),
+    connections.knexSearch.destroy(),
+  ])
+
+  connections.redis.disconnect()
+  if (connections.objectCacheRedis !== connections.redis) {
+    connections.objectCacheRedis.disconnect()
+  }
+}
+
+try {
+  const args = parseArgs(process.argv.slice(2))
+  const externalMetrics = args.externalMetrics
+    ? JSON.parse(await readFile(path.resolve(args.externalMetrics), 'utf8'))
+    : undefined
+  const service = new TransparencyService(connections)
+  const metrics = await service.exportMetrics({
+    start: args.start as string,
+    end: args.end as string,
+    timezone: args.timezone ?? 'Asia/Taipei',
+    externalMetrics,
+  })
+  const csv = service.toCsv(metrics)
+  const slug = args.slug ?? `${args.start}_${args.end}`
+  const jsonPath = path.resolve(
+    args.outDir,
+    `transparency-metrics-${slug}.json`
+  )
+  const csvPath = path.resolve(args.outDir, `transparency-metrics-${slug}.csv`)
+
+  await mkdir(args.outDir, { recursive: true })
+  await Promise.all([
+    writeFile(jsonPath, `${JSON.stringify(metrics, null, 2)}\n`),
+    writeFile(csvPath, csv),
+  ])
+
+  console.log(`wrote ${jsonPath}`)
+  console.log(`wrote ${csvPath}`)
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error)
+  console.error(usage.trim())
+  process.exitCode = 1
+} finally {
+  await shutdown()
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,8 +91,12 @@ const { version } = require('../package.json')
   // Sentry error handler
   Sentry.setupExpressErrorHandler(app)
 
-  await new Promise((resolve) =>
-    app.listen({ port: PORT }, resolve as () => void)
-  )
-  console.log(`🚀 Server ready at http://localhost:${PORT}/graphql`)
+  const httpServer = app.listen({ port: PORT }, () => {
+    console.log(`🚀 Server ready at http://localhost:${PORT}/graphql`)
+  })
+
+  // Keep server keep-alive longer than nginx upstream to avoid reusing
+  // connections the server already closed (connection reset by peer).
+  httpServer.keepAliveTimeout = 65000
+  httpServer.headersTimeout = 66000
 })()

--- a/src/mutations/article/updateArticleState.ts
+++ b/src/mutations/article/updateArticleState.ts
@@ -2,16 +2,25 @@ import type { GQLMutationResolvers } from '#definitions/index.js'
 
 import {
   ARTICLE_STATE,
+  AUDIT_LOG_ACTION,
+  AUDIT_LOG_STATUS,
   OFFICIAL_NOTICE_EXTEND_TYPE,
 } from '#common/enums/index.js'
+import { auditLog } from '#common/logger.js'
 import { fromGlobalId } from '#common/utils/index.js'
 
 const resolver: GQLMutationResolvers['updateArticleState'] = async (
   _,
   { input: { id, state } },
-  { dataSources: { atomService, notificationService } }
+  { dataSources: { atomService, notificationService }, viewer }
 ) => {
   const { id: dbId } = fromGlobalId(id)
+  const actorId = viewer && 'id' in viewer ? viewer.id : null
+
+  const before = await atomService.findUnique({
+    table: 'article',
+    where: { id: dbId },
+  })
 
   const article = await atomService.update({
     table: 'article',
@@ -19,6 +28,15 @@ const resolver: GQLMutationResolvers['updateArticleState'] = async (
     data: {
       state,
     },
+  })
+  auditLog({
+    actorId,
+    action: AUDIT_LOG_ACTION.updateArticleState,
+    status: AUDIT_LOG_STATUS.succeeded,
+    entity: 'article',
+    entityId: dbId,
+    oldValue: JSON.stringify({ state: before?.state ?? null }),
+    newValue: JSON.stringify({ state }),
   })
 
   // trigger notification

--- a/src/mutations/comment/communityWatchRemoveComment.ts
+++ b/src/mutations/comment/communityWatchRemoveComment.ts
@@ -45,6 +45,7 @@ const resolver = async (
     dataSources: {
       atomService,
       articleService,
+      commentService,
       userService,
       notificationService,
       connections,
@@ -167,13 +168,36 @@ const resolver = async (
     }
   )
 
-  notificationService.trigger({
+  const auditAction = await commentService.findActiveCommunityWatchAction(
+    updatedComment.id
+  )
+  if (auditAction) {
+    await commentService.syncCommunityWatchModerationCaseCreated({
+      action: auditAction,
+    })
+  }
+
+  const appealLink = `https://${environment.siteDomain}/appeals`
+  const moderationNoticeData = {
+    link: appealLink,
+    moderationSource: 'community_watch',
+    publicReason: auditAction?.reason || reason,
+    appealLink,
+  }
+
+  await notificationService.trigger({
     event: OFFICIAL_NOTICE_EXTEND_TYPE.comment_banned,
     entities: [
       { type: 'target', entityTable: 'comment', entity: updatedComment },
     ],
     recipientId: updatedComment.authorId,
+    data: moderationNoticeData,
   })
+  if (auditAction) {
+    await commentService.syncCommunityWatchModerationCaseNoticeSent({
+      action: auditAction,
+    })
+  }
 
   // Emit a report-alert event for the admin Telegram side-channel.
   // Aggregated by the reported user (not by comment) — if the same user

--- a/src/mutations/comment/restoreCommunityWatchComment.ts
+++ b/src/mutations/comment/restoreCommunityWatchComment.ts
@@ -5,6 +5,7 @@ import {
   NODE_TYPES,
   OFFICIAL_NOTICE_EXTEND_TYPE,
 } from '#common/enums/index.js'
+import { environment } from '#common/environment.js'
 import { ForbiddenError } from '#common/errors.js'
 import { invalidateFQC } from '@matters/apollo-response-cache'
 
@@ -39,6 +40,13 @@ const resolver = async (
     }
   )
   const recordLink = communityWatchRecordLink(action.uuid)
+  const appealLink = `https://${environment.siteDomain}/appeals`
+  const moderationNoticeData = {
+    link: recordLink,
+    moderationSource: 'community_watch',
+    publicReason: action.reason,
+    appealLink,
+  }
   const commentEntity = {
     type: 'target' as const,
     entityTable: 'comment' as const,
@@ -52,7 +60,7 @@ const resolver = async (
           event: OFFICIAL_NOTICE_EXTEND_TYPE.community_watch_comment_restored,
           recipientId: commentAuthorId,
           entities: [commentEntity],
-          data: { link: recordLink },
+          data: moderationNoticeData,
         })
       : Promise.resolve(),
     action.actorId && action.actorId !== viewer.id
@@ -60,10 +68,12 @@ const resolver = async (
           event: OFFICIAL_NOTICE_EXTEND_TYPE.community_watch_action_reversed,
           recipientId: action.actorId,
           entities: [commentEntity],
-          data: { link: recordLink },
+          data: moderationNoticeData,
         })
       : Promise.resolve(),
   ])
+
+  await commentService.syncCommunityWatchModerationCaseNoticeSent({ action })
 
   await invalidateFQC({
     node: {

--- a/src/mutations/quote/putQuote.ts
+++ b/src/mutations/quote/putQuote.ts
@@ -5,13 +5,10 @@ import {
   ARTICLE_STATE,
   MAX_QUOTE_LENGTH,
   NODE_TYPES,
-  QUOTE_DAILY_LIMIT,
-  QUOTE_PER_ARTICLE_LIMIT,
   QUOTE_STATE,
   USER_STATE,
 } from '#common/enums/index.js'
 import {
-  ActionLimitExceededError,
   ArticleNotFoundError,
   ForbiddenByStateError,
   ForbiddenError,
@@ -32,7 +29,7 @@ const resolver: GQLMutationResolvers['putQuote'] = async (
     dataSources: {
       atomService,
       articleService,
-      connections: { knexRO, redis },
+      connections: { redis },
     },
   }
 ) => {
@@ -127,34 +124,8 @@ const resolver: GQLMutationResolvers['putQuote'] = async (
     throw new UserInputError('this quote is already on the wall')
   }
 
-  // per-article cap (prevents plastering the wall with one article)
-  const perArticleCount = await atomService.count({
-    table: 'quote',
-    where: {
-      userId: viewer.id,
-      articleId: article.id,
-      state: QUOTE_STATE.active,
-    },
-  })
-  if (perArticleCount >= QUOTE_PER_ARTICLE_LIMIT) {
-    throw new ActionLimitExceededError(
-      `up to ${QUOTE_PER_ARTICLE_LIMIT} quotes per article`
-    )
-  }
-
-  // daily cap; counts posting actions (UTC day), retraction does not refund
-  const todayStart = new Date()
-  todayStart.setUTCHours(0, 0, 0, 0)
-  const dailyCount = await knexRO('quote')
-    .count('id')
-    .where({ userId: viewer.id })
-    .andWhere('createdAt', '>=', todayStart)
-    .first()
-  if (Number(dailyCount?.count ?? 0) >= QUOTE_DAILY_LIMIT) {
-    throw new ActionLimitExceededError(
-      `up to ${QUOTE_DAILY_LIMIT} quotes per day`
-    )
-  }
+  // no quantity caps: per-article and daily limits removed, so users may post
+  // any number of quotes; the content rules and dedup above still apply
 
   let quote
   try {

--- a/src/mutations/system/index.ts
+++ b/src/mutations/system/index.ts
@@ -20,6 +20,7 @@ import setWritingAdStatus from './setWritingAdStatus.js'
 import singleFileUpload from './singleFileUpload.js'
 import submitReport from './submitReport.js'
 import toggleSeedingUsers from './toggleSeedingUsers.js'
+import updateModerationCase from './updateModerationCase.js'
 
 export default {
   Mutation: {
@@ -40,6 +41,7 @@ export default {
     putUserFederationSetting,
     putArticleFederationSetting,
     submitReport,
+    updateModerationCase,
     putIcymiTopic,
     setSpamStatus,
     setAdStatus,

--- a/src/mutations/system/setSpamStatus.ts
+++ b/src/mutations/system/setSpamStatus.ts
@@ -1,15 +1,21 @@
 import type { GQLMutationResolvers } from '#definitions/index.js'
 
-import { NODE_TYPES } from '#common/enums/index.js'
+import {
+  AUDIT_LOG_ACTION,
+  AUDIT_LOG_STATUS,
+  NODE_TYPES,
+} from '#common/enums/index.js'
 import { UserInputError } from '#common/errors.js'
+import { auditLog } from '#common/logger.js'
 import { fromGlobalId } from '#common/utils/index.js'
 
 const resolver: GQLMutationResolvers['setSpamStatus'] = async (
   _,
   { input: { id: globalId, isSpam } },
-  { dataSources: { atomService, publicationService } }
+  { dataSources: { atomService, publicationService }, viewer }
 ) => {
   const { type, id } = fromGlobalId(globalId)
+  const actorId = viewer && 'id' in viewer ? viewer.id : null
 
   if (!id) {
     throw new UserInputError('id is invalid')
@@ -17,10 +23,23 @@ const resolver: GQLMutationResolvers['setSpamStatus'] = async (
 
   switch (type) {
     case NODE_TYPES.Article: {
+      const before = await atomService.findUnique({
+        table: 'article',
+        where: { id },
+      })
       const article = await atomService.update({
         table: 'article',
         where: { id },
         data: { isSpam },
+      })
+      auditLog({
+        actorId,
+        action: AUDIT_LOG_ACTION.setSpamStatus,
+        status: AUDIT_LOG_STATUS.succeeded,
+        entity: 'article',
+        entityId: id,
+        oldValue: JSON.stringify({ isSpam: before?.isSpam ?? null }),
+        newValue: JSON.stringify({ isSpam }),
       })
 
       if (!isSpam) {
@@ -31,20 +50,46 @@ const resolver: GQLMutationResolvers['setSpamStatus'] = async (
     }
 
     case NODE_TYPES.Comment: {
+      const before = await atomService.findUnique({
+        table: 'comment',
+        where: { id },
+      })
       const comment = await atomService.update({
         table: 'comment',
         where: { id },
         data: { isSpam },
+      })
+      auditLog({
+        actorId,
+        action: AUDIT_LOG_ACTION.setSpamStatus,
+        status: AUDIT_LOG_STATUS.succeeded,
+        entity: 'comment',
+        entityId: id,
+        oldValue: JSON.stringify({ isSpam: before?.isSpam ?? null }),
+        newValue: JSON.stringify({ isSpam }),
       })
 
       return { ...comment, __type: NODE_TYPES.Comment } as any
     }
 
     case NODE_TYPES.Moment: {
+      const before = await atomService.findUnique({
+        table: 'moment',
+        where: { id },
+      })
       const moment = await atomService.update({
         table: 'moment',
         where: { id },
         data: { isSpam },
+      })
+      auditLog({
+        actorId,
+        action: AUDIT_LOG_ACTION.setSpamStatus,
+        status: AUDIT_LOG_STATUS.succeeded,
+        entity: 'moment',
+        entityId: id,
+        oldValue: JSON.stringify({ isSpam: before?.isSpam ?? null }),
+        newValue: JSON.stringify({ isSpam }),
       })
 
       return { ...moment, __type: NODE_TYPES.Moment } as any

--- a/src/mutations/system/submitReport.ts
+++ b/src/mutations/system/submitReport.ts
@@ -1,6 +1,6 @@
 import type { GQLMutationResolvers, ReportType } from '#definitions/index.js'
 
-import { NODE_TYPES } from '#common/enums/index.js'
+import { NODE_TYPES, OFFICIAL_NOTICE_EXTEND_TYPE } from '#common/enums/index.js'
 import { environment } from '#common/environment.js'
 import { UserInputError } from '#common/errors.js'
 import { enqueueReportAlert } from '#common/notifications/reportAlert.js'
@@ -9,7 +9,7 @@ import { fromGlobalId, toGlobalId } from '#common/utils/index.js'
 const resolver: GQLMutationResolvers['submitReport'] = async (
   _,
   { input: { targetId: globalId, reason } },
-  { dataSources: { systemService }, viewer }
+  { dataSources: { atomService, notificationService, systemService }, viewer }
 ) => {
   const { type, id: targetId } = fromGlobalId(globalId)
   if (
@@ -23,6 +23,39 @@ const resolver: GQLMutationResolvers['submitReport'] = async (
     reporterId: viewer.id,
     reason,
   })
+
+  if (
+    type === NODE_TYPES.Comment &&
+    report.moderationOutcome === 'content_collapsed' &&
+    report.moderationCaseId
+  ) {
+    const comment = await atomService.commentIdLoader.load(targetId)
+    const appealLink = `https://${environment.siteDomain}/appeals`
+
+    if (comment?.authorId) {
+      await notificationService.trigger({
+        event: OFFICIAL_NOTICE_EXTEND_TYPE.comment_banned,
+        entities: [{ type: 'target', entityTable: 'comment', entity: comment }],
+        recipientId: comment.authorId,
+        data: {
+          link: appealLink,
+          moderationSource: 'direct_report',
+          publicReason: reason,
+          appealLink,
+        },
+      })
+      await systemService.markModerationCaseNoticeSent({
+        id: report.moderationCaseId,
+        publicReason: reason,
+        metadata: {
+          reportId: report.id,
+          source: 'direct_report',
+          targetType: 'comment',
+          notificationType: OFFICIAL_NOTICE_EXTEND_TYPE.comment_banned,
+        },
+      })
+    }
+  }
 
   // Emit a report-alert event to SQS. A separate Lambda worker delivers it
   // to the admin Telegram chat. enqueueReportAlert is best-effort and

--- a/src/mutations/system/updateModerationCase.ts
+++ b/src/mutations/system/updateModerationCase.ts
@@ -1,0 +1,27 @@
+import type {
+  Context,
+  ModerationCaseOutcome,
+  ModerationCaseStatus,
+  ModerationNoticeState,
+} from '#definitions/index.js'
+
+type UpdateModerationCaseInput = {
+  id: string
+  status?: ModerationCaseStatus | null
+  outcome?: ModerationCaseOutcome | null
+  noticeState?: ModerationNoticeState | null
+  publicReason?: string | null
+  internalNote?: string | null
+}
+
+const resolver = async (
+  _: unknown,
+  { input }: { input: UpdateModerationCaseInput },
+  { viewer, dataSources: { systemService } }: Context
+) =>
+  systemService.updateModerationCase({
+    ...input,
+    actorId: viewer.id,
+  })
+
+export default resolver

--- a/src/queries/system/oss/spamRings.ts
+++ b/src/queries/system/oss/spamRings.ts
@@ -17,6 +17,9 @@ export const spamRings: GQLOssResolvers['spamRings'] = async (
     case 'detectedAt':
       orderBy = { column: 'detectedAt', order: 'desc' }
       break
+    case 'frozenAt':
+      orderBy = { column: 'frozenAt', order: 'desc' }
+      break
     case 'nAuthors':
       orderBy = { column: 'nAuthors', order: 'desc' }
       break

--- a/src/queries/system/report.ts
+++ b/src/queries/system/report.ts
@@ -8,7 +8,52 @@ import { NODE_TYPES } from '#common/enums/index.js'
 import { ServerError } from '#common/errors.js'
 import { toGlobalId } from '#common/utils/index.js'
 
-const report: GQLReportResolvers = {
+type ReportParent = {
+  id: string
+  source?: ReportSource
+  reason?: string
+  articleId?: string | null
+  commentId?: string | null
+  momentId?: string | null
+}
+
+const getModerationTarget = ({
+  articleId,
+  commentId,
+  momentId,
+}: ReportParent) => {
+  if (articleId) {
+    return { targetType: 'article', targetId: articleId }
+  }
+  if (commentId) {
+    return { targetType: 'comment', targetId: commentId }
+  }
+  if (momentId) {
+    return { targetType: 'moment', targetId: momentId }
+  }
+  return null
+}
+
+const getModerationCaseReasonCandidates = ({
+  source,
+  reason,
+}: ReportParent) => {
+  if (!reason) {
+    return []
+  }
+  if (source !== 'community_watch') {
+    return [reason]
+  }
+  if (reason === 'community_watch_porn_ad') {
+    return [reason, 'porn_ad']
+  }
+  if (reason === 'community_watch_spam_ad') {
+    return [reason, 'spam_ad']
+  }
+  return [reason]
+}
+
+const report = {
   id: ({ id, source }) => {
     // For rows derived from `community_watch_action` the union resolver
     // synthesises an id like `cw:42`. Keep the prefix in the inner id so the
@@ -66,6 +111,40 @@ const report: GQLReportResolvers = {
       : parent.id
     return commentService.findCommunityWatchActionById(id)
   },
+  moderationCase: async (
+    parent: ReportParent,
+    _: unknown,
+    {
+      dataSources: {
+        connections: { knex },
+      },
+    }: Context
+  ) => {
+    const target = getModerationTarget(parent)
+    const reasonCandidates = getModerationCaseReasonCandidates(parent)
+    if (!target || reasonCandidates.length <= 0) {
+      return null
+    }
+
+    return knex('moderation_case')
+      .where({
+        source:
+          parent.source === 'community_watch'
+            ? 'community_watch'
+            : 'direct_report',
+        targetType: target.targetType,
+        targetId: target.targetId,
+      })
+      .whereIn('reason', reasonCandidates)
+      .orderBy('id', 'desc')
+      .first()
+  },
+} as GQLReportResolvers & {
+  moderationCase: (
+    parent: ReportParent,
+    _: unknown,
+    context: Context
+  ) => Promise<unknown>
 }
 
 export default report

--- a/src/types/__test__/2/comment.test.ts
+++ b/src/types/__test__/2/comment.test.ts
@@ -664,12 +664,161 @@ describe('community watch remove comment', () => {
       },
     })
     expect(syncedReport).toBeDefined()
+
+    const moderationCase = await connections.knex('moderation_case').where({
+      source: 'community_watch',
+      targetType: 'comment',
+      targetId: comment.id,
+      reason: 'spam_ad',
+    }).first()
+    expect(moderationCase).toMatchObject({
+      primaryReporterId: watcher.id,
+      publicReason: 'spam_ad',
+      status: 'action_taken',
+      outcome: 'content_hidden',
+      automationRole: 'none',
+      noticeState: 'sent',
+    })
+
+    const moderationEvents = await connections
+      .knex('moderation_event')
+      .where({ caseId: moderationCase.id })
+      .orderBy('id', 'asc')
+    expect(moderationEvents.map(({ eventType }) => eventType)).toEqual([
+      'created',
+      'actioned',
+      'notified',
+    ])
+    expect(JSON.stringify(moderationEvents)).not.toContain('<p>spam ad</p>')
+
     expect(mockTrigger).toHaveBeenCalledWith(
       expect.objectContaining({
         event: OFFICIAL_NOTICE_EXTEND_TYPE.comment_banned,
         recipientId: '2',
       })
     )
+  })
+
+  test('syncs moderation case review and restore transitions', async () => {
+    const watcher = await userService.create({
+      userName: `watcher${uuidv4().replace(/-/g, '').slice(0, 12)}`,
+    })
+    await atomService.create({
+      table: 'user_feature_flag',
+      data: {
+        userId: watcher.id,
+        type: USER_FEATURE_FLAG_TYPE.communityWatch,
+      },
+    })
+
+    const article = await atomService.articleIdLoader.load('1')
+    const { id: targetTypeId } = await atomService.findFirst({
+      table: 'entity_type',
+      where: { table: 'article' },
+    })
+    const comment = await atomService.create({
+      table: 'comment',
+      data: {
+        uuid: uuidv4(),
+        content: '<p>appealed spam ad</p>',
+        authorId: '2',
+        targetId: article.id,
+        targetTypeId,
+        parentCommentId: null,
+        type: COMMENT_TYPE.article,
+        state: COMMENT_STATE.active,
+      },
+    })
+    const server = await testClient({
+      userId: watcher.id,
+      isAuth: true,
+      connections,
+      dataSources: { notificationService: { trigger: jest.fn() } },
+    })
+
+    const { errors } = await server.executeOperation({
+      query: COMMUNITY_WATCH_REMOVE_COMMENT,
+      variables: {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.Comment, id: comment.id }),
+          reason: 'porn_ad',
+        },
+      },
+    })
+    expect(errors).toBeUndefined()
+
+    const action = await atomService.findFirst({
+      table: 'community_watch_action',
+      where: { commentId: comment.id },
+    })
+    let moderationCase = await connections.knex('moderation_case').where({
+      source: 'community_watch',
+      targetType: 'comment',
+      targetId: comment.id,
+      reason: 'porn_ad',
+    }).first()
+    expect(moderationCase).toMatchObject({
+      status: 'action_taken',
+      outcome: 'content_hidden',
+    })
+
+    await commentService.updateCommunityWatchActionState({
+      uuid: action.uuid,
+      actorId: watcher.id,
+      appealState: 'received',
+      note: 'appeal received',
+    })
+    moderationCase = await connections
+      .knex('moderation_case')
+      .where({ id: moderationCase.id })
+      .first()
+    expect(moderationCase).toMatchObject({
+      status: 'appealed',
+      outcome: 'content_hidden',
+    })
+
+    await commentService.updateCommunityWatchActionState({
+      uuid: action.uuid,
+      actorId: watcher.id,
+      reviewState: 'upheld',
+      note: 'review upheld',
+    })
+    moderationCase = await connections
+      .knex('moderation_case')
+      .where({ id: moderationCase.id })
+      .first()
+    expect(moderationCase).toMatchObject({
+      status: 'resolved',
+      outcome: 'upheld',
+    })
+    expect(moderationCase.resolvedAt).toBeDefined()
+
+    await commentService.restoreCommunityWatchComment({
+      uuid: action.uuid,
+      actorId: watcher.id,
+      note: 'restore after appeal',
+    })
+    moderationCase = await connections
+      .knex('moderation_case')
+      .where({ id: moderationCase.id })
+      .first()
+    expect(moderationCase).toMatchObject({
+      status: 'resolved',
+      outcome: 'restored',
+    })
+
+    const moderationEvents = await connections
+      .knex('moderation_event')
+      .where({ caseId: moderationCase.id })
+      .orderBy('id', 'asc')
+    expect(moderationEvents.map(({ eventType }) => eventType)).toEqual([
+      'created',
+      'actioned',
+      'notified',
+      'appealed',
+      'reviewed',
+      'restored',
+    ])
   })
 })
 

--- a/src/types/__test__/2/quote.test.ts
+++ b/src/types/__test__/2/quote.test.ts
@@ -5,8 +5,6 @@ import {
   USER_STATE,
   CAMPAIGN_STATE,
   QUOTE_STATE,
-  QUOTE_DAILY_LIMIT,
-  QUOTE_PER_ARTICLE_LIMIT,
 } from '#common/enums/index.js'
 import { toGlobalId, fromGlobalId } from '#common/utils/index.js'
 import { AtomService, CampaignService } from '#connectors/index.js'
@@ -255,11 +253,10 @@ describe('putQuote', () => {
     expect(count).toBe(1)
   })
 
-  test('per-article cap blocks the next quote once the limit is reached', async () => {
-    // pre-fill up to the per-article limit with distinct excerpts
+  test('no per-article cap: more quotes from the same article still succeed', async () => {
+    // quantity limits removed — distinct excerpts from one article all post
     await seedQuote({ content: 'some' })
     await seedQuote({ content: 'html' })
-    expect(QUOTE_PER_ARTICLE_LIMIT).toBe(2)
 
     const server = await testClient({
       connections,
@@ -270,13 +267,12 @@ describe('putQuote', () => {
       query: PUT_QUOTE,
       variables: { input: { articleId: articleGlobalId, content: 'string' } },
     })
-    expect(errors?.[0].extensions.code).toBe('ACTION_LIMIT_EXCEEDED')
+    expect(errors).toBeUndefined()
   })
 
-  test('daily cap blocks the next quote once the limit is reached', async () => {
-    // seed the daily limit worth of quotes for this user (today, any article)
-    expect(QUOTE_DAILY_LIMIT).toBe(5)
-    for (let i = 0; i < QUOTE_DAILY_LIMIT; i++) {
+  test('no daily cap: posting beyond the old daily limit still succeeds', async () => {
+    // quantity limits removed — posting many in a day no longer blocks
+    for (let i = 0; i < 5; i++) {
       await seedQuote({ content: `daily-${i}` })
     }
     const server = await testClient({
@@ -288,7 +284,7 @@ describe('putQuote', () => {
       query: PUT_QUOTE,
       variables: { input: { articleId: articleGlobalId, content: 'string' } },
     })
-    expect(errors?.[0].extensions.code).toBe('ACTION_LIMIT_EXCEEDED')
+    expect(errors).toBeUndefined()
   })
 })
 

--- a/src/types/__test__/2/system.test.ts
+++ b/src/types/__test__/2/system.test.ts
@@ -6,8 +6,13 @@ import type {
 } from '#definitions/index.js'
 
 import _get from 'lodash/get.js'
+import { jest } from '@jest/globals'
 
-import { NODE_TYPES, USER_STATE } from '#common/enums/index.js'
+import {
+  NODE_TYPES,
+  OFFICIAL_NOTICE_EXTEND_TYPE,
+  USER_STATE,
+} from '#common/enums/index.js'
 import { toGlobalId } from '#common/utils/index.js'
 import { MomentService, CampaignService } from '#connectors/index.js'
 
@@ -1363,6 +1368,9 @@ describe('federation settings', () => {
 
 describe('submitReport', () => {
   beforeEach(async () => {
+    await connections.knex('moderation_event').delete()
+    await connections.knex('moderation_case_reporter').delete()
+    await connections.knex('moderation_case').delete()
     await connections.knex('report').delete()
     await connections.knex('community_watch_action').delete()
   })
@@ -1380,6 +1388,9 @@ describe('submitReport', () => {
             state
           }
           ... on Moment {
+            id
+          }
+          ... on Comment {
             id
           }
         }
@@ -1401,6 +1412,17 @@ describe('submitReport', () => {
                 actionState
                 reviewState
               }
+              moderationCase {
+                id
+                source
+                targetType
+                reason
+                status
+                outcome
+                automationRole
+                noticeState
+                publicReason
+              }
               reporter {
                 id
               }
@@ -1418,6 +1440,20 @@ describe('submitReport', () => {
             }
           }
         }
+      }
+    }
+  `
+  const UPDATE_MODERATION_CASE = /* GraphQL */ `
+    mutation ($input: UpdateModerationCaseInput!) {
+      updateModerationCase(input: $input) {
+        id
+        source
+        targetType
+        reason
+        publicReason
+        status
+        outcome
+        noticeState
       }
     }
   `
@@ -1481,6 +1517,183 @@ describe('submitReport', () => {
     expect(dataQuery.oss.reports.edges[1].node.source).toBe('direct')
     expect(dataQuery.oss.reports.edges[0].node.communityWatchAction).toBeNull()
     expect(dataQuery.oss.reports.edges[1].node.communityWatchAction).toBeNull()
+    expect(dataQuery.oss.reports.edges[0].node.moderationCase).toMatchObject({
+      source: 'direct_report',
+      reason: 'other',
+      status: 'received',
+      outcome: null,
+      automationRole: 'none',
+      noticeState: 'not_required',
+      publicReason: null,
+    })
+    expect(dataQuery.oss.reports.edges[1].node.moderationCase).toMatchObject({
+      source: 'direct_report',
+      reason: 'other',
+      status: 'received',
+      outcome: null,
+      automationRole: 'none',
+      noticeState: 'not_required',
+      publicReason: null,
+    })
+  })
+
+  test('notifies comment author when direct reports collapse a comment', async () => {
+    const commentId = '1'
+    await connections
+      .knex('comment')
+      .where({ id: commentId })
+      .update({ state: 'active' })
+
+    const comment = await connections
+      .knex('comment')
+      .where({ id: commentId })
+      .first()
+    const notificationService = { trigger: jest.fn() }
+
+    for (const userId of ['2', '3', '4']) {
+      const server = await testClient({
+        connections,
+        userId,
+        dataSources: { notificationService },
+      })
+      const { errors } = await server.executeOperation({
+        query: SUBMIT_REPORT,
+        variables: {
+          input: {
+            targetId: toGlobalId({ type: NODE_TYPES.Comment, id: commentId }),
+            reason: 'other',
+          },
+        },
+      })
+      expect(errors).toBeUndefined()
+    }
+
+    expect(notificationService.trigger).toHaveBeenCalledTimes(1)
+    expect(notificationService.trigger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: OFFICIAL_NOTICE_EXTEND_TYPE.comment_banned,
+        recipientId: comment.authorId,
+        data: expect.objectContaining({
+          moderationSource: 'direct_report',
+          publicReason: 'other',
+          appealLink: expect.stringContaining('/appeals'),
+        }),
+      })
+    )
+
+    const moderationCase = await connections
+      .knex('moderation_case')
+      .where({
+        source: 'direct_report',
+        targetType: 'comment',
+        targetId: commentId,
+        reason: 'other',
+      })
+      .first()
+
+    expect(moderationCase).toMatchObject({
+      status: 'action_taken',
+      outcome: 'content_collapsed',
+      noticeState: 'sent',
+      publicReason: 'other',
+    })
+
+    const events = await connections
+      .knex('moderation_event')
+      .where({ caseId: moderationCase.id })
+      .orderBy('id')
+
+    expect(events.map((event) => event.eventType)).toEqual([
+      'created',
+      'actioned',
+      'notified',
+    ])
+    expect(events[2]).toEqual(
+      expect.objectContaining({
+        eventType: 'notified',
+        actorType: 'system',
+        publicReason: 'other',
+        fromStatus: 'action_taken',
+        toStatus: 'action_taken',
+        fromOutcome: 'content_collapsed',
+        toOutcome: 'content_collapsed',
+      })
+    )
+    expect(events[2].metadata).toEqual(
+      expect.objectContaining({
+        source: 'direct_report',
+        targetType: 'comment',
+        notificationType: OFFICIAL_NOTICE_EXTEND_TYPE.comment_banned,
+        noticeState: 'sent',
+      })
+    )
+  })
+
+  test('admin can update moderation case review summary', async () => {
+    const server = await testClient({
+      isAuth: true,
+      isAdmin: true,
+      connections,
+    })
+    await server.executeOperation({
+      query: SUBMIT_REPORT,
+      variables: {
+        input: {
+          targetId: toGlobalId({ type: NODE_TYPES.Article, id: 1 }),
+          reason: 'other',
+        },
+      },
+    })
+
+    const reportResult = await server.executeOperation({
+      query: GET_REPORTS,
+      variables: { input: { first: 1 } },
+    })
+    const moderationCase =
+      reportResult.data.oss.reports.edges[0].node.moderationCase
+
+    const { data, errors } = await server.executeOperation({
+      query: UPDATE_MODERATION_CASE,
+      variables: {
+        input: {
+          id: moderationCase.id,
+          status: 'rejected',
+          outcome: 'no_action',
+          noticeState: 'sent',
+          publicReason: '未違反站規',
+          internalNote: 'reviewed by NCC P1 test',
+        },
+      },
+    })
+
+    expect(errors).toBeUndefined()
+    expect(data.updateModerationCase).toMatchObject({
+      id: moderationCase.id,
+      source: 'direct_report',
+      status: 'rejected',
+      outcome: 'no_action',
+      noticeState: 'sent',
+      publicReason: '未違反站規',
+    })
+    expect(JSON.stringify(data.updateModerationCase)).not.toContain(
+      'reviewed by NCC P1 test'
+    )
+
+    const event = await connections
+      .knex('moderation_event')
+      .where({ caseId: moderationCase.id })
+      .orderBy('id', 'desc')
+      .first()
+    expect(event).toMatchObject({
+      eventType: 'reviewed',
+      actorType: 'admin',
+      fromStatus: 'received',
+      toStatus: 'rejected',
+      fromOutcome: null,
+      toOutcome: 'no_action',
+      publicReason: '未違反站規',
+      internalNote: 'reviewed by NCC P1 test',
+    })
   })
 
   test('reports query unions community_watch_action rows', async () => {
@@ -1596,6 +1809,7 @@ describe('submitReport', () => {
       actionState: 'active',
       reviewState: 'pending',
     })
+    expect(watchEdge?.node.moderationCase).toBeNull()
     // The target resolves to the underlying Comment.
     expect(watchEdge?.node.target.id).toBeDefined()
   })

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -682,6 +682,7 @@ export default /* GraphQL */ `
     circle_management
     circle_interact
     spam_detection
+    topic_channel_spam_filter
     article_channel
     hottest_moment_feed
   }

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -49,6 +49,7 @@ export default /* GraphQL */ `
     putUserFederationSetting(input: PutUserFederationSettingInput!): UserFederationSetting! @auth(mode: "${AUTH_MODE.admin}")
     putArticleFederationSetting(input: PutArticleFederationSettingInput!): ArticleFederationSetting! @auth(mode: "${AUTH_MODE.admin}")
     putIcymiTopic(input: PutIcymiTopicInput!): IcymiTopic @auth(mode: "${AUTH_MODE.admin}") @purgeCache(type: "${NODE_TYPES.IcymiTopic}")
+    updateModerationCase(input: UpdateModerationCaseInput!): ModerationCase! @auth(mode: "${AUTH_MODE.admin}")
     setSpamStatus(input: SetSpamStatusInput!): Writing! @auth(mode: "${AUTH_MODE.admin}") @purgeCache(type: "${NODE_TYPES.Writing}")
     setAdStatus(input: SetAdStatusInput!): Article! @auth(mode: "${AUTH_MODE.admin}") @purgeCache(type: "${NODE_TYPES.Article}")
     setWritingAdStatus(input: SetAdStatusInput!): Writing! @auth(mode: "${AUTH_MODE.admin}") @purgeCache(type: "${NODE_TYPES.Writing}")
@@ -249,7 +250,24 @@ export default /* GraphQL */ `
     source: ReportSource!
     "The audit record when this report originates from a community watch action."
     communityWatchAction: CommunityWatchAction
+    "Structured moderation case summary for OSS review and transparency reporting."
+    moderationCase: ModerationCase
     createdAt: DateTime!
+  }
+
+  type ModerationCase {
+    id: ID!
+    source: ModerationCaseSource!
+    targetType: ModerationTargetType!
+    reason: String!
+    publicReason: String
+    status: ModerationCaseStatus!
+    outcome: ModerationCaseOutcome
+    automationRole: ModerationAutomationRole!
+    noticeState: ModerationNoticeState!
+    createdAt: DateTime!
+    resolvedAt: DateTime
+    closedAt: DateTime
   }
 
   type ReportConnection implements Connection {
@@ -398,6 +416,15 @@ export default /* GraphQL */ `
 
   input OSSSpamRingsFilter {
     status: SpamRingStatus
+  }
+
+  input UpdateModerationCaseInput {
+    id: ID!
+    status: ModerationCaseStatus
+    outcome: ModerationCaseOutcome
+    noticeState: ModerationNoticeState
+    publicReason: String
+    internalNote: String
   }
 
   input NodeInput {
@@ -742,6 +769,61 @@ export default /* GraphQL */ `
     direct
     "Created automatically when a community watch member removes a comment."
     community_watch
+  }
+
+  enum ModerationCaseSource {
+    direct_report
+    community_watch
+    admin
+    system
+    model_assisted
+    automated
+  }
+
+  enum ModerationTargetType {
+    article
+    comment
+    moment
+    user
+    tag
+    other
+  }
+
+  enum ModerationCaseStatus {
+    received
+    reviewing
+    action_taken
+    rejected
+    appealed
+    resolved
+    closed
+  }
+
+  enum ModerationCaseOutcome {
+    no_action
+    content_collapsed
+    content_hidden
+    content_removed
+    account_limited
+    restored
+    partially_restored
+    upheld
+  }
+
+  enum ModerationAutomationRole {
+    none
+    suggested
+    assisted
+    automated
+  }
+
+  enum ModerationNoticeState {
+    not_required
+    pending
+    sent
+    delayed
+    prohibited
+    failed
   }
 
   type IcymiTopic implements Node {

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -326,6 +326,7 @@ export default /* GraphQL */ `
     topEntity: String
     sampleCodes: [String!]
     sampleBrands: [String!]
+    sampleTexts: [String!]
     contentModelMax: Float
   }
 
@@ -405,6 +406,7 @@ export default /* GraphQL */ `
     score
     detectedAt
     nAuthors
+    frozenAt
   }
 
   input OSSSpamRingsInput {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -898,6 +898,7 @@ export default /* GraphQL */ `
     topEntity: String
     sampleCodes: [String!]
     sampleBrands: [String!]
+    sampleTexts: [String!]
     contentModelMax: Float
   }
 


### PR DESCRIPTION
Promote current develop to production after staging verification.\n\nNotes:\n- Resolves develop -> master conflicts in topic channel article query tests and channel service by preserving the topic_channel_spam_filter behavior from develop.\n- Staging verification passed before production promotion.\n- topic_channel_spam_filter is enabled with value 0.8 on staging.\n- spam_detection remains enabled with value 0.88 on staging.\n\nProduction deploy will run through the existing pull_request closed workflow after merge.