### PR TITLE
chore(security): land auth-bypass + freeze-transaction fixes on develop (stranded by stacked merges)

### DIFF
--- a/src/connectors/__test__/spamRingService.test.ts
+++ b/src/connectors/__test__/spamRingService.test.ts
@@ -9,9 +9,11 @@ const DAY = 86400000
 const makeConnections = ({
   ring,
   members = [],
+  users = {},
 }: {
   ring: any
   members?: any[]
+  users?: Record<string, any>
 }) => {
   const rec = {
     memberUpdates: [] as any[],
@@ -26,6 +28,8 @@ const makeConnections = ({
         return b
       },
       orderBy: () => b,
+      transacting: () => b,
+      forUpdate: () => b,
       modify: (fn?: any) => {
         if (fn) fn(b)
         return b
@@ -36,6 +40,7 @@ const makeConnections = ({
       limit: () => b,
       first: async () => {
         if (ctx.table === 'spam_ring') return ring
+        if (ctx.table === 'user') return users[ctx.where.id] ?? undefined
         return undefined
       },
       update: (data: any) => {
@@ -46,14 +51,25 @@ const makeConnections = ({
           rec.ringUpdates.push(data)
         }
         return {
+          transacting: () => ({
+            returning: async () => [{ ...ring, ...data }],
+            then: (resolve: any) => resolve(1),
+          }),
           returning: async () => [{ ...ring, ...data }],
           then: (resolve: any) => resolve(1),
         }
       },
-      insert: async (rows: any) => {
+      insert: (rows: any) => {
         if (ctx.table === 'spam_ring_event') {
           rec.eventInserts.push(...(Array.isArray(rows) ? rows : [rows]))
         }
+        const inserted = Array.isArray(rows) ? rows[0] : rows
+        const res: any = {
+          transacting: () => res,
+          returning: async () => [{ ...ring, ...inserted }],
+          then: (resolve: any) => resolve(undefined),
+        }
+        return res
       },
       // awaiting the builder directly (findMembers): resolve member rows
       then: (resolve: any) =>
@@ -61,7 +77,9 @@ const makeConnections = ({
     }
     return b
   }
-  const knex = (t: string) => builder(t)
+  const knex: any = (t: string) => builder(t)
+  // run the freeze/unfreeze transaction inline against the same mock builder
+  knex.transaction = async (cb: (trx: any) => Promise<any>) => cb({})
   const connections: any = {
     knex,
     knexRO: knex,
@@ -125,7 +143,7 @@ describe('SpamRingService.freezeRing', () => {
         createdAt: new Date(Date.now() - DAY),
       },
     }
-    const { connections, rec } = makeConnections({ ring, members })
+    const { connections, rec } = makeConnections({ ring, members, users })
     const service = makeService(connections, users)
     const userService = makeUserService(users)
 
@@ -137,9 +155,10 @@ describe('SpamRingService.freezeRing', () => {
 
     // only u1 frozen (u2 old account, u3 already banned)
     expect(userService.freezeUser).toHaveBeenCalledTimes(1)
-    expect(userService.freezeUser).toHaveBeenCalledWith('u1', {
-      remark: USER_BAN_REMARK.spamRing,
-    })
+    expect(userService.freezeUser).toHaveBeenCalledWith(
+      'u1',
+      expect.objectContaining({ remark: USER_BAN_REMARK.spamRing })
+    )
     expect(userService.banUser).not.toHaveBeenCalled()
     expect(result.frozen.map((u: any) => u.id)).toEqual(['u1'])
     expect(result.skipped.map((s: any) => s.user.id).sort()).toEqual([
@@ -182,7 +201,7 @@ describe('SpamRingService.freezeRing', () => {
         createdAt: new Date(Date.now() - DAY),
       },
     }
-    const { connections, rec } = makeConnections({ ring, members })
+    const { connections, rec } = makeConnections({ ring, members, users })
     const service = makeService(connections, users)
     const userService = makeUserService(users)
     userService.findScore = jest.fn(async (id: string) =>
@@ -219,7 +238,7 @@ describe('SpamRingService.freezeRing', () => {
         createdAt: new Date(Date.now() - DAY),
       },
     }
-    const { connections } = makeConnections({ ring, members })
+    const { connections } = makeConnections({ ring, members, users })
     const service = makeService(connections, users)
     const userService = makeUserService(users)
 
@@ -232,6 +251,35 @@ describe('SpamRingService.freezeRing', () => {
     expect(userService.freezeUser).not.toHaveBeenCalled()
     expect(result.frozen).toEqual([])
     expect(result.skipped.map((s: any) => s.reason)).toEqual(['already frozen'])
+  })
+
+  test('idempotent no-op when the ring is already frozen under the lock', async () => {
+    // concurrency guard (audit F4): a second freeze that finds the ring already
+    // frozen inside the transaction must not re-process members.
+    const ring = { id: '1', status: 'frozen', signals: { nearDupRingSize: 1 } }
+    const members = [
+      { id: 'm1', userId: 'u1', status: 'pending', bannedByThisRing: false },
+    ]
+    const users: Record<string, any> = {
+      u1: {
+        id: 'u1',
+        state: USER_STATE.active,
+        createdAt: new Date(Date.now() - DAY),
+      },
+    }
+    const { connections } = makeConnections({ ring, members, users })
+    const service = makeService(connections, users)
+    const userService = makeUserService(users)
+
+    const result = await service.freezeRing({
+      ringId: '1',
+      actorId: '9',
+      userService: userService as any,
+    })
+
+    expect(userService.freezeUser).not.toHaveBeenCalled()
+    expect(result.frozen).toEqual([])
+    expect(result.ring.status).toBe('frozen')
   })
 
   test('refuses to freeze a dismissed ring', async () => {
@@ -274,7 +322,7 @@ describe('SpamRingService.unfreezeRing', () => {
       u2: { id: 'u2', state: USER_STATE.frozen }, // frozen by something else
       u3: { id: 'u3', state: USER_STATE.archived }, // state changed since freeze
     }
-    const { connections } = makeConnections({ ring, members })
+    const { connections } = makeConnections({ ring, members, users })
     const service = makeService(connections, users)
     const userService = makeUserService(users)
 
@@ -288,7 +336,8 @@ describe('SpamRingService.unfreezeRing', () => {
     expect(userService.unfreezeUser).toHaveBeenCalledTimes(1)
     expect(userService.unfreezeUser).toHaveBeenCalledWith(
       'u1',
-      USER_STATE.active
+      USER_STATE.active,
+      expect.anything()
     )
     expect(result.unbanned.map((u: any) => u.id)).toEqual(['u1'])
     expect(result.skipped.map((s: any) => s.user.id)).toEqual(['u3'])

--- a/src/connectors/spamRingService.ts
+++ b/src/connectors/spamRingService.ts
@@ -248,125 +248,167 @@ export class SpamRingService extends BaseService<SpamRing> {
     frozen: User[]
     skipped: Array<{ user: User; reason: string }>
   }> => {
-    const ring = await this.findRingById(ringId)
-    if (!ring) {
-      throw new UserInputError('spam ring not found')
-    }
-    if (ring.status === 'dismissed') {
-      throw new UserInputError('cannot freeze a dismissed ring')
-    }
-
-    const members = await this.findMembers(ringId)
     const frozen: User[] = []
     const skipped: Array<{ user: User; reason: string }> = []
-    const bypassGuardrail = isHighConfidenceFreezeRing(ring)
 
-    for (const member of members) {
-      const user = (await this.models.userIdLoader.load(
-        member.userId
-      )) as User | null
+    // 整個凍結（逐成員 + ring 狀態）包在一個交易裡，並對 ring 列 FOR UPDATE：
+    //   - 原子性：中途失敗整批 rollback，不會留下「成員已凍但 ring 仍 pending」（稽核 F3）
+    //   - 序列化：並發 freeze/unfreeze/dismiss 互斥，不再重複處置／重複事件（F4）
+    //   - 新鮮讀：成員 user.state 在鎖內直接讀主庫（FOR UPDATE），不走 request 快取 loader（F2）
+    const updatedRing = await this.knex.transaction(async (trx) => {
+      const ring = (await this.knex('spam_ring')
+        .transacting(trx)
+        .forUpdate()
+        .where({ id: ringId })
+        .first()) as SpamRing | undefined
+      if (!ring) {
+        throw new UserInputError('spam ring not found')
+      }
+      if (ring.status === 'dismissed') {
+        throw new UserInputError('cannot freeze a dismissed ring')
+      }
+      if (ring.status === 'frozen') {
+        // 已在鎖內確認凍結 → idempotent no-op（成員早已處理）
+        return ring
+      }
 
-      if (!user) {
-        await this.updateMember(member.id, {
-          status: 'skipped',
-          skipReason: 'user not found',
+      const members = (await this.knex('spam_ring_member')
+        .transacting(trx)
+        .where({ ringId })
+        .orderBy('id', 'asc')) as SpamRingMember[]
+      const bypassGuardrail = isHighConfidenceFreezeRing(ring)
+
+      for (const member of members) {
+        const user = (await this.knex('user')
+          .transacting(trx)
+          .forUpdate()
+          .where({ id: member.userId })
+          .first()) as User | undefined
+
+        if (!user) {
+          await this.updateMember(
+            member.id,
+            { status: 'skipped', skipReason: 'user not found' },
+            trx
+          )
+          continue
+        }
+        // 本 ring 已凍結過此人 → idempotent，略過
+        if (member.status === 'frozen' && member.bannedByThisRing) {
+          frozen.push(user)
+          continue
+        }
+        if (user.state === USER_STATE.archived) {
+          await this.skipMember(
+            member.id,
+            user,
+            'archived',
+            actorId,
+            ringId,
+            trx
+          )
+          skipped.push({ user, reason: 'archived' })
+          continue
+        }
+        if (user.state === USER_STATE.banned) {
+          await this.skipMember(
+            member.id,
+            user,
+            'already banned',
+            actorId,
+            ringId,
+            trx
+          )
+          skipped.push({ user, reason: 'already banned' })
+          continue
+        }
+        if (user.state === USER_STATE.frozen) {
+          // already frozen (by admin or another ring) → don't re-claim it,
+          // otherwise unfreeze would lift a freeze this ring didn't cause.
+          await this.skipMember(
+            member.id,
+            user,
+            'already frozen',
+            actorId,
+            ringId,
+            trx
+          )
+          skipped.push({ user, reason: 'already frozen' })
+          continue
+        }
+
+        // 低信心 ring 保留老帳號 / 高 karma 護欄；大量重複或外連邀請 ring 仍處置重複帳號。
+        const ageDays =
+          (Date.now() - new Date(user.createdAt).getTime()) / DAY_MS
+        const score = await userService.findScore(user.id)
+        if (
+          !bypassGuardrail &&
+          (ageDays > SPAM_RING_GUARDRAIL_MAX_AGE_DAYS ||
+            score > SPAM_RING_GUARDRAIL_MAX_SCORE)
+        ) {
+          const reason =
+            ageDays > SPAM_RING_GUARDRAIL_MAX_AGE_DAYS
+              ? `old account (age ${Math.floor(
+                  ageDays
+                )}d > ${SPAM_RING_GUARDRAIL_MAX_AGE_DAYS}d)`
+              : `high karma (score ${score} > ${SPAM_RING_GUARDRAIL_MAX_SCORE})`
+          await this.skipMember(member.id, user, reason, actorId, ringId, trx)
+          skipped.push({ user, reason })
+          continue
+        }
+
+        // 永久但可逆的凍結：設 state='frozen'（與一般凍結同狀態，不寫 punish_record、
+        // 無到期）；freezeUser 會發 user_frozen 申訴通知，維持可申訴。
+        const frozenUser = (await userService.freezeUser(user.id, {
+          remark: USER_BAN_REMARK.spamRing,
+          trx,
+        })) as User
+        await this.updateMember(
+          member.id,
+          {
+            status: 'frozen',
+            bannedByThisRing: true,
+            preFreezeState: user.state,
+            skipReason: null,
+          },
+          trx
+        )
+        await this.insertEvents(
+          [{ ringId, memberId: member.id, actorId, action: 'member_frozen' }],
+          trx
+        )
+        frozen.push(frozenUser)
+      }
+
+      const now = new Date()
+      const [ring2] = await this.knex('spam_ring')
+        .transacting(trx)
+        .where({ id: ringId })
+        .update({
+          status: 'frozen',
+          frozenAt: now,
+          frozenBy: actorId,
+          updatedAt: now,
         })
-        continue
-      }
-      // 本 ring 已凍結過此人 → idempotent，略過
-      if (member.status === 'frozen' && member.bannedByThisRing) {
-        frozen.push(user)
-        continue
-      }
-      if (user.state === USER_STATE.archived) {
-        await this.skipMember(member.id, user, 'archived', actorId, ringId)
-        skipped.push({ user, reason: 'archived' })
-        continue
-      }
-      if (user.state === USER_STATE.banned) {
-        await this.skipMember(
-          member.id,
-          user,
-          'already banned',
-          actorId,
-          ringId
-        )
-        skipped.push({ user, reason: 'already banned' })
-        continue
-      }
-      if (user.state === USER_STATE.frozen) {
-        // already frozen (by admin or another ring) → don't re-claim it,
-        // otherwise unfreeze would lift a freeze this ring didn't cause.
-        await this.skipMember(
-          member.id,
-          user,
-          'already frozen',
-          actorId,
-          ringId
-        )
-        skipped.push({ user, reason: 'already frozen' })
-        continue
-      }
-
-      // 低信心 ring 保留老帳號 / 高 karma 護欄；大量重複或外連邀請 ring 仍處置重複帳號。
-      const ageDays = (Date.now() - new Date(user.createdAt).getTime()) / DAY_MS
-      const score = await userService.findScore(user.id)
-      if (
-        !bypassGuardrail &&
-        (ageDays > SPAM_RING_GUARDRAIL_MAX_AGE_DAYS ||
-          score > SPAM_RING_GUARDRAIL_MAX_SCORE)
-      ) {
-        const reason =
-          ageDays > SPAM_RING_GUARDRAIL_MAX_AGE_DAYS
-            ? `old account (age ${Math.floor(
-                ageDays
-              )}d > ${SPAM_RING_GUARDRAIL_MAX_AGE_DAYS}d)`
-            : `high karma (score ${score} > ${SPAM_RING_GUARDRAIL_MAX_SCORE})`
-        await this.skipMember(member.id, user, reason, actorId, ringId)
-        skipped.push({ user, reason })
-        continue
-      }
-
-      // 永久但可逆的凍結：設 state='frozen'（與一般凍結同狀態，不寫 punish_record、
-      // 無到期）；freezeUser 會發 user_frozen 申訴通知，維持可申訴。
-      const frozenUser = (await userService.freezeUser(user.id, {
-        remark: USER_BAN_REMARK.spamRing,
-      })) as User
-      await this.updateMember(member.id, {
-        status: 'frozen',
-        bannedByThisRing: true,
-        preFreezeState: user.state,
-        skipReason: null,
-      })
-      await this.insertEvents([
-        { ringId, memberId: member.id, actorId, action: 'member_frozen' },
-      ])
-      frozen.push(frozenUser)
-    }
-
-    const now = new Date()
-    const [updatedRing] = await this.knex('spam_ring')
-      .where({ id: ringId })
-      .update({
-        status: 'frozen',
-        frozenAt: now,
-        frozenBy: actorId,
-        updatedAt: now,
-      })
-      .returning('*')
-    await this.insertEvents([
-      {
-        ringId,
-        actorId,
-        action: 'frozen',
-        detail: {
-          remark: remark ?? null,
-          frozen: frozen.length,
-          skipped: skipped.length,
-          guardrailBypassed: bypassGuardrail,
-        },
-      },
-    ])
+        .returning('*')
+      await this.insertEvents(
+        [
+          {
+            ringId,
+            actorId,
+            action: 'frozen',
+            detail: {
+              remark: remark ?? null,
+              frozen: frozen.length,
+              skipped: skipped.length,
+              guardrailBypassed: bypassGuardrail,
+            },
+          },
+        ],
+        trx
+      )
+      return ring2 as SpamRing
+    })
 
     return { ring: updatedRing, frozen, skipped }
   }
@@ -385,66 +427,88 @@ export class SpamRingService extends BaseService<SpamRing> {
     unbanned: User[]
     skipped: Array<{ user: User; reason: string }>
   }> => {
-    const ring = await this.findRingById(ringId)
-    if (!ring) {
-      throw new UserInputError('spam ring not found')
-    }
-    if (ring.status !== 'frozen') {
-      throw new UserInputError('spam ring is not frozen')
-    }
-
-    const members = await this.findMembers(ringId)
     const unbanned: User[] = []
     const skipped: Array<{ user: User; reason: string }> = []
 
-    for (const member of members) {
-      if (!member.bannedByThisRing) {
-        continue
+    // 同 freezeRing：包進交易、ring 列 FOR UPDATE、成員 user.state 鎖內新鮮讀。
+    const updatedRing = await this.knex.transaction(async (trx) => {
+      const ring = (await this.knex('spam_ring')
+        .transacting(trx)
+        .forUpdate()
+        .where({ id: ringId })
+        .first()) as SpamRing | undefined
+      if (!ring) {
+        throw new UserInputError('spam ring not found')
       }
-      const user = (await this.models.userIdLoader.load(
-        member.userId
-      )) as User | null
-      if (!user) {
-        continue
+      if (ring.status !== 'frozen') {
+        throw new UserInputError('spam ring is not frozen')
       }
-      // freeze 後狀態又被改動（例如被封存/封禁）→ 不復活，僅記錄
-      if (user.state !== USER_STATE.frozen) {
-        const reason = `state changed to ${user.state}`
-        await this.updateMember(member.id, {
-          status: 'skipped',
-          skipReason: reason,
-        })
-        skipped.push({ user, reason })
-        continue
-      }
-      // 還原成凍結前的狀態（preFreezeState，通常為 active）
-      const restored = (await userService.unfreezeUser(
-        user.id,
-        member.preFreezeState ?? USER_STATE.active
-      )) as User
-      await this.updateMember(member.id, {
-        status: 'restored',
-        bannedByThisRing: false,
-      })
-      await this.insertEvents([
-        { ringId, memberId: member.id, actorId, action: 'member_restored' },
-      ])
-      unbanned.push(restored)
-    }
 
-    const now = new Date()
-    const [updatedRing] = await this.knex('spam_ring')
-      .where({ id: ringId })
-      .update({ status: 'restored', updatedAt: now })
-      .returning('*')
-    await this.insertEvents([
-      {
-        ringId,
-        actorId,
-        action: 'unfrozen',
-        detail: { unbanned: unbanned.length },
-      },
-    ])
+      const members = (await this.knex('spam_ring_member')
+        .transacting(trx)
+        .where({ ringId })
+        .orderBy('id', 'asc')) as SpamRingMember[]
+
+      for (const member of members) {
+        if (!member.bannedByThisRing) {
+          continue
+        }
+        const user = (await this.knex('user')
+          .transacting(trx)
+          .forUpdate()
+          .where({ id: member.userId })
+          .first()) as User | undefined
+        if (!user) {
+          continue
+        }
+        // freeze 後狀態又被改動（例如被封存/封禁）→ 不復活，僅記錄
+        if (user.state !== USER_STATE.frozen) {
+          const reason = `state changed to ${user.state}`
+          await this.updateMember(
+            member.id,
+            { status: 'skipped', skipReason: reason },
+            trx
+          )
+          skipped.push({ user, reason })
+          continue
+        }
+        // 還原成凍結前的狀態（preFreezeState，通常為 active）
+        const restored = (await userService.unfreezeUser(
+          user.id,
+          member.preFreezeState ?? USER_STATE.active,
+          trx
+        )) as User
+        await this.updateMember(
+          member.id,
+          { status: 'restored', bannedByThisRing: false },
+          trx
+        )
+        await this.insertEvents(
+          [{ ringId, memberId: member.id, actorId, action: 'member_restored' }],
+          trx
+        )
+        unbanned.push(restored)
+      }
+
+      const now = new Date()
+      const [ring2] = await this.knex('spam_ring')
+        .transacting(trx)
+        .where({ id: ringId })
+        .update({ status: 'restored', updatedAt: now })
+        .returning('*')
+      await this.insertEvents(
+        [
+          {
+            ringId,
+            actorId,
+            action: 'unfrozen',
+            detail: { unbanned: unbanned.length },
+          },
+        ],
+        trx
+      )
+      return ring2 as SpamRing
+    })
 
     return { ring: updatedRing, unbanned, skipped }
   }
@@ -521,11 +585,16 @@ export class SpamRingService extends BaseService<SpamRing> {
       bannedByThisRing: boolean
       skipReason: string | null
       preFreezeState: string
-    }>
+    }>,
+    trx?: Knex.Transaction
   ): Promise<void> => {
-    await this.knex('spam_ring_member')
+    const query = this.knex('spam_ring_member')
       .where({ id })
       .update({ ...patch, updatedAt: new Date() })
+    if (trx) {
+      query.transacting(trx)
+    }
+    await query
   }
 
   private skipMember = async (
@@ -533,28 +602,39 @@ export class SpamRingService extends BaseService<SpamRing> {
     user: User,
     reason: string,
     actorId: string,
-    ringId: string
+    ringId: string,
+    trx?: Knex.Transaction
   ): Promise<void> => {
-    await this.updateMember(memberId, {
-      status: 'skipped',
-      skipReason: reason,
-      bannedByThisRing: false,
-      preFreezeState: user.state,
-    })
-    await this.insertEvents([
+    await this.updateMember(
+      memberId,
       {
-        ringId,
-        memberId,
-        actorId,
-        action: 'member_skipped',
-        detail: { reason },
+        status: 'skipped',
+        skipReason: reason,
+        bannedByThisRing: false,
+        preFreezeState: user.state,
       },
-    ])
+      trx
+    )
+    await this.insertEvents(
+      [
+        {
+          ringId,
+          memberId,
+          actorId,
+          action: 'member_skipped',
+          detail: { reason },
+        },
+      ],
+      trx
+    )
   }
 
-  private insertEvents = async (events: RingEventInput[]): Promise<void> => {
+  private insertEvents = async (
+    events: RingEventInput[],
+    trx?: Knex.Transaction
+  ): Promise<void> => {
     const now = new Date()
-    await this.knex('spam_ring_event').insert(
+    const query = this.knex('spam_ring_event').insert(
       events.map((e) => ({
         uuid: v4(),
         ringId: e.ringId,
@@ -565,5 +645,9 @@ export class SpamRingService extends BaseService<SpamRing> {
         createdAt: now,
       }))
     )
+    if (trx) {
+      query.transacting(trx)
+    }
+    await query
   }
 }

--- a/src/connectors/userService.ts
+++ b/src/connectors/userService.ts
@@ -1996,8 +1996,14 @@ export class UserService extends BaseService<User> {
   // state as an admin freeze (no punish_record, no expiry).
   public freezeUser = async (
     userId: string,
-    { remark }: { remark?: ValueOf<typeof USER_BAN_REMARK> } = {}
+    {
+      remark,
+      trx,
+    }: { remark?: ValueOf<typeof USER_BAN_REMARK>; trx?: Knex.Transaction } = {}
   ) => {
+    // fire-and-forget appeal notice (not awaited, holds no DB lock); safe to keep
+    // inside a caller transaction — a rollback only wastes a notice in the rare
+    // mid-loop-failure case.
     const notificationService = new NotificationService(this.connections)
     notificationService.trigger({
       event: OFFICIAL_NOTICE_EXTEND_TYPE.user_frozen,
@@ -2009,14 +2015,20 @@ export class UserService extends BaseService<User> {
       updatedAt: new Date(),
     }
 
-    return await this.baseUpdate(userId, remark ? { ...data, remark } : data)
+    return await this.baseUpdate(
+      userId,
+      remark ? { ...data, remark } : data,
+      undefined,
+      trx
+    )
   }
 
   // Reverse a freeze by restoring an explicit prior state (e.g. preFreezeState).
   public unfreezeUser = async (
     userId: string,
-    state: ValueOf<typeof USER_STATE>
-  ) => await this.baseUpdate(userId, { state })
+    state: ValueOf<typeof USER_STATE>,
+    trx?: Knex.Transaction
+  ) => await this.baseUpdate(userId, { state }, undefined, trx)
 
   public verifyWalletSignature = async ({
     ethAddress,

--- a/src/types/directives/__test__/auth.test.ts
+++ b/src/types/directives/__test__/auth.test.ts
@@ -1,0 +1,62 @@
+import { makeExecutableSchema } from '@graphql-tools/schema'
+import { graphql } from 'graphql'
+
+import { AUTH_MODE } from '#common/enums/index.js'
+
+import { authDirective } from '../auth.js'
+
+const { typeDef, transformer } = authDirective('auth')
+
+const makeSchema = () =>
+  transformer(
+    makeExecutableSchema({
+      typeDefs: [
+        typeDef,
+        `type OSS { secret: String }
+         type Query {
+           oss: OSS @auth(mode: "${AUTH_MODE.admin}")
+           publicField: String @auth(mode: "${AUTH_MODE.visitor}")
+         }`,
+      ],
+      resolvers: {
+        Query: { oss: () => ({}), publicField: () => 'public' },
+        OSS: { secret: () => 'TOP-SECRET' },
+      },
+    })
+  )
+
+// anonymous visitor: no `id`, only the visitor auth mode
+const anonymousViewer = {
+  authMode: AUTH_MODE.visitor,
+  hasAuthMode: (req: string) => req === AUTH_MODE.visitor,
+}
+
+const run = (source: string) =>
+  graphql({
+    schema: makeSchema(),
+    source,
+    contextValue: { viewer: anonymousViewer },
+  })
+
+describe('auth directive — anonymous access to admin-gated fields', () => {
+  test('rejects an anonymous query of an admin field (oss)', async () => {
+    const res = await run('{ oss { secret } }')
+    expect(res.data?.oss ?? null).toBeNull()
+    expect(res.errors?.[0]?.message).toMatch(/isn't authorized/)
+  })
+
+  // Regression for the field-alias bypass: aliasing `oss` must NOT skip the admin gate.
+  test('rejects an anonymous query of an ALIASED admin field', async () => {
+    const res = await run('{ x: oss { secret } }')
+    expect(
+      (res.data as { x?: unknown } | null | undefined)?.x ?? null
+    ).toBeNull()
+    expect(res.errors?.[0]?.message).toMatch(/isn't authorized/)
+  })
+
+  test('still allows an anonymous query of a visitor field', async () => {
+    const res = await run('{ publicField }')
+    expect(res.errors).toBeUndefined()
+    expect(res.data?.publicField).toBe('public')
+  })
+})

--- a/src/types/directives/auth.ts
+++ b/src/types/directives/auth.ts
@@ -28,8 +28,13 @@ export const authDirective = (directiveName = 'auth') => ({
              * Query
              */
             if (isQuery) {
-              // "visitor" can only access anonymous' fields
-              if (!viewer.id && isSelf && !nodes.includes('oss')) {
+              // "visitor" can only access anonymous' fields.
+              // Gate on the field's own required mode, NOT on a substring of the
+              // response path: `nodes` is alias-derived, so `!nodes.includes('oss')`
+              // was bypassable by aliasing `oss` (e.g. `x: oss`), which let an
+              // anonymous viewer skip the admin check below and read the whole OSS
+              // admin subtree. Admin-gated fields must never take this fast path.
+              if (!viewer.id && isSelf && requireMode !== AUTH_MODE.admin) {
                 return await resolve(root, args, context, info)
               }
 


### PR DESCRIPTION
## Land the two security-audit fixes on `develop` (stranded by stacked-merge ordering)

Two already-merged fixes are **not in `develop`** and need cherry-picking here:

1. **#4880 — auth field-alias bypass (HIGH, `2d2ced109`)** merged to **master** as a hotfix. Per AGENTS.md (b1) a master-based hotfix must be cherry-picked to develop — otherwise develop keeps the vulnerable `@auth` directive and a future release would reintroduce the unauthenticated OSS-console read.
2. **#4884 — spam-ring freeze transaction/locking (LOW, `d2aded24d`)** merged into its base branch `chore/reland-spam-ring-freeze-as-frozen` **34s after** that base (#4881) had already merged to develop — so develop got #4881 but not #4884 (same merge-race that stranded #4879).

This PR cherry-picks both commits onto current develop. Clean apply (no conflicts; develop already has #4879 via #4881, which #4884 builds on).

### Verification
`tsc -p .` 0 errors. Tests: `auth.test.ts` 3/3 + `spamRingService.test.ts` 11/11 = **14/14**. prettier clean.

### Contents (unchanged from the merged PRs)
- `auth.ts`: anonymous query fast-path gates on `requireMode !== AUTH_MODE.admin` (alias-proof) + regression test.
- `spamRingService`/`userService`: freeze/unfreeze wrapped in `this.knex.transaction` + `spam_ring` `FOR UPDATE` + in-lock fresh user reads + `trx` threading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
