### PR TITLE
release: spam-ring freeze always protects old/high-karma accounts (#4887)

### DIFF
--- a/src/connectors/__test__/spamRingService.test.ts
+++ b/src/connectors/__test__/spamRingService.test.ts
@@ -179,26 +179,32 @@ describe('SpamRingService.freezeRing', () => {
     )
   })
 
-  test('bans old and high-karma members for high-confidence repeated ring', async () => {
+  test('protects old / high-karma members even in a high-confidence ring', async () => {
     const ring = {
       id: '1',
       status: 'pending',
-      signals: { nearDupRingSize: 12, sampleCodes: ['LIDANG'] },
+      signals: { nearDupRingSize: 12, sampleCodes: ['LIDANG'] }, // high confidence
     }
     const members = [
       { id: 'm1', userId: 'u1', status: 'pending', bannedByThisRing: false },
       { id: 'm2', userId: 'u2', status: 'pending', bannedByThisRing: false },
+      { id: 'm3', userId: 'u3', status: 'pending', bannedByThisRing: false },
     ]
     const users: Record<string, any> = {
       u1: {
         id: 'u1',
         state: USER_STATE.active,
-        createdAt: new Date(Date.now() - 100 * DAY),
+        createdAt: new Date(Date.now() - 100 * DAY), // old account (> 60d)
       },
       u2: {
         id: 'u2',
         state: USER_STATE.active,
-        createdAt: new Date(Date.now() - DAY),
+        createdAt: new Date(Date.now() - DAY), // new but high karma
+      },
+      u3: {
+        id: 'u3',
+        state: USER_STATE.active,
+        createdAt: new Date(Date.now() - DAY), // new, low karma → frozen
       },
     }
     const { connections, rec } = makeConnections({ ring, members, users })
@@ -214,15 +220,24 @@ describe('SpamRingService.freezeRing', () => {
       userService: userService as any,
     })
 
-    expect(userService.freezeUser).toHaveBeenCalledTimes(2)
-    expect(result.frozen.map((u: any) => u.id).sort()).toEqual(['u1', 'u2'])
-    expect(result.skipped).toEqual([])
+    // high confidence no longer bypasses the guard: u1 (old) and u2 (high karma)
+    // go to human; only u3 (new + low karma) is frozen.
+    expect(userService.freezeUser).toHaveBeenCalledTimes(1)
+    expect(userService.freezeUser).toHaveBeenCalledWith(
+      'u3',
+      expect.objectContaining({ remark: USER_BAN_REMARK.spamRing })
+    )
+    expect(result.frozen.map((u: any) => u.id)).toEqual(['u3'])
+    expect(result.skipped.map((s: any) => s.user.id).sort()).toEqual([
+      'u1',
+      'u2',
+    ])
 
     const frozenEvent = rec.eventInserts.find((e) => e.action === 'frozen')
     expect(JSON.parse(frozenEvent.detail)).toMatchObject({
-      frozen: 2,
-      skipped: 0,
-      guardrailBypassed: true,
+      frozen: 1,
+      skipped: 2,
+      highConfidence: true,
     })
   })
 

--- a/src/connectors/spamRingService.ts
+++ b/src/connectors/spamRingService.ts
@@ -20,7 +20,7 @@ import { BaseService } from './baseService.js'
 
 // 老帳號豁免護欄（roadmap 軸一 D 硬性）：超過任一門檻的帳號不自動凍結，改列人工複查。
 // 模組級常數，便於與信任安全負責人統一調參。
-export const SPAM_RING_GUARDRAIL_MAX_AGE_DAYS = 30
+export const SPAM_RING_GUARDRAIL_MAX_AGE_DAYS = 60
 export const SPAM_RING_GUARDRAIL_MAX_SCORE = 5
 export const SPAM_RING_GUARDRAIL_BYPASS_MIN_RING_SIZE = 10
 
@@ -276,7 +276,10 @@ export class SpamRingService extends BaseService<SpamRing> {
         .transacting(trx)
         .where({ ringId })
         .orderBy('id', 'asc')) as SpamRingMember[]
-      const bypassGuardrail = isHighConfidenceFreezeRing(ring)
+      // informational only: a high-confidence ring no longer bypasses the
+      // old-account / high-karma guard — established accounts always go to
+      // human review even in high-confidence rings.
+      const highConfidence = isHighConfidenceFreezeRing(ring)
 
       for (const member of members) {
         const user = (await this.knex('user')
@@ -337,14 +340,14 @@ export class SpamRingService extends BaseService<SpamRing> {
           continue
         }
 
-        // 低信心 ring 保留老帳號 / 高 karma 護欄；大量重複或外連邀請 ring 仍處置重複帳號。
+        // 硬性護欄：老帳號（帳齡 > 60 天）或高 karma 一律不自動凍結、改送人工，
+        // 高信心 ring 也不例外——避免誤判時把既有真實用戶直接凍掉。
         const ageDays =
           (Date.now() - new Date(user.createdAt).getTime()) / DAY_MS
         const score = await userService.findScore(user.id)
         if (
-          !bypassGuardrail &&
-          (ageDays > SPAM_RING_GUARDRAIL_MAX_AGE_DAYS ||
-            score > SPAM_RING_GUARDRAIL_MAX_SCORE)
+          ageDays > SPAM_RING_GUARDRAIL_MAX_AGE_DAYS ||
+          score > SPAM_RING_GUARDRAIL_MAX_SCORE
         ) {
           const reason =
             ageDays > SPAM_RING_GUARDRAIL_MAX_AGE_DAYS
@@ -401,7 +404,7 @@ export class SpamRingService extends BaseService<SpamRing> {
               remark: remark ?? null,
               frozen: frozen.length,
               skipped: skipped.length,
-              guardrailBypassed: bypassGuardrail,
+              highConfidence,
             },
           },
         ],


### PR DESCRIPTION
## Release develop → master: always protect old/high-karma in spam-ring freeze

`develop` is **2 commits ahead of master** — only the guardrail fix (#4887). Merging ships it to production (same Create Release + EB `deploy-eb-production` path).

### Ships
**fix(spam-ring): always protect old / high-karma accounts in freeze (#4887)** — stops the false-positive freezes you just hit. The high-confidence bypass no longer skips the old-account / high-karma guard; "old account" is now > 60 days (was 30). New throwaway accounts are still auto-frozen; established accounts (>60d or karma>5) always go to human review, even in high-confidence rings.

### Why expedite
A real batch of false-positive freezes traced to the over-broad high-confidence bypass. This release is the fix; until it's on prod, the console freeze can still auto-freeze established real users when a ring carries an external entity.

### Verification
`tsc` 0 errors; `spamRingService.test.ts` 11/11.

### Note
Pairs with spam-detection-scaffold #23 (繁簡/emoji fingerprint merge), already merged to `main` — live on the next ring-detection job run (no separate deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
