### PR TITLE
fix(spam-ring): allow 'member_frozen' in spam_ring_event action constraint [HOTFIX: freeze broken on prod]

### DIFF
--- a/db/migrations/20260630120000_fix_spam_ring_event_action_add_member_frozen.js
+++ b/db/migrations/20260630120000_fix_spam_ring_event_action_add_member_frozen.js
@@ -1,0 +1,39 @@
+const table = 'spam_ring_event'
+const constraint = 'spam_ring_event_action_check'
+
+// #4879 renamed the per-member freeze event action 'member_banned' → 'member_frozen'
+// in code, but the CHECK constraint created by t.enu() in the create-table migration
+// still only allowed the original list — so every freezeSpamRing failed on the event
+// insert with "violates check constraint spam_ring_event_action_check". Recreate the
+// constraint with 'member_frozen' added (keep 'member_banned' for existing rows).
+const ACTIONS = [
+  'detected',
+  'frozen',
+  'unfrozen',
+  'dismissed',
+  'member_banned',
+  'member_frozen',
+  'member_skipped',
+  'member_restored',
+]
+
+const setCheck = async (knex, actions) => {
+  const list = actions.map((a) => `'${a}'`).join(', ')
+  await knex.raw(
+    `ALTER TABLE "${table}" DROP CONSTRAINT IF EXISTS "${constraint}"`
+  )
+  await knex.raw(
+    `ALTER TABLE "${table}" ADD CONSTRAINT "${constraint}" CHECK (action IN (${list}))`
+  )
+}
+
+export const up = async (knex) => {
+  await setCheck(knex, ACTIONS)
+}
+
+export const down = async (knex) => {
+  await setCheck(
+    knex,
+    ACTIONS.filter((a) => a !== 'member_frozen')
+  )
+}


### PR DESCRIPTION
## 🔴 Hotfix: freezeSpamRing fails on prod — `member_frozen` missing from the event CHECK constraint

**Every "凍結集團" on production currently fails** with:
```
insert into "spam_ring_event" ... violates check constraint "spam_ring_event_action_check"
```

**Cause:** #4879 renamed the per-member freeze event action `member_banned` → `member_frozen` in code (`spamRingService.freezeRing`), but the `t.enu('action', [...])` CHECK constraint from the create-table migration (`20260620002000`) still only allows the original list — so the event insert at the end of each member freeze is rejected, aborting the whole freeze.

**Fix:** a migration that recreates `spam_ring_event_action_check` with `member_frozen` added (keeps `member_banned` for existing rows). Idempotent (`DROP CONSTRAINT IF EXISTS` + `ADD CONSTRAINT`).

### Rollout
Hotfix on **master** — the deploy's `migrate-db-production` step applies it, then freezing works again. **Cherry-pick to develop** (develop's freeze is broken the same way). `node --check` + prettier clean.

> This is why the user saw "凍結集團失敗" and no state change on the rows.
