### PR TITLE
fix(spam-ring): allow 'member_frozen' in spam_ring_event action constraint (develop)

### DIFF
--- a/db/migrations/20260630120000_fix_spam_ring_event_action_add_member_frozen.js
+++ b/db/migrations/20260630120000_fix_spam_ring_event_action_add_member_frozen.js
@@ -1,0 +1,39 @@
+const table = 'spam_ring_event'
+const constraint = 'spam_ring_event_action_check'
+
+// #4879 renamed the per-member freeze event action 'member_banned' → 'member_frozen'
+// in code, but the CHECK constraint created by t.enu() in the create-table migration
+// still only allowed the original list — so every freezeSpamRing failed on the event
+// insert with "violates check constraint spam_ring_event_action_check". Recreate the
+// constraint with 'member_frozen' added (keep 'member_banned' for existing rows).
+const ACTIONS = [
+  'detected',
+  'frozen',
+  'unfrozen',
+  'dismissed',
+  'member_banned',
+  'member_frozen',
+  'member_skipped',
+  'member_restored',
+]
+
+const setCheck = async (knex, actions) => {
+  const list = actions.map((a) => `'${a}'`).join(', ')
+  await knex.raw(
+    `ALTER TABLE "${table}" DROP CONSTRAINT IF EXISTS "${constraint}"`
+  )
+  await knex.raw(
+    `ALTER TABLE "${table}" ADD CONSTRAINT "${constraint}" CHECK (action IN (${list}))`
+  )
+}
+
+export const up = async (knex) => {
+  await setCheck(knex, ACTIONS)
+}
+
+export const down = async (knex) => {
+  await setCheck(
+    knex,
+    ACTIONS.filter((a) => a !== 'member_frozen')
+  )
+}


### PR DESCRIPTION
Cherry-pick of the prod hotfix #4889 onto develop. develop's freeze is broken the same way: #4879 renamed the member freeze event action to 'member_frozen' but the t.enu() CHECK constraint still only allowed 'member_banned' → every freezeSpamRing fails. This migration recreates spam_ring_event_action_check with 'member_frozen' added. node --check OK; migration is idempotent (DROP IF EXISTS + ADD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)