### PR TITLE
fix: route Coastguard comment links to OSS Next

### DIFF
--- a/src/connectors/__test__/commentService.test.ts
+++ b/src/connectors/__test__/commentService.test.ts
@@ -941,7 +941,7 @@ describe('spam telegram alert (notify-only tiering)', () => {
       dedupeKey: `comment:${comment.id}`,
     })
     // carries an OSS deep-link for one-click moderation
-    expect(sent[0].ossUrl).toContain('/comments?id=')
+    expect(sent[0].ossUrl).toContain('/next/comments?id=')
   })
 
   test('emits Tier C (spam_review) for high-score benign-looking content', async () => {

--- a/src/connectors/commentService.ts
+++ b/src/connectors/commentService.ts
@@ -1481,9 +1481,9 @@ export class CommentService extends BaseService<Comment> {
         2
       )}）：${snippet}`,
       reason: TIER_REASON[tier],
-      ossUrl: `${environment.ossSiteDomain}/comments?id=${encodeURIComponent(
-        globalId
-      )}`,
+      ossUrl: `${
+        environment.ossSiteDomain
+      }/next/comments?id=${encodeURIComponent(globalId)}`,
     })
   }
 


### PR DESCRIPTION
## Summary
- Update Coastguard spam Telegram OSS comment deep links from `/comments?id=` to `/next/comments?id=`.
- Update the related `commentService` test assertion.

## SOP path
- Route: hotfix exception to `master`, because this fixes production moderation notification links and `master` is protected.
- Change state: Done. No feature flag needed; this only corrects an existing operator deep link.
- Files: `src/connectors/commentService.ts`, `src/connectors/__test__/commentService.test.ts`.
- Backmerge requirement: after this PR merges, back-merge `master` into `develop` per `matters-agent-sop` selective release policy.

## Regression / Silent-Revert Guard
- Target: `origin/master`.
- Merge-base: `3c6b7e0595251bc9cfe134787253ca441aa7bafb`.
- Stale count: `0`.
- Hot-zone files: none.
- Removed sentinel scan: clean.
- Added entrypoint scan: clean.

## Verification
- `npx prettier --check src/connectors/commentService.ts src/connectors/__test__/commentService.test.ts`
- `npm run build`

## Production state
- Production deploy pending PR checks, approval, and merge.
