### PR TITLE
fix: route Coastguard comment links to OSS Next

### DIFF
--- a/src/connectors/__test__/commentService.test.ts
+++ b/src/connectors/__test__/commentService.test.ts
@@ -941,7 +941,7 @@ describe('spam telegram alert (notify-only tiering)', () => {
       dedupeKey: `comment:${comment.id}`,
     })
     // carries an OSS deep-link for one-click moderation
-    expect(sent[0].ossUrl).toContain('/comments?id=')
+    expect(sent[0].ossUrl).toContain('/next/comments?id=')
   })
 
   test('emits Tier C (spam_review) for high-score benign-looking content', async () => {

--- a/src/connectors/commentService.ts
+++ b/src/connectors/commentService.ts
@@ -746,8 +746,7 @@ export class CommentService extends BaseService<Comment> {
       action: CommunityWatchAction
     }
   ): Promise<ModerationCase> => {
-    const previousBase =
-      this.toCommunityWatchModerationCaseBase(previousAction)
+    const previousBase = this.toCommunityWatchModerationCaseBase(previousAction)
     const currentBase = this.toCommunityWatchModerationCaseBase(action)
 
     const previousCase = await trx<ModerationCase>('moderation_case')
@@ -809,7 +808,9 @@ export class CommentService extends BaseService<Comment> {
       .where(base)
       .first()
     if (!moderationCase) {
-      throw new Error('failed to create or load Community Watch moderation case')
+      throw new Error(
+        'failed to create or load Community Watch moderation case'
+      )
     }
 
     return { moderationCase, created: false }
@@ -1480,9 +1481,9 @@ export class CommentService extends BaseService<Comment> {
         2
       )}）：${snippet}`,
       reason: TIER_REASON[tier],
-      ossUrl: `${environment.ossSiteDomain}/comments?id=${encodeURIComponent(
-        globalId
-      )}`,
+      ossUrl: `${
+        environment.ossSiteDomain
+      }/next/comments?id=${encodeURIComponent(globalId)}`,
     })
   }
 


### PR DESCRIPTION
## Summary
- Update Coastguard spam Telegram OSS comment deep links from `/comments?id=` to `/next/comments?id=`.
- Update the related `commentService` test assertion.
- Apply Prettier to the touched `commentService.ts` file so the normal PR checks can pass.

## SOP path
- Route: normal `feature branch -> develop` path per `matters-agent-sop`.
- Change state: Done. No feature flag needed; this only corrects an existing operator deep link.
- Production path after this PR: release owner opens a whole-branch `develop -> master` PR, not a hotfix PR.

## Regression / Silent-Revert Guard
- Target: `origin/develop`.
- Merge-base: `ac09628db084f3e01e3f24a30eeceb022131fbbe`.
- Stale count: `0`.
- Hot-zone files: none.
- Removed sentinel scan: clean.
- Added entrypoint scan: clean.

## Verification
- `npx prettier --check src/connectors/commentService.ts src/connectors/__test__/commentService.test.ts`
- `npm run build`
