### PR TITLE
fix: hide restricted-author comments from public surfaces

### DIFF
--- a/src/connectors/commentService.ts
+++ b/src/connectors/commentService.ts
@@ -70,12 +70,23 @@ export interface CommentFilter {
   state?: string
 }
 
+type FindCommentsInput = GQLCommentsInput & {
+  where: CommentFilter
+  order?: string
+  includeRestrictedAuthors?: boolean
+}
+
 export type CommunityWatchActionsFilter = {
   reason?: string | null
   actionState?: string | null
   appealState?: string | null
   reviewState?: string | null
 }
+
+const RESTRICTED_COMMENT_AUTHOR_STATES = [
+  USER_STATE.frozen,
+  USER_STATE.archived,
+] as const
 
 export type CommunityWatchActionStateUpdate = {
   uuid: string
@@ -884,16 +895,31 @@ export class CommentService extends BaseService<Comment> {
    */
   public count = async (
     targetId: string,
-    type: ValueOf<typeof COMMENT_TYPE>
+    type: ValueOf<typeof COMMENT_TYPE>,
+    {
+      parentCommentId,
+      includeRestrictedAuthors = false,
+    }: {
+      parentCommentId?: string | null
+      includeRestrictedAuthors?: boolean
+    } = {}
   ) => {
-    const result = await this.knexRO(this.table)
+    const query = this.knexRO(this.table)
       .where({
         targetId,
         type,
       })
       .whereIn('state', [COMMENT_STATE.active, COMMENT_STATE.collapsed])
-      .count()
-      .first()
+
+    if (parentCommentId || parentCommentId === null) {
+      query.where({ parentCommentId })
+    }
+
+    if (!includeRestrictedAuthors) {
+      this.excludeRestrictedCommentAuthors(query)
+    }
+
+    const result = await query.count().first()
     return parseInt(result ? (result.count as string) : '0', 10)
   }
 
@@ -908,10 +934,12 @@ export class CommentService extends BaseService<Comment> {
     sort,
     skip,
     take,
+    includeRestrictedAuthors = false,
   }: GQLCommentCommentsInput & {
     id: string
     skip?: number
     take?: number
+    includeRestrictedAuthors?: boolean
   }): Promise<[Comment[], number]> => {
     let where: { [key: string]: string | boolean } = {
       parentCommentId: id,
@@ -936,6 +964,11 @@ export class CommentService extends BaseService<Comment> {
                   )
                 )
             })
+        })
+        .modify((builder) => {
+          if (!includeRestrictedAuthors) {
+            this.excludeRestrictedCommentAuthors(builder)
+          }
         })
         .orderBy('created_at', by)
 
@@ -973,9 +1006,8 @@ export class CommentService extends BaseService<Comment> {
     before,
     includeAfter = false,
     includeBefore = false,
-  }: GQLCommentsInput & { where: CommentFilter; order?: string }): Promise<
-    [Comment[], number]
-  > => {
+    includeRestrictedAuthors = false,
+  }: FindCommentsInput): Promise<[Comment[], number]> => {
     const subQuery = this.knexRO
       .select(this.knexRO.raw('COUNT(id) OVER() AS total_count'), '*')
       .fromRaw('comment AS outer_comment')
@@ -1010,6 +1042,11 @@ export class CommentService extends BaseService<Comment> {
             })
         }
       })
+      .modify((builder) => {
+        if (!includeRestrictedAuthors) {
+          this.excludeRestrictedCommentAuthors(builder, 'outer_comment')
+        }
+      })
       .orderBy('created_at', order)
 
     const query = this.knexRO.from(subQuery.as('t1'))
@@ -1034,6 +1071,25 @@ export class CommentService extends BaseService<Comment> {
     const records = await query
     return [records, +records[0]?.totalCount || 0]
   }
+
+  public isAuthorRestricted = async (comment: Comment) => {
+    const author = await this.models.userIdLoader.load(comment.authorId)
+    return RESTRICTED_COMMENT_AUTHOR_STATES.includes(
+      author?.state as (typeof RESTRICTED_COMMENT_AUTHOR_STATES)[number]
+    )
+  }
+
+  private excludeRestrictedCommentAuthors = (
+    query: Knex.QueryBuilder,
+    commentTable = 'comment'
+  ) =>
+    query.whereNotExists(
+      this.knexRO
+        .select(1)
+        .from('user')
+        .whereRaw('"user"."id" = ??', [`${commentTable}.author_id`])
+        .whereIn('user.state', RESTRICTED_COMMENT_AUTHOR_STATES)
+    )
 
   /**
    * Find commented followees by a given comment target.

--- a/src/queries/comment/article/commentCount.ts
+++ b/src/queries/comment/article/commentCount.ts
@@ -5,7 +5,10 @@ import { COMMENT_TYPE } from '#common/enums/index.js'
 const resolver: GQLArticleResolvers['commentCount'] = (
   { id: articleId },
   _,
-  { dataSources: { commentService } }
-) => commentService.count(articleId, COMMENT_TYPE.article)
+  { viewer, dataSources: { commentService } }
+) =>
+  commentService.count(articleId, COMMENT_TYPE.article, {
+    includeRestrictedAuthors: viewer.hasRole('admin'),
+  })
 
 export default resolver

--- a/src/queries/comment/article/comments.ts
+++ b/src/queries/comment/article/comments.ts
@@ -12,7 +12,7 @@ import {
 const resolver: GQLArticleResolvers['comments'] = async (
   { id },
   { input: { sort, first, ...rest } },
-  { dataSources: { atomService, commentService } }
+  { viewer, dataSources: { atomService, commentService } }
 ) => {
   // resolve sort to order
   const order = sort === 'oldest' ? 'asc' : 'desc'
@@ -67,6 +67,7 @@ const resolver: GQLArticleResolvers['comments'] = async (
     order,
     includeAfter: rest.includeAfter,
     includeBefore: rest.includeBefore,
+    includeRestrictedAuthors: viewer.hasRole('admin'),
   })
 
   if (!comments.length) {

--- a/src/queries/comment/article/featuredComments.ts
+++ b/src/queries/comment/article/featuredComments.ts
@@ -6,7 +6,7 @@ import { connectionFromArray } from '#common/utils/index.js'
 const resolver: GQLArticleResolvers['featuredComments'] = async (
   { id: articleId },
   { input: { first, after } },
-  { dataSources: { atomService } }
+  { viewer, dataSources: { atomService, commentService } }
 ) => {
   const featuredsComments = await atomService.findMany({
     table: 'featured_comment_materialized',
@@ -20,9 +20,22 @@ const resolver: GQLArticleResolvers['featuredComments'] = async (
       { column: 'score', order: 'desc' },
     ],
   })
+  const visibleComments = viewer.hasRole('admin')
+    ? featuredsComments
+    : (
+        await Promise.all(
+          featuredsComments.map(async (comment) =>
+            (await commentService.isAuthorRestricted(
+              comment as unknown as Comment
+            ))
+              ? null
+              : comment
+          )
+        )
+      ).filter(Boolean)
 
   // use simple pagination for now
-  return connectionFromArray(featuredsComments as unknown as Comment[], {
+  return connectionFromArray(visibleComments as unknown as Comment[], {
     first,
     after,
   })

--- a/src/queries/comment/article/pinnedComments.ts
+++ b/src/queries/comment/article/pinnedComments.ts
@@ -1,13 +1,13 @@
-import type { GQLArticleResolvers } from '#definitions/index.js'
+import type { Comment, GQLArticleResolvers } from '#definitions/index.js'
 
 import { COMMENT_STATE, COMMENT_TYPE } from '#common/enums/index.js'
 
 const resolver: GQLArticleResolvers['pinnedComments'] = (
   { id: articleId },
   _,
-  { dataSources: { atomService } }
-) =>
-  atomService.findMany({
+  { viewer, dataSources: { atomService, commentService } }
+) => {
+  const comments = atomService.findMany({
     table: 'comment',
     where: {
       pinned: true,
@@ -17,5 +17,19 @@ const resolver: GQLArticleResolvers['pinnedComments'] = (
     },
     orderBy: [{ column: 'pinned_at', order: 'desc' }],
   })
+
+  if (viewer.hasRole('admin')) {
+    return comments
+  }
+
+  return comments.then(async (records) => {
+    const visible = await Promise.all(
+      records.map(async (comment) =>
+        (await commentService.isAuthorRestricted(comment)) ? null : comment
+      )
+    )
+    return visible.filter((comment): comment is Comment => Boolean(comment))
+  })
+}
 
 export default resolver

--- a/src/queries/comment/campaign/discussion.ts
+++ b/src/queries/comment/campaign/discussion.ts
@@ -14,7 +14,7 @@ import {
 const resolver: GQLWritingChallengeResolvers['discussion'] = async (
   { id },
   { input: { sort, first, ...rest } },
-  { dataSources: { atomService, commentService } }
+  { viewer, dataSources: { atomService, commentService } }
 ) => {
   if (!id) {
     return connectionFromArray([], rest)
@@ -76,6 +76,7 @@ const resolver: GQLWritingChallengeResolvers['discussion'] = async (
     order,
     includeAfter: rest.includeAfter,
     includeBefore: rest.includeBefore,
+    includeRestrictedAuthors: viewer.hasRole('admin'),
   })
 
   if (!comments.length) {

--- a/src/queries/comment/campaign/discussionCount.ts
+++ b/src/queries/comment/campaign/discussionCount.ts
@@ -5,7 +5,10 @@ import { COMMENT_TYPE } from '#common/enums/index.js'
 const resolver: GQLWritingChallengeResolvers['discussionCount'] = async (
   { id },
   _,
-  { dataSources: { commentService } }
-) => commentService.count(id, COMMENT_TYPE.campaignDiscussion)
+  { viewer, dataSources: { commentService } }
+) =>
+  commentService.count(id, COMMENT_TYPE.campaignDiscussion, {
+    includeRestrictedAuthors: viewer.hasRole('admin'),
+  })
 
 export default resolver

--- a/src/queries/comment/circle/broadcast.ts
+++ b/src/queries/comment/circle/broadcast.ts
@@ -12,7 +12,7 @@ import {
 const resolver: GQLCircleResolvers['broadcast'] = async (
   { id },
   { input: { sort, first, ...rest } },
-  { dataSources: { atomService, commentService } }
+  { viewer, dataSources: { atomService, commentService } }
 ) => {
   if (!id) {
     return connectionFromArray([], rest)
@@ -73,6 +73,7 @@ const resolver: GQLCircleResolvers['broadcast'] = async (
     order,
     includeAfter: rest.includeAfter,
     includeBefore: rest.includeBefore,
+    includeRestrictedAuthors: viewer.hasRole('admin'),
   })
 
   if (!comments.length) {

--- a/src/queries/comment/circle/discussion.ts
+++ b/src/queries/comment/circle/discussion.ts
@@ -84,6 +84,7 @@ const resolver: GQLCircleResolvers['discussion'] = async (
     order,
     includeAfter: rest.includeAfter,
     includeBefore: rest.includeBefore,
+    includeRestrictedAuthors: viewer.hasRole('admin'),
   })
 
   if (!comments.length) {

--- a/src/queries/comment/circle/discussionCount.ts
+++ b/src/queries/comment/circle/discussionCount.ts
@@ -1,22 +1,14 @@
 import type { GQLCircleResolvers } from '#definitions/index.js'
 
-import { COMMENT_STATE, COMMENT_TYPE } from '#common/enums/index.js'
+import { COMMENT_TYPE } from '#common/enums/index.js'
 
 const resolver: GQLCircleResolvers['discussionCount'] = async (
   { id },
   _,
-  { dataSources: { atomService } }
-) => {
-  const count = await atomService.count({
-    table: 'comment',
-    where: {
-      state: COMMENT_STATE.active,
-      targetId: id,
-      type: COMMENT_TYPE.circleDiscussion,
-    },
+  { viewer, dataSources: { commentService } }
+) =>
+  commentService.count(id, COMMENT_TYPE.circleDiscussion, {
+    includeRestrictedAuthors: viewer.hasRole('admin'),
   })
-
-  return count
-}
 
 export default resolver

--- a/src/queries/comment/circle/discussionThreadCount.ts
+++ b/src/queries/comment/circle/discussionThreadCount.ts
@@ -1,23 +1,15 @@
 import type { GQLCircleResolvers } from '#definitions/index.js'
 
-import { COMMENT_STATE, COMMENT_TYPE } from '#common/enums/index.js'
+import { COMMENT_TYPE } from '#common/enums/index.js'
 
 const resolver: GQLCircleResolvers['discussionThreadCount'] = async (
   { id },
   _,
-  { dataSources: { atomService } }
-) => {
-  const count = await atomService.count({
-    table: 'comment',
-    where: {
-      state: COMMENT_STATE.active,
-      parentCommentId: null,
-      targetId: id,
-      type: COMMENT_TYPE.circleDiscussion,
-    },
+  { viewer, dataSources: { commentService } }
+) =>
+  commentService.count(id, COMMENT_TYPE.circleDiscussion, {
+    parentCommentId: null,
+    includeRestrictedAuthors: viewer.hasRole('admin'),
   })
-
-  return count
-}
 
 export default resolver

--- a/src/queries/comment/circle/pinnedBroadcast.ts
+++ b/src/queries/comment/circle/pinnedBroadcast.ts
@@ -1,13 +1,13 @@
-import type { GQLCircleResolvers } from '#definitions/index.js'
+import type { Comment, GQLCircleResolvers } from '#definitions/index.js'
 
 import { COMMENT_STATE, COMMENT_TYPE } from '#common/enums/index.js'
 
 const resolver: GQLCircleResolvers['pinnedBroadcast'] = async (
   { id },
   _,
-  { dataSources: { atomService } }
-) =>
-  atomService.findMany({
+  { viewer, dataSources: { atomService, commentService } }
+) => {
+  const comments = await atomService.findMany({
     table: 'comment',
     where: {
       pinned: true,
@@ -17,5 +17,17 @@ const resolver: GQLCircleResolvers['pinnedBroadcast'] = async (
     },
     orderBy: [{ column: 'pinned_at', order: 'desc' }],
   })
+
+  if (viewer.hasRole('admin')) {
+    return comments
+  }
+
+  const visible = await Promise.all(
+    comments.map(async (comment) =>
+      (await commentService.isAuthorRestricted(comment)) ? null : comment
+    )
+  )
+  return visible.filter((comment): comment is Comment => Boolean(comment))
+}
 
 export default resolver

--- a/src/queries/comment/comments.ts
+++ b/src/queries/comment/comments.ts
@@ -5,7 +5,7 @@ import { connectionFromArray, fromConnectionArgs } from '#common/utils/index.js'
 const resolver: GQLCommentResolvers['comments'] = async (
   { id },
   { input: { author, sort, ...connectionArgs } },
-  { dataSources: { commentService } }
+  { viewer, dataSources: { commentService } }
 ) => {
   const { take, skip } = fromConnectionArgs(connectionArgs, {
     allowTakeAll: true,
@@ -17,6 +17,7 @@ const resolver: GQLCommentResolvers['comments'] = async (
     sort,
     skip,
     take,
+    includeRestrictedAuthors: viewer.hasRole('admin'),
   })
   return connectionFromArray(comments, connectionArgs, totalCount)
 }

--- a/src/queries/comment/parentComment.ts
+++ b/src/queries/comment/parentComment.ts
@@ -1,10 +1,23 @@
 import type { GQLCommentResolvers } from '#definitions/index.js'
 
-const resolver: GQLCommentResolvers['parentComment'] = (
+const resolver: GQLCommentResolvers['parentComment'] = async (
   { parentCommentId },
   _,
-  { dataSources: { atomService } }
-) =>
-  parentCommentId ? atomService.commentIdLoader.load(parentCommentId) : null
+  { viewer, dataSources: { atomService, commentService } }
+) => {
+  if (!parentCommentId) {
+    return null
+  }
+
+  const comment = await atomService.commentIdLoader.load(parentCommentId)
+  if (
+    !viewer.hasRole('admin') &&
+    (await commentService.isAuthorRestricted(comment))
+  ) {
+    return null
+  }
+
+  return comment
+}
 
 export default resolver

--- a/src/queries/comment/replyTo.ts
+++ b/src/queries/comment/replyTo.ts
@@ -1,9 +1,23 @@
 import type { GQLCommentResolvers } from '#definitions/index.js'
 
-const resolver: GQLCommentResolvers['replyTo'] = (
+const resolver: GQLCommentResolvers['replyTo'] = async (
   { replyTo },
   _,
-  { dataSources: { atomService } }
-) => (replyTo ? atomService.commentIdLoader.load(replyTo) : null)
+  { viewer, dataSources: { atomService, commentService } }
+) => {
+  if (!replyTo) {
+    return null
+  }
+
+  const comment = await atomService.commentIdLoader.load(replyTo)
+  if (
+    !viewer.hasRole('admin') &&
+    (await commentService.isAuthorRestricted(comment))
+  ) {
+    return null
+  }
+
+  return comment
+}
 
 export default resolver

--- a/src/queries/moment/comments.ts
+++ b/src/queries/moment/comments.ts
@@ -12,7 +12,7 @@ import {
 const resolver: GQLMomentResolvers['comments'] = async (
   { id },
   { input: { sort, first, ...rest } },
-  { dataSources: { atomService, commentService } }
+  { viewer, dataSources: { atomService, commentService } }
 ) => {
   // resolve sort to order
   const order = sort === 'oldest' ? 'asc' : 'desc'
@@ -61,6 +61,7 @@ const resolver: GQLMomentResolvers['comments'] = async (
     order,
     includeAfter: rest.includeAfter,
     includeBefore: rest.includeBefore,
+    includeRestrictedAuthors: viewer.hasRole('admin'),
   })
 
   if (!comments.length) {

--- a/src/queries/moment/index.ts
+++ b/src/queries/moment/index.ts
@@ -25,8 +25,10 @@ const schema: GQLResolvers = {
       atomService.userIdLoader.load(authorId),
     state: ({ state }) => state,
 
-    commentCount: ({ id }, _, { dataSources: { commentService } }) =>
-      commentService.count(id, COMMENT_TYPE.moment),
+    commentCount: ({ id }, _, { dataSources: { commentService }, viewer }) =>
+      commentService.count(id, COMMENT_TYPE.moment, {
+        includeRestrictedAuthors: viewer.hasRole('admin'),
+      }),
     comments: comments,
     commentedFollowees: (
       { id, authorId },

--- a/src/queries/response/article/responseCount.ts
+++ b/src/queries/response/article/responseCount.ts
@@ -5,11 +5,13 @@ import { COMMENT_TYPE } from '#common/enums/index.js'
 const resolver: GQLArticleResolvers['responseCount'] = async (
   { id: articleId },
   _,
-  { dataSources: { articleService, commentService } }
+  { viewer, dataSources: { articleService, commentService } }
 ) => {
   const [articleCount, commentCount] = await Promise.all([
     articleService.countActiveConnectedBy(articleId),
-    commentService.count(articleId, COMMENT_TYPE.article),
+    commentService.count(articleId, COMMENT_TYPE.article, {
+      includeRestrictedAuthors: viewer.hasRole('admin'),
+    }),
   ])
   return articleCount + commentCount
 }

--- a/src/queries/response/article/responses.ts
+++ b/src/queries/response/article/responses.ts
@@ -5,7 +5,7 @@ import type {
   GlobalId,
 } from '#definitions/index.js'
 
-import { NODE_TYPES } from '#common/enums/index.js'
+import { COMMENT_TYPE, NODE_TYPES } from '#common/enums/index.js'
 import { ServerError } from '#common/errors.js'
 import { fromGlobalId, toGlobalId } from '#common/utils/index.js'
 import _last from 'lodash/last.js'
@@ -13,7 +13,7 @@ import _last from 'lodash/last.js'
 const resolver: GQLArticleResolvers['responses'] = async (
   { id: articleId },
   { input: { sort, first, ...restParams } },
-  { dataSources: { articleService, atomService } }
+  { viewer, dataSources: { articleService, atomService, commentService } }
 ) => {
   const order = sort === 'oldest' ? 'asc' : 'desc'
 
@@ -43,9 +43,17 @@ const resolver: GQLArticleResolvers['responses'] = async (
     includeBefore,
     articleOnly,
   })
+  const [articleResponseCount, commentResponseCount] = await Promise.all([
+    articleService.countActiveConnectedBy(articleId),
+    articleOnly
+      ? Promise.resolve(0)
+      : commentService.count(articleId, COMMENT_TYPE.article, {
+          includeRestrictedAuthors: viewer.hasRole('admin'),
+        }),
+  ])
 
   // fetch responses
-  const items = await Promise.all(
+  const loadedItems = await Promise.all(
     sources.map((source: { entityId: string; type: string }) => {
       switch (source.type) {
         case 'Article': {
@@ -60,6 +68,21 @@ const resolver: GQLArticleResolvers['responses'] = async (
       }
     })
   )
+  const items = (
+    await Promise.all(
+      loadedItems.map(async (item) => {
+        const isComment = 'articleId' in item
+        if (
+          isComment &&
+          !viewer.hasRole('admin') &&
+          (await commentService.isAuthorRestricted(item))
+        ) {
+          return null
+        }
+        return item
+      })
+    )
+  ).filter(Boolean) as Array<Article | Comment>
 
   // re-process edges
   const isArticle = (item: Article | Comment): item is Article =>
@@ -98,7 +121,7 @@ const resolver: GQLArticleResolvers['responses'] = async (
 
   return {
     edges,
-    totalCount: +head.totalCount,
+    totalCount: articleResponseCount + commentResponseCount,
     pageInfo: {
       startCursor: edgeHead ? edgeHead.cursor : '',
       endCursor: edgeTail ? edgeTail.cursor : '',

--- a/src/queries/system/node.ts
+++ b/src/queries/system/node.ts
@@ -6,6 +6,6 @@ const resolver: GQLQueryResolvers['node'] = async (
   _,
   { input: { id } },
   context
-) => getNode(id, context) as any
+) => getNode(id, context, { hideRestrictedCommentAuthorAsNull: true }) as any
 
 export default resolver

--- a/src/queries/system/nodes.ts
+++ b/src/queries/system/nodes.ts
@@ -15,7 +15,7 @@ const resolver: GQLQueryResolvers['nodes'] = async (
       `query exceeds maximum input limit ${GRAPHQL_INPUT_LENGTH_LIMIT}, current: ${ids.length}`
     )
   }
-  return Promise.all(ids.map((id) => getNode(id, context)))
+  return Promise.all(ids.map((id) => getNode(id, context))) as any
 }
 
 export default resolver

--- a/src/queries/system/utils.ts
+++ b/src/queries/system/utils.ts
@@ -1,13 +1,19 @@
-import type { Context, Draft, GlobalId } from '#definitions/index.js'
+import type { Comment, Context, Draft, GlobalId } from '#definitions/index.js'
 
 import { NODE_TYPES } from '#common/enums/index.js'
 import { EntityNotFoundError, ForbiddenError } from '#common/errors.js'
 import { fromGlobalId } from '#common/utils/index.js'
 
-export const getNode = async (globalId: GlobalId, context: Context) => {
+export const getNode = async (
+  globalId: GlobalId,
+  context: Context,
+  {
+    hideRestrictedCommentAuthorAsNull = false,
+  }: { hideRestrictedCommentAuthorAsNull?: boolean } = {}
+) => {
   const {
     viewer,
-    dataSources: { atomService },
+    dataSources: { atomService, commentService },
   } = context
   const services = {
     [NODE_TYPES.Article]: atomService.articleIdLoader,
@@ -40,6 +46,17 @@ export const getNode = async (globalId: GlobalId, context: Context) => {
 
   if (type === 'Draft' && viewer.id !== (node as Draft).authorId) {
     throw new ForbiddenError('only author is allowed to view draft')
+  }
+
+  if (
+    type === NODE_TYPES.Comment &&
+    !viewer.hasRole('admin') &&
+    (await commentService.isAuthorRestricted(node as Comment))
+  ) {
+    if (hideRestrictedCommentAuthorAsNull) {
+      return null
+    }
+    throw new EntityNotFoundError('target does not exist')
   }
 
   return { ...node, __type: type }

--- a/src/types/__test__/2/comment.test.ts
+++ b/src/types/__test__/2/comment.test.ts
@@ -11,6 +11,7 @@ import {
   NOTICE_TYPE,
   OFFICIAL_NOTICE_EXTEND_TYPE,
   USER_FEATURE_FLAG_TYPE,
+  USER_STATE,
 } from '#common/enums/index.js'
 import {
   AtomService,
@@ -169,6 +170,48 @@ describe('query comment list on article', () => {
       }
     }
   `
+  const GET_ARTICLE_COMMENT_SURFACE = /* GraphQL */ `
+    query ($articleInput: NodeInput!, $commentInput: NodeInput!, $author: ID!) {
+      articleNode: node(input: $articleInput) {
+        ... on Article {
+          commentCount
+          pinnedComments {
+            id
+            content
+          }
+          comments(input: { filter: { author: $author }, first: 10 }) {
+            totalCount
+            edges {
+              node {
+                id
+                content
+                parentComment {
+                  id
+                  content
+                }
+                replyTo {
+                  id
+                  content
+                }
+                author {
+                  id
+                }
+              }
+            }
+          }
+        }
+      }
+      commentNode: node(input: $commentInput) {
+        ... on Comment {
+          id
+          content
+          author {
+            id
+          }
+        }
+      }
+    }
+  `
   const ARTICLE_ID = toGlobalId({ type: NODE_TYPES.Article, id: 1 })
 
   test('query comments by author', async () => {
@@ -264,6 +307,137 @@ describe('query comment list on article', () => {
     expect(data2.node.comments.pageInfo.hasPreviousPage).toBe(true)
     expect(data2.node.comments.pageInfo.hasNextPage).toBe(true)
     expect(data.node.comments.totalCount).toBeGreaterThan(1)
+  })
+
+  test('hide article comments by restricted authors from public surfaces', async () => {
+    const author = await userService.create({
+      userName: `hiddencomment${uuidv4().replace(/-/g, '').slice(0, 12)}`,
+    })
+    await atomService.update({
+      table: 'user',
+      where: { id: author.id },
+      data: { state: USER_STATE.frozen },
+    })
+
+    const publicServer = await testClient({ connections })
+    const before = await publicServer.executeOperation({
+      query: GET_ARTICLE_COMMENT_SURFACE,
+      variables: {
+        articleInput: { id: ARTICLE_ID },
+        commentInput: { id: toGlobalId({ type: NODE_TYPES.Comment, id: 1 }) },
+        author: toGlobalId({ type: NODE_TYPES.User, id: author.id }),
+      },
+    })
+    expect(before.errors).toBeUndefined()
+
+    const { id: targetTypeId } = await atomService.findFirst({
+      table: 'entity_type',
+      where: { table: 'article' },
+    })
+    const comment = await atomService.create({
+      table: 'comment',
+      data: {
+        uuid: uuidv4(),
+        content: '<p>hidden spam</p>',
+        authorId: author.id,
+        targetId: '1',
+        targetTypeId,
+        parentCommentId: null,
+        state: COMMENT_STATE.active,
+        type: COMMENT_TYPE.article,
+        pinned: true,
+        pinnedAt: new Date(),
+      },
+    })
+    const childComment = await atomService.create({
+      table: 'comment',
+      data: {
+        uuid: uuidv4(),
+        content: '<p>visible child</p>',
+        authorId: '1',
+        targetId: '1',
+        targetTypeId,
+        parentCommentId: comment.id,
+        replyTo: comment.id,
+        state: COMMENT_STATE.active,
+        type: COMMENT_TYPE.article,
+      },
+    })
+
+    const publicResult = await publicServer.executeOperation({
+      query: GET_ARTICLE_COMMENT_SURFACE,
+      variables: {
+        articleInput: { id: ARTICLE_ID },
+        commentInput: {
+          id: toGlobalId({ type: NODE_TYPES.Comment, id: comment.id }),
+        },
+        author: toGlobalId({ type: NODE_TYPES.User, id: author.id }),
+      },
+    })
+    expect(publicResult.errors).toBeUndefined()
+    expect(publicResult.data.articleNode.commentCount).toBe(
+      before.data.articleNode.commentCount + 1
+    )
+    expect(publicResult.data.articleNode.comments.totalCount).toBe(0)
+    expect(publicResult.data.articleNode.comments.edges).toHaveLength(0)
+    expect(publicResult.data.commentNode).toBeNull()
+    expect(
+      publicResult.data.articleNode.pinnedComments.map(
+        ({ id }: { id: string }) => id
+      )
+    ).not.toContain(toGlobalId({ type: NODE_TYPES.Comment, id: comment.id }))
+
+    const publicChildResult = await publicServer.executeOperation({
+      query: GET_ARTICLE_COMMENT_SURFACE,
+      variables: {
+        articleInput: { id: ARTICLE_ID },
+        commentInput: {
+          id: toGlobalId({ type: NODE_TYPES.Comment, id: childComment.id }),
+        },
+        author: toGlobalId({ type: NODE_TYPES.User, id: '1' }),
+      },
+    })
+    expect(publicChildResult.errors).toBeUndefined()
+    const publicChild = publicChildResult.data.articleNode.comments.edges.find(
+      ({ node }: { node: { id: string } }) =>
+        node.id ===
+        toGlobalId({ type: NODE_TYPES.Comment, id: childComment.id })
+    ).node
+    expect(publicChild.parentComment).toBeNull()
+    expect(publicChild.replyTo).toBeNull()
+
+    const adminServer = await testClient({
+      connections,
+      isAuth: true,
+      isAdmin: true,
+    })
+    const adminResult = await adminServer.executeOperation({
+      query: GET_ARTICLE_COMMENT_SURFACE,
+      variables: {
+        articleInput: { id: ARTICLE_ID },
+        commentInput: {
+          id: toGlobalId({ type: NODE_TYPES.Comment, id: comment.id }),
+        },
+        author: toGlobalId({ type: NODE_TYPES.User, id: author.id }),
+      },
+    })
+    expect(adminResult.errors).toBeUndefined()
+    expect(adminResult.data.articleNode.commentCount).toBe(
+      before.data.articleNode.commentCount + 2
+    )
+    expect(adminResult.data.articleNode.comments.totalCount).toBe(1)
+    expect(adminResult.data.commentNode.content).toBe('<p>hidden spam</p>')
+    expect(
+      adminResult.data.articleNode.pinnedComments.map(
+        ({ id }: { id: string }) => id
+      )
+    ).toContain(toGlobalId({ type: NODE_TYPES.Comment, id: comment.id }))
+
+    await atomService.update({
+      table: 'comment',
+      where: { id: comment.id },
+      data: { pinned: false, pinnedAt: null },
+    })
   })
 })
 
@@ -518,6 +692,93 @@ describe('vote/unvote commment', () => {
   })
 })
 
+describe('query comment list on moment', () => {
+  const GET_MOMENT_COMMENT_SURFACE = /* GraphQL */ `
+    query ($input: MomentInput!, $author: ID!) {
+      moment(input: $input) {
+        commentCount
+        comments(input: { filter: { author: $author }, first: 10 }) {
+          totalCount
+          edges {
+            node {
+              id
+              content
+              author {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+  `
+
+  test('hide moment comments by archived authors from public surfaces', async () => {
+    const moment = await momentService.create(
+      { content: 'moment with hidden comment' },
+      { id: '1', state: USER_STATE.active, userName: 'test' }
+    )
+    const author = await userService.create({
+      userName: `archivedcomment${uuidv4().replace(/-/g, '').slice(0, 12)}`,
+    })
+    await atomService.update({
+      table: 'user',
+      where: { id: author.id },
+      data: { state: USER_STATE.archived },
+    })
+
+    const { id: targetTypeId } = await atomService.findFirst({
+      table: 'entity_type',
+      where: { table: 'moment' },
+    })
+    await atomService.create({
+      table: 'comment',
+      data: {
+        uuid: uuidv4(),
+        content: '<p>archived spam</p>',
+        authorId: author.id,
+        targetId: moment.id,
+        targetTypeId,
+        parentCommentId: null,
+        state: COMMENT_STATE.active,
+        type: COMMENT_TYPE.moment,
+      },
+    })
+
+    const publicServer = await testClient({ connections })
+    const publicResult = await publicServer.executeOperation({
+      query: GET_MOMENT_COMMENT_SURFACE,
+      variables: {
+        input: { shortHash: moment.shortHash },
+        author: toGlobalId({ type: NODE_TYPES.User, id: author.id }),
+      },
+    })
+    expect(publicResult.errors).toBeUndefined()
+    expect(publicResult.data.moment.commentCount).toBe(0)
+    expect(publicResult.data.moment.comments.totalCount).toBe(0)
+    expect(publicResult.data.moment.comments.edges).toHaveLength(0)
+
+    const adminServer = await testClient({
+      connections,
+      isAuth: true,
+      isAdmin: true,
+    })
+    const adminResult = await adminServer.executeOperation({
+      query: GET_MOMENT_COMMENT_SURFACE,
+      variables: {
+        input: { shortHash: moment.shortHash },
+        author: toGlobalId({ type: NODE_TYPES.User, id: author.id }),
+      },
+    })
+    expect(adminResult.errors).toBeUndefined()
+    expect(adminResult.data.moment.commentCount).toBe(1)
+    expect(adminResult.data.moment.comments.totalCount).toBe(1)
+    expect(adminResult.data.moment.comments.edges[0].node.content).toBe(
+      '<p>archived spam</p>'
+    )
+  })
+})
+
 describe('delete commment', () => {
   test('delete comment by commment author', async () => {
     const server = await testClient({ isAuth: true, connections })
@@ -665,12 +926,15 @@ describe('community watch remove comment', () => {
     })
     expect(syncedReport).toBeDefined()
 
-    const moderationCase = await connections.knex('moderation_case').where({
-      source: 'community_watch',
-      targetType: 'comment',
-      targetId: comment.id,
-      reason: 'spam_ad',
-    }).first()
+    const moderationCase = await connections
+      .knex('moderation_case')
+      .where({
+        source: 'community_watch',
+        targetType: 'comment',
+        targetId: comment.id,
+        reason: 'spam_ad',
+      })
+      .first()
     expect(moderationCase).toMatchObject({
       primaryReporterId: watcher.id,
       publicReason: 'spam_ad',
@@ -751,12 +1015,15 @@ describe('community watch remove comment', () => {
       table: 'community_watch_action',
       where: { commentId: comment.id },
     })
-    let moderationCase = await connections.knex('moderation_case').where({
-      source: 'community_watch',
-      targetType: 'comment',
-      targetId: comment.id,
-      reason: 'porn_ad',
-    }).first()
+    let moderationCase = await connections
+      .knex('moderation_case')
+      .where({
+        source: 'community_watch',
+        targetType: 'comment',
+        targetId: comment.id,
+        reason: 'porn_ad',
+      })
+      .first()
     expect(moderationCase).toMatchObject({
       status: 'action_taken',
       outcome: 'content_hidden',


### PR DESCRIPTION
## Summary
- Hide comments authored by frozen or archived users from public article, moment, campaign, and circle comment lists.
- Align public counts, pinned/featured comments, child comment references, `node(input:)`, and article responses with the same visibility rule.
- Preserve admin visibility with `includeRestrictedAuthors` so OSS/admin review can still inspect the underlying comments.
- Add regression coverage for public vs admin behavior on article and moment comment surfaces.

## Public surface audit
- Article: `comments`, `commentCount`, `pinnedComments`, `featuredComments`, `responses`, `responseCount`, `node(input:)` comment permalink.
- Moment: `comments`, `commentCount`.
- Campaign: `discussion`, `discussionCount`.
- Circle: `discussion`, `discussionCount`, `discussionThreadCount`, `broadcast`, `pinnedBroadcast`.
- Nested references: `Comment.comments`, `parentComment`, `replyTo`.
- Existing article-author restricted handling remains in the current codebase; this PR closes the historical comment gap.

## SOP notes
- Branch path: feature branch -> `develop` -> `master`.
- State: Done. This is a moderation/public visibility bug fix, not a dark-launched feature.
- Regression guard: branch base equals current `origin/develop`; changed-file sentinel scan found no removed sunsetting/deprecated/hidden markers.
- Security/release note: this touches public moderation visibility, so the `develop -> master` promotion should keep the SOP security gate and Codecov gate as hard gates.

## Checks
- `npm run build`
- `npm run lint`
- `npx prettier --check <changed server files>`
- `git diff --check`
- `npm run testcmd -- build/types/__test__/2/comment.test.js --runInBand --forceExit` attempted, but local DB test bootstrap fails before assertions with `AggregateError` at connection setup and afterAll `Cannot read properties of undefined (reading 'knex')`; CI DB-backed tests are the merge gate.