### PR TITLE
release: hide restricted-author articles from public reads

### DIFF
--- a/src/queries/article/noindex.ts
+++ b/src/queries/article/noindex.ts
@@ -39,12 +39,15 @@ const resolver: GQLArticleResolvers['noindex'] = async (
     return true
   }
 
-  // if author is archived
+  // if author is hidden from public reading
   const author = await atomService.findUnique({
     table: 'user',
     where: { id: authorId },
   })
-  if (author?.state === USER_STATE.archived) {
+  if (
+    author?.state === USER_STATE.archived ||
+    author?.state === USER_STATE.frozen
+  ) {
     return true
   }
 

--- a/src/queries/article/rootArticle.ts
+++ b/src/queries/article/rootArticle.ts
@@ -6,7 +6,13 @@ import { getLogger } from '#common/logger.js'
 
 const logger = getLogger('resolver-root-articles')
 
-const hideFrozenAuthorArticle = async ({
+const restrictedAuthorStates = new Set<string>([
+  USER_STATE.frozen,
+  USER_STATE.banned,
+  USER_STATE.archived,
+])
+
+const hideRestrictedAuthorArticle = async ({
   article,
   atomService,
   viewer,
@@ -19,12 +25,12 @@ const hideFrozenAuthorArticle = async ({
     return null
   }
 
-  if (viewer.hasRole('admin')) {
+  if (viewer.id === article.authorId || viewer.hasRole('admin')) {
     return article
   }
 
   const author = await atomService.userIdLoader.load(article.authorId)
-  if (author?.state === USER_STATE.frozen) {
+  if (author && restrictedAuthorStates.has(author.state)) {
     return null
   }
 
@@ -38,7 +44,7 @@ const resolver: GQLQueryResolvers['article'] = async (
 ) => {
   if (shortHash) {
     const article = await articleService.findArticleByShortHash(shortHash)
-    return hideFrozenAuthorArticle({ article, atomService, viewer })
+    return hideRestrictedAuthorArticle({ article, atomService, viewer })
   }
   if (mediaHash) {
     const node = await articleService.findVersionByMediaHash(mediaHash)
@@ -47,7 +53,7 @@ const resolver: GQLQueryResolvers['article'] = async (
       return null
     }
     const article = await atomService.articleIdLoader.load(node.articleId)
-    return hideFrozenAuthorArticle({ article, atomService, viewer })
+    return hideRestrictedAuthorArticle({ article, atomService, viewer })
   }
 
   throw new UserInputError('one of mediaHash or shortHash is required')

--- a/src/queries/article/rootArticle.ts
+++ b/src/queries/article/rootArticle.ts
@@ -1,24 +1,53 @@
-import type { GQLQueryResolvers } from '#definitions/index.js'
+import type { Article, Context, GQLQueryResolvers } from '#definitions/index.js'
 
+import { USER_STATE } from '#common/enums/index.js'
 import { UserInputError } from '#common/errors.js'
 import { getLogger } from '#common/logger.js'
 
 const logger = getLogger('resolver-root-articles')
 
+const hideFrozenAuthorArticle = async ({
+  article,
+  atomService,
+  viewer,
+}: {
+  article: Article | null | undefined
+  atomService: Context['dataSources']['atomService']
+  viewer: Context['viewer']
+}) => {
+  if (!article) {
+    return null
+  }
+
+  if (viewer.hasRole('admin')) {
+    return article
+  }
+
+  const author = await atomService.userIdLoader.load(article.authorId)
+  if (author?.state === USER_STATE.frozen) {
+    return null
+  }
+
+  return article
+}
+
 const resolver: GQLQueryResolvers['article'] = async (
   _,
   { input: { mediaHash, shortHash } },
-  { dataSources: { articleService, atomService } }
+  { dataSources: { articleService, atomService }, viewer }
 ) => {
   if (shortHash) {
-    return articleService.findArticleByShortHash(shortHash)
+    const article = await articleService.findArticleByShortHash(shortHash)
+    return hideFrozenAuthorArticle({ article, atomService, viewer })
   }
   if (mediaHash) {
     const node = await articleService.findVersionByMediaHash(mediaHash)
     if (!node) {
       logger.warn('article version by media_hash:%s not found', mediaHash)
+      return null
     }
-    return atomService.articleIdLoader.load(node.articleId)
+    const article = await atomService.articleIdLoader.load(node.articleId)
+    return hideFrozenAuthorArticle({ article, atomService, viewer })
   }
 
   throw new UserInputError('one of mediaHash or shortHash is required')

--- a/src/queries/article/user/articles.ts
+++ b/src/queries/article/user/articles.ts
@@ -9,10 +9,16 @@ import {
 
 const logger = getLogger('resolver-user-articles')
 
+const restrictedAuthorStates = new Set<string>([
+  USER_STATE.frozen,
+  USER_STATE.banned,
+  USER_STATE.archived,
+])
+
 const resolver: GQLUserResolvers['articles'] = async (
   { id, state: userState },
   { input },
-  { dataSources: { articleService }, viewer }
+  { dataSources: { articleService, atomService }, viewer }
 ) => {
   if (!id) {
     return connectionFromArray([], input)
@@ -21,8 +27,12 @@ const resolver: GQLUserResolvers['articles'] = async (
   const isViewer = viewer.id === id
   const isAdmin = viewer.hasRole('admin')
 
-  if (!isViewer && !isAdmin && userState === USER_STATE.frozen) {
-    return connectionFromArray([], input)
+  if (!isViewer && !isAdmin) {
+    const authorState =
+      userState ?? (await atomService.userIdLoader.load(id))?.state ?? null
+    if (authorState && restrictedAuthorStates.has(authorState)) {
+      return connectionFromArray([], input)
+    }
   }
 
   // only viewer and admin can see all articles

--- a/src/queries/article/user/articles.ts
+++ b/src/queries/article/user/articles.ts
@@ -1,5 +1,6 @@
 import type { GQLUserResolvers } from '#definitions/index.js'
 
+import { USER_STATE } from '#common/enums/index.js'
 import { getLogger } from '#common/logger.js'
 import {
   connectionFromArray,
@@ -9,7 +10,7 @@ import {
 const logger = getLogger('resolver-user-articles')
 
 const resolver: GQLUserResolvers['articles'] = async (
-  { id },
+  { id, state: userState },
   { input },
   { dataSources: { articleService }, viewer }
 ) => {
@@ -19,20 +20,29 @@ const resolver: GQLUserResolvers['articles'] = async (
 
   const isViewer = viewer.id === id
   const isAdmin = viewer.hasRole('admin')
+
+  if (!isViewer && !isAdmin && userState === USER_STATE.frozen) {
+    return connectionFromArray([], input)
+  }
+
   // only viewer and admin can see all articles
-  let state
+  let articleState
   if (isViewer || isAdmin) {
-    state = input?.filter?.state ?? null
+    articleState = input?.filter?.state ?? null
   } else {
-    state = input?.filter?.state ?? 'active'
-    if (state !== 'active') {
-      logger.warn('user %s is not allowed to see state %s', viewer.id, state)
+    articleState = input?.filter?.state ?? 'active'
+    if (articleState !== 'active') {
+      logger.warn(
+        'user %s is not allowed to see state %s',
+        viewer.id,
+        articleState
+      )
       return connectionFromArray([], input)
     }
   }
 
   const articles = await articleService.findByAuthor(id, {
-    state,
+    state: articleState,
     orderBy: input.sort,
   })
 

--- a/src/queries/system/utils.ts
+++ b/src/queries/system/utils.ts
@@ -1,8 +1,24 @@
-import type { Comment, Context, Draft, GlobalId } from '#definitions/index.js'
+import type {
+  Article,
+  Comment,
+  Context,
+  Draft,
+  GlobalId,
+} from '#definitions/index.js'
 
-import { NODE_TYPES } from '#common/enums/index.js'
-import { EntityNotFoundError, ForbiddenError } from '#common/errors.js'
+import { NODE_TYPES, USER_STATE } from '#common/enums/index.js'
+import {
+  ArticleNotFoundError,
+  EntityNotFoundError,
+  ForbiddenError,
+} from '#common/errors.js'
 import { fromGlobalId } from '#common/utils/index.js'
+
+const restrictedAuthorStates = new Set<string>([
+  USER_STATE.frozen,
+  USER_STATE.banned,
+  USER_STATE.archived,
+])
 
 export const getNode = async (
   globalId: GlobalId,
@@ -57,6 +73,16 @@ export const getNode = async (
       return null
     }
     throw new EntityNotFoundError('target does not exist')
+  }
+
+  if (type === NODE_TYPES.Article) {
+    const article = node as Article
+    if (viewer.id !== article.authorId && !viewer.hasRole('admin')) {
+      const author = await atomService.userIdLoader.load(article.authorId)
+      if (author && restrictedAuthorStates.has(author.state)) {
+        throw new ArticleNotFoundError('target article does not exists')
+      }
+    }
   }
 
   return { ...node, __type: type }

--- a/src/types/__test__/1/article/article.test.ts
+++ b/src/types/__test__/1/article/article.test.ts
@@ -10,6 +10,7 @@ import {
   TRANSACTION_STATE,
   TRANSACTION_TARGET_TYPE,
   CAMPAIGN_STATE,
+  USER_STATE,
 } from '#common/enums/index.js'
 import { fromGlobalId, toGlobalId } from '#common/utils/index.js'
 import {
@@ -92,6 +93,22 @@ const GET_ARTICLE = /* GraphQL */ `
         }
       }
       bookmarkCount
+      noindex
+    }
+  }
+`
+
+const GET_USER_ARTICLES = /* GraphQL */ `
+  query ($input: UserInput!) {
+    user(input: $input) {
+      articles(input: { first: 10 }) {
+        totalCount
+        edges {
+          node {
+            id
+          }
+        }
+      }
     }
   }
 `
@@ -170,6 +187,71 @@ describe('query articles', () => {
 
     expect(errors2).toBeUndefined()
     expect(data2.article.mediaHash).toBe('someIpfsMediaHash1')
+  })
+
+  test('hide frozen author article from public reads', async () => {
+    const article = await atomService.articleIdLoader.load(ARTICLE_DB_ID)
+    const author = await atomService.userIdLoader.load(article.authorId)
+
+    expect(article.shortHash).toBe('short-hash-1')
+    const anonymousServer = await testClient({ connections })
+
+    await atomService.update({
+      table: 'user',
+      where: { id: author.id },
+      data: { state: USER_STATE.frozen },
+    })
+
+    try {
+      const shortHashResult = await anonymousServer.executeOperation({
+        query: GET_ARTICLE,
+        variables: {
+          input: { shortHash: article.shortHash },
+        },
+      })
+      expect(shortHashResult.errors).toBeUndefined()
+      expect(shortHashResult.data.article).toBeNull()
+
+      const mediaHashResult = await anonymousServer.executeOperation({
+        query: GET_ARTICLE,
+        variables: {
+          input: { mediaHash: 'someIpfsMediaHash1' },
+        },
+      })
+      expect(mediaHashResult.errors).toBeUndefined()
+      expect(mediaHashResult.data.article).toBeNull()
+
+      const adminServer = await testClient({
+        connections,
+        isAuth: true,
+        isAdmin: true,
+      })
+      const adminResult = await adminServer.executeOperation({
+        query: GET_ARTICLE,
+        variables: {
+          input: { shortHash: article.shortHash },
+        },
+      })
+      expect(adminResult.errors).toBeUndefined()
+      expect(adminResult.data.article.shortHash).toBe(article.shortHash)
+      expect(adminResult.data.article.noindex).toBe(true)
+
+      const userArticlesResult = await anonymousServer.executeOperation({
+        query: GET_USER_ARTICLES,
+        variables: {
+          input: { userName: author.userName },
+        },
+      })
+      expect(userArticlesResult.errors).toBeUndefined()
+      expect(userArticlesResult.data.user.articles.totalCount).toBe(0)
+      expect(userArticlesResult.data.user.articles.edges).toHaveLength(0)
+    } finally {
+      await atomService.update({
+        table: 'user',
+        where: { id: author.id },
+        data: { state: author.state },
+      })
+    }
   })
 })
 

--- a/src/types/__test__/1/article/article.test.ts
+++ b/src/types/__test__/1/article/article.test.ts
@@ -221,6 +221,16 @@ describe('query articles', () => {
       expect(mediaHashResult.errors).toBeUndefined()
       expect(mediaHashResult.data.article).toBeNull()
 
+      const nodeResult = await anonymousServer.executeOperation({
+        query: GET_ARTICLE_TAGS,
+        variables: {
+          input: {
+            id: ARTICLE_ID,
+          },
+        },
+      })
+      expect(nodeResult.errors?.[0].extensions.code).toBe('ARTICLE_NOT_FOUND')
+
       const adminServer = await testClient({
         connections,
         isAuth: true,


### PR DESCRIPTION
## Summary

Release #4895 to production.

- Hide articles by frozen, banned, and archived authors from public Query.article reads.
- Hide restricted author User.articles results from public profile pages.
- Block Query.node Article global-id reads for restricted-author articles.
- Keep admin and author access for audit and self visibility.

## Verification

- #4895 checks are green: format-check, both Test build jobs, Codecov patch and project.
- Local checks on the PR branch passed: npm run build, npm run lint.
- Production bug was reproduced before this release: @omisenote01 is frozen but article py70epoeykdy is still publicly readable.

## Expected production behavior after deploy

- https://matters.town/@omisenote01 should no longer list the frozen author articles for public visitors.
- https://matters.town/a/py70epoeykdy should no longer render readable article content for public visitors.
