### PR TITLE
[codex] Hide restricted latest works and purge state caches

### DIFF
--- a/src/mutations/user/updateUserState.ts
+++ b/src/mutations/user/updateUserState.ts
@@ -1,8 +1,9 @@
 import type { GQLMutationResolvers, User } from '#definitions/index.js'
 
-import { USER_STATE } from '#common/enums/index.js'
+import { NODE_TYPES, USER_STATE } from '#common/enums/index.js'
 import { ActionFailedError, UserInputError } from '#common/errors.js'
 import { fromGlobalId } from '#common/utils/index.js'
+import { invalidateFQC } from '@matters/apollo-response-cache'
 
 const resolver: GQLMutationResolvers['updateUserState'] = async (
   _,
@@ -11,13 +12,25 @@ const resolver: GQLMutationResolvers['updateUserState'] = async (
     viewer,
     dataSources: {
       userService,
+      articleService,
       notificationService,
       atomService,
+      connections: { redis },
       queues: { userQueue },
     },
   }
 ) => {
   const id = globalId ? fromGlobalId(globalId).id : undefined
+
+  const invalidateUserCaches = async (userId: string) => {
+    await invalidateFQC({ node: { type: NODE_TYPES.User, id: userId }, redis })
+    for (const article of await articleService.findByAuthor(userId)) {
+      await invalidateFQC({
+        node: { type: NODE_TYPES.Article, id: article.id },
+        redis,
+      })
+    }
+  }
 
   /**
    * archive
@@ -40,6 +53,7 @@ const resolver: GQLMutationResolvers['updateUserState'] = async (
     // sync
     const user = await atomService.userIdLoader.load(id)
     const archivedUser = await userService.archive(id)
+    await invalidateUserCaches(id)
 
     // async
     userQueue.archiveUser({ userId: id })
@@ -61,12 +75,13 @@ const resolver: GQLMutationResolvers['updateUserState'] = async (
    * active, banned, frozen
    */
   const handleUpdateUserState = async (user: User) => {
+    let updatedUser: User
     if (state === USER_STATE.banned) {
-      return await userService.banUser(user.id, { banDays })
+      updatedUser = await userService.banUser(user.id, { banDays })
     } else if (state !== user.state && user.state === USER_STATE.banned) {
-      return await userService.unbanUser(user.id, state)
+      updatedUser = await userService.unbanUser(user.id, state)
     } else {
-      return await atomService.update({
+      updatedUser = await atomService.update({
         table: 'user',
         where: { id: user.id },
         data: {
@@ -74,6 +89,8 @@ const resolver: GQLMutationResolvers['updateUserState'] = async (
         },
       })
     }
+    await invalidateUserCaches(user.id)
+    return updatedUser
   }
   const validateUserState = (user: User) => {
     if (

--- a/src/queries/user/latestWorks.ts
+++ b/src/queries/user/latestWorks.ts
@@ -1,16 +1,35 @@
 import type { GQLUserResolvers } from '#definitions/index.js'
 
-import { NODE_TYPES, LATEST_WORKS_NUM } from '#common/enums/index.js'
+import {
+  NODE_TYPES,
+  LATEST_WORKS_NUM,
+  USER_STATE,
+} from '#common/enums/index.js'
+
+const restrictedAuthorStates = new Set<string>([
+  USER_STATE.frozen,
+  USER_STATE.banned,
+  USER_STATE.archived,
+])
 
 const resolver: GQLUserResolvers['latestWorks'] = async (
   { id },
   _,
-  { dataSources: { articleService, collectionService } }
+  { dataSources: { articleService, atomService, collectionService }, viewer }
 ) => {
+  const user = await atomService.userIdLoader.load(id)
+  const hideArticles =
+    viewer.id !== id &&
+    !viewer.hasRole('admin') &&
+    user &&
+    restrictedAuthorStates.has(user.state)
+
   const [articles, collections] = await Promise.all([
-    articleService.findByAuthor(id, {
-      take: LATEST_WORKS_NUM,
-    }),
+    hideArticles
+      ? []
+      : articleService.findByAuthor(id, {
+          take: LATEST_WORKS_NUM,
+        }),
     collectionService.findByAuthor(id, { take: LATEST_WORKS_NUM }, true),
   ])
   const works = [

--- a/src/types/__test__/1/collection.test.ts
+++ b/src/types/__test__/1/collection.test.ts
@@ -3,20 +3,27 @@ import type { Connections } from '#definitions/index.js'
 import {
   MAX_ARTICLES_PER_COLLECTION_LIMIT,
   NODE_TYPES,
+  USER_STATE,
 } from '#common/enums/index.js'
 import { toGlobalId } from '#common/utils/index.js'
-import { CollectionService, ArticleService } from '#connectors/index.js'
+import {
+  CollectionService,
+  ArticleService,
+  UserService,
+} from '#connectors/index.js'
 
 import { testClient, genConnections, closeConnections } from '../utils.js'
 
 let connections: Connections
 let collectionService: CollectionService
 let articleService: ArticleService
+let userService: UserService
 
 beforeAll(async () => {
   connections = await genConnections()
   collectionService = new CollectionService(connections)
   articleService = new ArticleService(connections)
+  userService = new UserService(connections)
 }, 30000)
 
 afterAll(async () => {
@@ -1111,6 +1118,45 @@ test('get latest works', async () => {
     expect(data?.viewer?.latestWorks[0].updatedAt.getTime()).toBeGreaterThan(
       data?.viewer?.latestWorks[1].updatedAt.getTime()
     )
+  }
+})
+
+test('hide restricted user articles from public latest works', async () => {
+  const GET_USER_LATEST_WORKS = /* GraphQL */ `
+    query ($input: UserInput!) {
+      user(input: $input) {
+        latestWorks {
+          id
+          ... on Article {
+            shortHash
+          }
+        }
+      }
+    }
+  `
+  const user = await userService.findByUserName('test1')
+  await connections.knex('user').where({ id: user.id }).update({
+    state: USER_STATE.frozen,
+  })
+
+  try {
+    const server = await testClient({ connections })
+    const { data } = await server.executeOperation({
+      query: GET_USER_LATEST_WORKS,
+      variables: {
+        input: { userName: user.userName },
+      },
+    })
+
+    expect(
+      data?.user?.latestWorks.some(
+        (work: { shortHash?: string }) => work.shortHash
+      )
+    ).toBe(false)
+  } finally {
+    await connections.knex('user').where({ id: user.id }).update({
+      state: USER_STATE.active,
+    })
   }
 })
 


### PR DESCRIPTION
## Summary
- hide restricted users' article entries from public `user.latestWorks` while keeping author/admin visibility
- invalidate user and article FQC entries after `updateUserState` changes so public caches refresh after freeze/ban/archive
- add regression coverage for public `latestWorks` hiding restricted-author articles

## Validation
- `npm run build`
- `npm run lint`
- targeted local GraphQL tests still require the repo's DB/Redis test services; GitHub Actions is the merge gate for the regression suite
