### PR TITLE
fix: hide restricted latest works from public profiles

### DIFF
--- a/src/queries/user/latestWorks.ts
+++ b/src/queries/user/latestWorks.ts
@@ -13,16 +13,14 @@ const restrictedAuthorStates = new Set<string>([
 ])
 
 const resolver: GQLUserResolvers['latestWorks'] = async (
-  { id },
+  { id, state },
   _,
-  { dataSources: { articleService, atomService, collectionService }, viewer }
+  { dataSources: { articleService, collectionService }, viewer }
 ) => {
-  const user = await atomService.userIdLoader.load(id)
   const hideArticles =
     viewer.id !== id &&
     !viewer.hasRole('admin') &&
-    user &&
-    restrictedAuthorStates.has(user.state)
+    restrictedAuthorStates.has(state || '')
 
   const [articles, collections] = await Promise.all([
     hideArticles

--- a/src/types/__test__/1/collection.test.ts
+++ b/src/types/__test__/1/collection.test.ts
@@ -1125,7 +1125,11 @@ test('hide restricted user articles from public latest works', async () => {
   const GET_USER_LATEST_WORKS = /* GraphQL */ `
     query ($input: UserInput!) {
       user(input: $input) {
+        status {
+          state
+        }
         latestWorks {
+          __typename
           id
           ... on Article {
             shortHash
@@ -1135,12 +1139,34 @@ test('hide restricted user articles from public latest works', async () => {
     }
   `
   const user = await userService.findByUserName('test1')
-  await connections.knex('user').where({ id: user.id }).update({
-    state: USER_STATE.frozen,
-  })
+  const articles = await articleService.findByAuthor(user.id, { take: 1 })
+  expect(articles.length).toBeGreaterThan(0)
+
+  const article = articles[0]
+  const originalArticleUpdatedAt = article.updatedAt
+  await connections
+    .knex('article')
+    .where({ id: article.id })
+    .update({ updatedAt: new Date(Date.now() + 60 * 1000) })
 
   try {
     const server = await testClient({ connections })
+    const { data: activeData } = await server.executeOperation({
+      query: GET_USER_LATEST_WORKS,
+      variables: {
+        input: { userName: user.userName },
+      },
+    })
+    expect(
+      activeData?.user?.latestWorks.some(
+        (work: { __typename: string }) => work.__typename === 'Article'
+      )
+    ).toBe(true)
+
+    await connections.knex('user').where({ id: user.id }).update({
+      state: USER_STATE.frozen,
+    })
+
     const { data } = await server.executeOperation({
       query: GET_USER_LATEST_WORKS,
       variables: {
@@ -1148,15 +1174,20 @@ test('hide restricted user articles from public latest works', async () => {
       },
     })
 
+    expect(data?.user?.status.state).toBe(USER_STATE.frozen)
     expect(
       data?.user?.latestWorks.some(
-        (work: { shortHash?: string }) => work.shortHash
+        (work: { __typename: string }) => work.__typename === 'Article'
       )
     ).toBe(false)
   } finally {
     await connections.knex('user').where({ id: user.id }).update({
       state: USER_STATE.active,
     })
+    await connections
+      .knex('article')
+      .where({ id: article.id })
+      .update({ updatedAt: originalArticleUpdatedAt })
   }
 })
 


### PR DESCRIPTION
## Summary
- fix public `User.latestWorks` hiding for frozen/banned/archived users by using the parent user state instead of reloading via `atomService.userIdLoader`
- strengthen the regression test so it first proves the active user has article latestWorks, then verifies frozen public latestWorks no longer includes Article entries

## Why
Production GraphQL already returns `article(shortHash)` as null for frozen-author articles, but the public profile query still returned frozen users' `latestWorks` article entries. That lets web SSR preload those article objects in `__NEXT_DATA__`.

## Validation
- `npm run build`
- `npm run lint`
- `git diff --check`
- attempted direct single-file Jest run, but local DB/Redis initialization fails with the existing `AggregateError`; GitHub Actions is the test gate

## Live check before fix
- `server.matters.town` article query for `py70epoeykdy` returns `null`
- `server.matters.town` public `user(userName: \"omisenote01\") { latestWorks }` still returns Article entries
