### PR TITLE
fix: hide restricted user writings publicly

### DIFF
--- a/src/queries/user/writings.ts
+++ b/src/queries/user/writings.ts
@@ -1,13 +1,34 @@
 import type { GQLUserResolvers } from '#definitions/index.js'
 
-import { NODE_TYPES } from '#common/enums/index.js'
-import { connectionFromUnionQuery } from '#common/utils/index.js'
+import { NODE_TYPES, USER_STATE } from '#common/enums/index.js'
+import {
+  connectionFromArray,
+  connectionFromUnionQuery,
+} from '#common/utils/index.js'
+
+const restrictedAuthorStates = new Set<string>([
+  USER_STATE.frozen,
+  USER_STATE.banned,
+  USER_STATE.archived,
+])
 
 const resolver: GQLUserResolvers['writings'] = async (
-  { id },
+  { id, state },
   { input },
-  { dataSources: { userWorkService, atomService } }
+  { dataSources: { userWorkService, atomService }, viewer }
 ) => {
+  if (!id) {
+    return connectionFromArray([], input)
+  }
+
+  if (viewer.id !== id && !viewer.hasRole('admin')) {
+    const authorState =
+      state ?? (await atomService.userIdLoader.load(id))?.state ?? null
+    if (authorState && restrictedAuthorStates.has(authorState)) {
+      return connectionFromArray([], input)
+    }
+  }
+
   return connectionFromUnionQuery({
     query: userWorkService.findWritingsByUser(id),
     args: input,

--- a/src/types/__test__/2/user/user.test.ts
+++ b/src/types/__test__/2/user/user.test.ts
@@ -1345,6 +1345,29 @@ describe('query user writings', () => {
       }
     }
   `
+  const QUERY_USER_WRITINGS = /* GraphQL */ `
+    query ($userInput: UserInput!, $writingsInput: WritingInput!) {
+      user(input: $userInput) {
+        id
+        status {
+          state
+        }
+        writings(input: $writingsInput) {
+          edges {
+            node {
+              ... on Article {
+                id
+              }
+              ... on Moment {
+                id
+              }
+            }
+          }
+          totalCount
+        }
+      }
+    }
+  `
   let user: User
   let idx: number = 1
   beforeEach(async () => {
@@ -1404,5 +1427,69 @@ describe('query user writings', () => {
     expect(dataAfter.viewer.writings.totalCount).toBe(2)
     expect(dataAfter.viewer.writings.pageInfo.hasPreviousPage).toBeTruthy()
     expect(dataAfter.viewer.writings.pageInfo.hasNextPage).toBeFalsy()
+  })
+  test('hide restricted user writings from public visitors', async () => {
+    await momentService.create({ content: 'test' }, user)
+    await publicationService.createArticle({
+      title: 'test',
+      content: 'test',
+      authorId: user.id,
+    })
+
+    await connections.knex('user').where({ id: user.id }).update({
+      state: USER_STATE.frozen,
+    })
+
+    try {
+      const publicServer = await testClient({ connections })
+      const publicResult = await publicServer.executeOperation({
+        query: QUERY_USER_WRITINGS,
+        variables: {
+          userInput: { userName: user.userName },
+          writingsInput: { first: 5 },
+        },
+      })
+
+      expect(publicResult.errors).toBeUndefined()
+      expect(publicResult.data?.user?.status.state).toBe(USER_STATE.frozen)
+      expect(publicResult.data?.user?.writings.totalCount).toBe(0)
+      expect(publicResult.data?.user?.writings.edges).toHaveLength(0)
+
+      const ownerServer = await testClient({
+        isAuth: true,
+        connections,
+        context: { viewer: user },
+      })
+      const ownerResult = await ownerServer.executeOperation({
+        query: QUERY_USER_WRITINGS,
+        variables: {
+          userInput: { userName: user.userName },
+          writingsInput: { first: 5 },
+        },
+      })
+
+      expect(ownerResult.errors).toBeUndefined()
+      expect(ownerResult.data?.user?.writings.totalCount).toBe(2)
+
+      const adminServer = await testClient({
+        isAuth: true,
+        isAdmin: true,
+        connections,
+      })
+      const adminResult = await adminServer.executeOperation({
+        query: QUERY_USER_WRITINGS,
+        variables: {
+          userInput: { userName: user.userName },
+          writingsInput: { first: 5 },
+        },
+      })
+
+      expect(adminResult.errors).toBeUndefined()
+      expect(adminResult.data?.user?.writings.totalCount).toBe(2)
+    } finally {
+      await connections.knex('user').where({ id: user.id }).update({
+        state: USER_STATE.active,
+      })
+    }
   })
 })


### PR DESCRIPTION
## Summary
- Hide `User.writings` for frozen, banned, and archived users from public visitors and non-admin users.
- Keep owner and admin visibility for moderation and audit workflows.
- Add coverage for public, owner, and admin reads of restricted-user writings.

## Root cause
`User.articles`, `Query.article`, and `User.latestWorks` already had public restricted-author guards, but the profile writings feed still resolved through `userWorkService.findWritingsByUser` without checking the author state. The web profile page uses `user.writings(first: 20)`, so frozen users could still expose article references on public profiles.

## Validation
- `npm run build`
- `npm run lint`
- `npx prettier --check src/queries/user/writings.ts src/types/__test__/2/user/user.test.ts`
- `git diff --check`

## Local test note
- `npm run testcmd -- build/types/__test__/2/user/user.test.js --runInBand --forceExit` is blocked by the local test database connection. The suite fails before assertions with `AggregateError`, matching the existing local environment issue.
