### PR TITLE
fix(oss): point report alert OSS links to /next/watch

### DIFF
--- a/src/common/notifications/__test__/reportAlert.test.ts
+++ b/src/common/notifications/__test__/reportAlert.test.ts
@@ -43,7 +43,7 @@ describe('enqueueReportAlert (producer)', () => {
       dedupeKey: 'direct:Article:42',
       subject: 'Article (QXJ0aWNsZTo0Mg)',
       reason: 'illegal_advertising',
-      ossUrl: 'https://oss.example.com/reports?targetId=QXJ0aWNsZTo0Mg',
+      ossUrl: 'https://oss.example.com/next/watch?targetId=QXJ0aWNsZTo0Mg',
     })
 
     expect(sentMessages).toHaveLength(1)
@@ -54,7 +54,7 @@ describe('enqueueReportAlert (producer)', () => {
       dedupeKey: 'direct:Article:42',
       subject: 'Article (QXJ0aWNsZTo0Mg)',
       reason: 'illegal_advertising',
-      ossUrl: 'https://oss.example.com/reports?targetId=QXJ0aWNsZTo0Mg',
+      ossUrl: 'https://oss.example.com/next/watch?targetId=QXJ0aWNsZTo0Mg',
     })
     expect(typeof sent.messageBody.occurredAt).toBe('string')
     // Loose ISO-8601 sanity check; we don't try to validate calendar dates.
@@ -69,7 +69,7 @@ describe('enqueueReportAlert (producer)', () => {
       dedupeKey: 'cw:author:99',
       subject: 'Alice @alice',
       reason: 'porn_ad',
-      ossUrl: 'https://oss.example.com/reports',
+      ossUrl: 'https://oss.example.com/next/watch',
     })
 
     expect(sentMessages).toHaveLength(1)
@@ -78,7 +78,7 @@ describe('enqueueReportAlert (producer)', () => {
       dedupeKey: 'cw:author:99',
       subject: 'Alice @alice',
       reason: 'porn_ad',
-      ossUrl: 'https://oss.example.com/reports',
+      ossUrl: 'https://oss.example.com/next/watch',
     })
   })
 

--- a/src/mutations/comment/communityWatchRemoveComment.ts
+++ b/src/mutations/comment/communityWatchRemoveComment.ts
@@ -222,7 +222,7 @@ const resolver = async (
         dedupeKey: `cw:author:${authorId}`,
         subject,
         reason,
-        ossUrl: `${environment.ossSiteDomain}/reports`,
+        ossUrl: `${environment.ossSiteDomain}/next/watch`,
       })
     } catch {
       // swallowed; report-alert is a notification side channel

--- a/src/mutations/system/submitReport.ts
+++ b/src/mutations/system/submitReport.ts
@@ -66,9 +66,9 @@ const resolver: GQLMutationResolvers['submitReport'] = async (
     dedupeKey: `direct:${type}:${targetId}`,
     subject: `${type} (${targetGlobalId})`,
     reason,
-    ossUrl: `${environment.ossSiteDomain}/reports?targetId=${encodeURIComponent(
-      targetGlobalId
-    )}`,
+    ossUrl: `${
+      environment.ossSiteDomain
+    }/next/watch?targetId=${encodeURIComponent(targetGlobalId)}`,
   })
 
   return report


### PR DESCRIPTION
## What / Why

Follow-up to #4893. That fix migrated the comment-spam Telegram deep link to `oss.matters.town/next`, but the other two report-alert links still pointed to the legacy `/reports` page:

- `submitReport` (user 檢舉): `/reports?targetId=…` → `/next/watch?targetId=…`
- `communityWatchRemoveComment` (社區守望移除): `/reports` → `/next/watch`

oss-next has **no `/reports` route** (the home page still lists it under 尚未遷入/舊站), so `/next/reports` would 404. Its `/watch` page queries the same `oss.reports` connection and renders plain reports without a community-watch action (「無守望相助紀錄」), so it is the correct destination for both. The `targetId` query param is kept — `/watch` ignores it today, but it preserves intent for future deep-link support.

## SOP

Trivial tier per [matters-agent-sop](https://github.com/thematters/matters-agent-sop) (constant URL change, no behavior change, no UI, no auth/permission logic) — state: **Done**.

## Tests

- `reportAlert.test.ts` fixtures updated to the new URL shape; 4/4 pass.
- `tsc --noEmit`, prettier, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)