### PR TITLE
release: OSS report-alert links → /next/watch

### DIFF
--- a/src/common/notifications/__test__/reportAlert.test.ts
+++ b/src/common/notifications/__test__/reportAlert.test.ts
@@ -43,7 +43,7 @@ describe('enqueueReportAlert (producer)', () => {
       dedupeKey: 'direct:Article:42',
       subject: 'Article (QXJ0aWNsZTo0Mg)',
       reason: 'illegal_advertising',
-      ossUrl: 'https://oss.example.com/reports?targetId=QXJ0aWNsZTo0Mg',
+      ossUrl: 'https://oss.example.com/next/watch?targetId=QXJ0aWNsZTo0Mg',
     })
 
     expect(sentMessages).toHaveLength(1)
@@ -54,7 +54,7 @@ describe('enqueueReportAlert (producer)', () => {
       dedupeKey: 'direct:Article:42',
       subject: 'Article (QXJ0aWNsZTo0Mg)',
       reason: 'illegal_advertising',
-      ossUrl: 'https://oss.example.com/reports?targetId=QXJ0aWNsZTo0Mg',
+      ossUrl: 'https://oss.example.com/next/watch?targetId=QXJ0aWNsZTo0Mg',
     })
     expect(typeof sent.messageBody.occurredAt).toBe('string')
     // Loose ISO-8601 sanity check; we don't try to validate calendar dates.
@@ -69,7 +69,7 @@ describe('enqueueReportAlert (producer)', () => {
       dedupeKey: 'cw:author:99',
       subject: 'Alice @alice',
       reason: 'porn_ad',
-      ossUrl: 'https://oss.example.com/reports',
+      ossUrl: 'https://oss.example.com/next/watch',
     })
 
     expect(sentMessages).toHaveLength(1)
@@ -78,7 +78,7 @@ describe('enqueueReportAlert (producer)', () => {
       dedupeKey: 'cw:author:99',
       subject: 'Alice @alice',
       reason: 'porn_ad',
-      ossUrl: 'https://oss.example.com/reports',
+      ossUrl: 'https://oss.example.com/next/watch',
     })
   })
 

--- a/src/mutations/comment/communityWatchRemoveComment.ts
+++ b/src/mutations/comment/communityWatchRemoveComment.ts
@@ -222,7 +222,7 @@ const resolver = async (
         dedupeKey: `cw:author:${authorId}`,
         subject,
         reason,
-        ossUrl: `${environment.ossSiteDomain}/reports`,
+        ossUrl: `${environment.ossSiteDomain}/next/watch`,
       })
     } catch {
       // swallowed; report-alert is a notification side channel

--- a/src/mutations/system/submitReport.ts
+++ b/src/mutations/system/submitReport.ts
@@ -66,9 +66,9 @@ const resolver: GQLMutationResolvers['submitReport'] = async (
     dedupeKey: `direct:${type}:${targetId}`,
     subject: `${type} (${targetGlobalId})`,
     reason,
-    ossUrl: `${environment.ossSiteDomain}/reports?targetId=${encodeURIComponent(
-      targetGlobalId
-    )}`,
+    ossUrl: `${
+      environment.ossSiteDomain
+    }/next/watch?targetId=${encodeURIComponent(targetGlobalId)}`,
   })
 
   return report


### PR DESCRIPTION
## Release content (develop → master, whole branch)

Only one change rides this promote — #4904 (merged to develop today):

- `submitReport` 檢舉通知連結:`/reports?targetId=…` → `/next/watch?targetId=…`
- `communityWatchRemoveComment` 守望移除通知連結:`/reports` → `/next/watch`

Completes the oss.matters.town → /next link migration started by #4893 (comment-spam deep link, already in production via #4898).

## Checks

- ✅ Staging deploy ([run 28654501317](https://github.com/thematters/matters-server/actions/runs/28654501317)): `deploy-eb-develop` and `deploy-report-telegram-alert` succeeded. The 3 red lambda jobs (recommendation-hottest-v5, ipfs-publication, archive-user) failed on CloudFormation **"Rate exceeded"** throttling — transient, unrelated to this change.
- ✅ Done/Dark/Inert: **Done** — constant URL change, no behavior/schema/UI change, no migration.
- ℹ️ Note: master carries 2 hotfixes not yet back-merged to develop (#4902, #4903). This merge does not affect them; a master → develop back-merge is still owed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)