### PR TITLE
fix(notice): hide restricted-actor notices from notification feeds

### DIFF
--- a/src/connectors/__test__/notificationService.test.ts
+++ b/src/connectors/__test__/notificationService.test.ts
@@ -4,9 +4,12 @@ import {
   MONTH,
   NOTICE_TYPE,
   OFFICIAL_NOTICE_EXTEND_TYPE,
+  USER_STATE,
 } from '#common/enums/index.js'
 import { NotificationService } from '#connectors/notification/notificationService.js'
 import { mergeDataWith } from '#connectors/notification/utils.js'
+import { UserService } from '#connectors/userService.js'
+import { v4 as uuidv4 } from 'uuid'
 
 import { genConnections, closeConnections } from './utils.js'
 
@@ -398,5 +401,53 @@ describe('query notices with onlyRecent flag', () => {
       onlyRecent: true,
     })
     expect(notices1.length - notices2.length).toBe(1)
+  })
+})
+
+describe('exclude restricted actor notices', () => {
+  test('frozen/archived actor notices are hidden from list and count', async () => {
+    const userService = new UserService(connections)
+    const genUserName = () =>
+      `noticeactor${uuidv4().replace(/-/g, '').slice(0, 12)}`
+    const recipient = await userService.create({ userName: genUserName() })
+    const actor = await userService.create({ userName: genUserName() })
+
+    await notificationService.process({
+      event: NOTICE_TYPE.user_new_follower,
+      actorId: actor.id,
+      recipientId: recipient.id,
+      tag: `follow:${actor.id}:${recipient.id}`,
+    })
+    const setActorState = (state: string) =>
+      connections
+        .knex('user')
+        .where({ id: actor.id })
+        .update({ state, updatedAt: new Date() })
+
+    expect(
+      await notificationService.countNotice({ userId: recipient.id })
+    ).toBe(1)
+    expect(
+      (await notificationService.findByUser({ userId: recipient.id })).length
+    ).toBe(1)
+
+    // frozen and archived actors are excluded
+    for (const state of [USER_STATE.frozen, USER_STATE.archived]) {
+      await setActorState(state)
+      expect(
+        await notificationService.countNotice({ userId: recipient.id })
+      ).toBe(0)
+      expect(
+        (await notificationService.findByUser({ userId: recipient.id })).length
+      ).toBe(0)
+    }
+
+    // banned is a temporary punishment and stays visible
+    await setActorState(USER_STATE.banned)
+    const notices = await notificationService.findByUser({
+      userId: recipient.id,
+    })
+    expect(notices.length).toBe(1)
+    expect(notices[0]?.actors?.map(({ id }) => id)).toEqual([actor.id])
   })
 })

--- a/src/connectors/dailySummaryEmailService.ts
+++ b/src/connectors/dailySummaryEmailService.ts
@@ -222,6 +222,7 @@ export class DailySummaryEmailService {
         ],
       ],
       whereIn: ['notice_detail.notice_type', validNoticeTypes],
+      excludeRestrictedActors: true,
     })
 
     const notices = await Promise.all(

--- a/src/connectors/notification/notificationService.ts
+++ b/src/connectors/notification/notificationService.ts
@@ -21,6 +21,7 @@ import {
   QUEUE_URL,
   CACHE_TTL,
   USER_ACTION,
+  USER_STATE,
   NOTICE_TYPE,
   BUNDLED_NOTICE_TYPE,
   OFFICIAL_NOTICE_EXTEND_TYPE,
@@ -46,6 +47,14 @@ const logger = getLogger('service-notification')
 const SKIP_NOTICE_FLAG_PREFIX = 'skip-notice'
 const DELETE_NOTICE_KEY_PREFIX = 'delete-notice'
 const LOCK_NOTICE_PREFIX = 'lock-notice'
+
+// mirrors RESTRICTED_COMMENT_AUTHOR_STATES in commentService: `banned` is a
+// temporary punishment whose content stays, while frozen/archived actors
+// should not surface in other users' notification feeds
+const RESTRICTED_NOTICE_ACTOR_STATES = [
+  USER_STATE.frozen,
+  USER_STATE.archived,
+] as const
 
 export class NotificationService {
   public mail: typeof mail
@@ -145,6 +154,7 @@ export class NotificationService {
       where,
       skip,
       take,
+      excludeRestrictedActors: true,
     })
 
     return Promise.all(
@@ -185,6 +195,9 @@ export class NotificationService {
     if (onlyRecent) {
       query.whereRaw(`updated_at > now() - interval '6 months'`)
     }
+
+    // keep the badge count in sync with the filtered notice list
+    this.excludeRestrictedActorNotices(query)
 
     const result = await query
     return parseInt(result ? (result.count as string) : '0', 10)
@@ -296,11 +309,13 @@ export class NotificationService {
     whereIn,
     skip,
     take,
+    excludeRestrictedActors,
   }: {
     where?: any[][]
     whereIn?: [string, any[]]
     skip?: number
     take?: number
+    excludeRestrictedActors?: boolean
   }): Promise<NoticeDetail[]> => {
     const knexRO = this.connections.knexRO
     const query = knexRO
@@ -331,6 +346,10 @@ export class NotificationService {
 
     if (whereIn) {
       query.whereIn(...whereIn)
+    }
+
+    if (excludeRestrictedActors) {
+      this.excludeRestrictedActorNotices(query)
     }
 
     if (skip) {
@@ -401,8 +420,30 @@ export class NotificationService {
       .from('notice_actor')
       .innerJoin('user', 'notice_actor.actor_id', '=', 'user.id')
       .where({ noticeId })
+      .whereNotIn('user.state', RESTRICTED_NOTICE_ACTOR_STATES)
     return actors
   }
+
+  // exclude notices whose actors are all restricted; notices without actors
+  // (e.g. official announcements) are kept
+  private excludeRestrictedActorNotices = (query: Knex.QueryBuilder) =>
+    query.where((builder) =>
+      builder
+        .whereNotExists(
+          this.knexRO
+            .select(1)
+            .from('notice_actor')
+            .whereRaw('notice_actor.notice_id = notice.id')
+        )
+        .orWhereExists(
+          this.knexRO
+            .select(1)
+            .from('notice_actor')
+            .innerJoin('user', 'notice_actor.actor_id', '=', 'user.id')
+            .whereRaw('notice_actor.notice_id = notice.id')
+            .whereNotIn('user.state', RESTRICTED_NOTICE_ACTOR_STATES)
+        )
+    )
 
   private deleteNotice = async (id: string) =>
     this.models.update({

--- a/src/queries/comment/content.ts
+++ b/src/queries/comment/content.ts
@@ -2,20 +2,34 @@ import type { GQLCommentResolvers } from '#definitions/index.js'
 
 import { COMMENT_STATE } from '#common/enums/index.js'
 
-const resolver: GQLCommentResolvers['content'] = (
-  { content, state },
+const resolver: GQLCommentResolvers['content'] = async (
+  comment,
   _,
-  { viewer }
+  { viewer, dataSources: { commentService } }
 ) => {
+  const { content, state, authorId } = comment
   const isActive = state === COMMENT_STATE.active
   const isCollapsed = state === 'collapsed'
   const isAdmin = viewer.hasRole('admin')
 
-  if (isActive || isCollapsed || isAdmin) {
+  if (isAdmin) {
     return content ?? null
   }
 
-  return ''
+  if (!isActive && !isCollapsed) {
+    return ''
+  }
+
+  // hide content from restricted (frozen/archived) authors on every read
+  // path, incl. notices that load comments outside the filtered lists
+  if (
+    viewer.id !== authorId &&
+    (await commentService.isAuthorRestricted(comment))
+  ) {
+    return ''
+  }
+
+  return content ?? null
 }
 
 export default resolver

--- a/src/types/__test__/2/notice.test.ts
+++ b/src/types/__test__/2/notice.test.ts
@@ -1,12 +1,18 @@
 import type { Connections } from '#definitions/index.js'
 import { v4 as uuidv4 } from 'uuid'
-import { NODE_TYPES } from '#common/enums/index.js'
+import {
+  COMMENT_STATE,
+  COMMENT_TYPE,
+  NODE_TYPES,
+  USER_STATE,
+} from '#common/enums/index.js'
 import { toGlobalId, fromGlobalId } from '#common/utils/index.js'
 import {
   AtomService,
   SystemService,
   CollectionService,
   CampaignService,
+  UserService,
 } from '#connectors/index.js'
 
 import { testClient, genConnections, closeConnections } from '../utils.js'
@@ -193,4 +199,120 @@ test('query `scheduled_article_published` notice', async () => {
       latestNotice.entities[2].__typename,
     ].sort()
   ).toEqual(['Article', 'WritingChallenge', 'Collection'].sort())
+})
+
+test('hide notices from restricted actors', async () => {
+  const GET_COMMENT_NOTICES = /* GraphQL */ `
+    query ($nodeInput: NodeInput!) {
+      node(input: $nodeInput) {
+        ... on User {
+          notices(input: { first: 100 }) {
+            edges {
+              node {
+                id
+                ... on CommentNotice {
+                  actors {
+                    id
+                  }
+                  target {
+                    id
+                    content
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `
+  const userService = new UserService(connections)
+  const spammer = await userService.create({
+    userName: `spamactor${uuidv4().replace(/-/g, '').slice(0, 12)}`,
+  })
+
+  // an active spam comment on article 1, authored by the spammer
+  const { id: articleEntityTypeId } = await systemService.baseFindEntityTypeId(
+    'article'
+  )
+  const comment = await atomService.create({
+    table: 'comment',
+    data: {
+      uuid: uuidv4(),
+      content: '<p>spam notice content</p>',
+      authorId: spammer.id,
+      targetId: '1',
+      targetTypeId: articleEntityTypeId,
+      parentCommentId: null,
+      state: COMMENT_STATE.active,
+      type: COMMENT_TYPE.article,
+    },
+  })
+
+  // an `article_new_comment` notice to user 1 with the spammer as actor
+  const noticeDetail = await atomService.create({
+    table: 'notice_detail',
+    data: { noticeType: 'article_new_comment' },
+  })
+  const notice = await atomService.create({
+    table: 'notice',
+    data: {
+      noticeDetailId: noticeDetail.id,
+      recipientId: '1',
+      uuid: uuidv4(),
+    },
+  })
+  await atomService.create({
+    table: 'notice_actor',
+    data: { noticeId: notice.id, actorId: spammer.id },
+  })
+  const { id: commentEntityTypeId } = await systemService.baseFindEntityTypeId(
+    'comment'
+  )
+  await atomService.create({
+    table: 'notice_entity',
+    data: {
+      noticeId: notice.id,
+      entityTypeId: commentEntityTypeId,
+      entityId: comment.id,
+      type: 'comment',
+    },
+  })
+
+  const noticeGlobalId = toGlobalId({ type: NODE_TYPES.Notice, id: notice.id })
+  const server = await testClient({ isAuth: true, connections })
+  const findNotice = async () => {
+    const { data, errors } = await server.executeOperation({
+      query: GET_COMMENT_NOTICES,
+      variables: { nodeInput: { id: USER_ID } },
+    })
+    expect(errors).toBeUndefined()
+    return data.node.notices.edges.find(
+      (e: { node: { id: string } }) => e.node.id === noticeGlobalId
+    )?.node
+  }
+
+  // visible while the actor is active
+  const before = await findNotice()
+  expect(before.target.content).toBe('<p>spam notice content</p>')
+
+  // freezing the only actor drops the whole notice
+  await atomService.update({
+    table: 'user',
+    where: { id: spammer.id },
+    data: { state: USER_STATE.frozen },
+  })
+  expect(await findNotice()).toBeUndefined()
+
+  // bundling an active actor restores the notice, but the frozen actor
+  // stays hidden and the restricted author's comment content is blanked
+  await atomService.create({
+    table: 'notice_actor',
+    data: { noticeId: notice.id, actorId: '2' },
+  })
+  const bundled = await findNotice()
+  expect(bundled.actors.map((a: { id: string }) => a.id)).toEqual([
+    toGlobalId({ type: NODE_TYPES.User, id: 2 }),
+  ])
+  expect(bundled.target.content).toBe('')
 })


### PR DESCRIPTION
## Problem

#4896 removed restricted-author (frozen/archived) comments from public surfaces, but other users' **notification feeds** were untouched:

- `findByUser` / `countNotice` return notices regardless of actor state, so a frozen spammer's notice still shows up in the notice list, the unread badge and the daily summary email
- notice resolvers load target/entity comments via id loaders, bypassing the filtered comment lists
- `Comment.content` only checks the comment's own state — a frozen spammer's comment is still `active`, so its content renders in full inside `CommentNotice`

Real case: batch-frozen spam accounts (e.g. the comment/moment spam rings frozen via OSS on 2026-07-03) still surface their spam content in recipients' notifications.

## Fix

- `notificationService.findByUser` / `countNotice` / daily summary `findDetail`: exclude notices whose actors are **all** frozen/archived (opt-in `excludeRestrictedActors` flag on `findDetail`, so notice bundling lookups are unaffected). Actor-less official notices are kept.
- `findActors`: filter restricted actors, so bundled notices only show active actors.
- `Comment.content`: blank content for restricted authors (unless viewer is admin or the author), covering bundled notices that survive via an active co-actor and any future read path.

`banned` is deliberately **not** restricted: it is a temporary punishment whose content stays, mirroring `RESTRICTED_COMMENT_AUTHOR_STATES` in commentService.

## Tests

- `connectors/notificationService`: new case — frozen/archived actor hides the notice from list + count, banned keeps it visible (16/16 pass locally)
- `types/2/notice`: new e2e — `article_new_comment` notice visible while actor active → dropped when frozen → reappears when an active actor bundles in, with the frozen actor filtered out and comment content blanked (25/25 pass with comment.test)
- `connectors/dailySummaryEmailService`: 12/12 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)