### PR TITLE
ci(lambda-deploy): retry CloudFormation throttling via SDK adaptive retry

### DIFF
--- a/.github/workflows/lambda-deploy.yml
+++ b/.github/workflows/lambda-deploy.yml
@@ -25,6 +25,12 @@ env:
   ECR_REPOSITORY: lambda-handlers-image
   MATTERS_ENV: ${{ inputs.environment == 'develop' && 'development' || 'production' }}
   SQS_ENV: ${{ inputs.environment == 'develop' && 'dev' || 'prod' }}
+  # ~28 deploy jobs hit CloudFormation concurrently and trip its API rate
+  # limit, failing a random subset with "Rate exceeded" on nearly every run.
+  # aws-cloudformation-github-deploy@v1 uses AWS SDK v3, which honors these
+  # vars: adaptive mode rate-limits client-side and retries with backoff.
+  AWS_RETRY_MODE: adaptive
+  AWS_MAX_ATTEMPTS: '10'
 
 jobs:
   build-lambda-image:


### PR DESCRIPTION
## What / Why

Nearly every Deploy run goes red: the lambda-deploy workflow fires **~28 concurrent jobs** at CloudFormation and a random subset dies with `##[error]Rate exceeded` — e.g. [28654501317](https://github.com/thematters/matters-server/actions/runs/28654501317) (staging, 3 jobs), [28655653346](https://github.com/thematters/matters-server/actions/runs/28655653346) (production, 2 jobs), [28650150182](https://github.com/thematters/matters-server/actions/runs/28650150182) (production, 2 jobs). `sync-blockchain-events` has now missed **two consecutive production deploys** and is running a stale build.

## Fix

`aws-cloudformation-github-deploy@v1` is built on **AWS SDK v3** (`@aws-sdk/client-cloudformation ^3.474.0`), which honors `AWS_RETRY_MODE` / `AWS_MAX_ATTEMPTS` from the environment. Exporting `adaptive` mode with 10 attempts at the workflow `env` level makes the change-set calls **and** the `DescribeStacks` polling back off and retry client-side instead of failing the job. 6-line diff, no job restructuring.

### Why not a `max-parallel` matrix?

Converting the 28 jobs to a matrix was considered, but `strategy.matrix` values **cannot reference the `secrets` context**, which the `sqsArn` parameter-overrides need (`secrets.AWS_REGION` / `secrets.AWS_ACCOUNT_ID`). That refactor would need placeholder indirection and rewrite the whole file for the same outcome. If throttling ever persists after this, that's the follow-up.

## SOP

Trivial tier (CI-only, no runtime behavior change) — state: **Inert** for users; effective on staging deploys immediately after merge, on production deploys after the next develop → master promote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)