### PR TITLE
fix(search): exclude freshly restricted users from search and hide their bios

### DIFF
--- a/src/connectors/__test__/searchService/article.test.ts
+++ b/src/connectors/__test__/searchService/article.test.ts
@@ -1,7 +1,8 @@
 import type { Connections } from '#definitions/index.js'
 
-import { FEATURE_NAME, FEATURE_FLAG } from '#common/enums/index.js'
+import { FEATURE_NAME, FEATURE_FLAG, USER_STATE } from '#common/enums/index.js'
 import { PublicationService } from '../../article/publicationService.js'
+import { UserService } from '../../userService.js'
 import { AtomService } from '../../atomService.js'
 import { SearchService } from '../../searchService.js'
 import { SystemService } from '../../systemService.js'
@@ -183,5 +184,49 @@ describe('quicksearch', () => {
       where: { id: article.id },
       data: { spamScore: spamThreshold + 0.1 },
     })
+  })
+})
+
+describe('restricted authors', () => {
+  test('exclude articles whose authors were restricted after the index sync', async () => {
+    const userService = new UserService(connections)
+    const author = await userService.create({ userName: 'stalefrozenauthor' })
+    const [article] = await publicationService.createArticle({
+      title: 'stalesearchable title',
+      content: 'stalesearchable body',
+      authorId: author.id,
+    })
+    // index while the author is still active
+    await searchService.indexArticles([article.id])
+
+    const before = await searchService.searchArticles({
+      key: 'stalesearchable',
+      take: 10,
+      skip: 0,
+    })
+    expect(before.nodes.map(({ id }) => id)).toContain(article.id)
+
+    await connections
+      .knex('user')
+      .where({ id: author.id })
+      .update({ state: USER_STATE.frozen })
+
+    // fresh service to avoid the test-only dataloader cache
+    const freshSearchService = new SearchService(connections)
+    const after = await freshSearchService.searchArticles({
+      key: 'stalesearchable',
+      take: 10,
+      skip: 0,
+    })
+    expect(after.nodes.map(({ id }) => id)).not.toContain(article.id)
+
+    // quicksearch reads the live database and excludes as well
+    const quick = await freshSearchService.searchArticles({
+      key: 'stalesearchable',
+      take: 10,
+      skip: 0,
+      quicksearch: true,
+    })
+    expect(quick.nodes.map(({ id }) => id)).not.toContain(article.id)
   })
 })

--- a/src/connectors/__test__/searchService/user.test.ts
+++ b/src/connectors/__test__/searchService/user.test.ts
@@ -1,7 +1,8 @@
 import type { Connections } from '#definitions/index.js'
 
-import { USER_ACTION } from '#common/enums/index.js'
+import { USER_ACTION, USER_STATE } from '#common/enums/index.js'
 import { SearchService } from '../../searchService.js'
+import { UserService } from '../../userService.js'
 
 import { genConnections, closeConnections } from '../utils.js'
 
@@ -120,5 +121,44 @@ describe('search', () => {
     })
     expect(res3.nodes.length).toBe(5)
     expect(res3.totalCount).toBe(6)
+  })
+})
+
+describe('restricted users', () => {
+  test('exclude users restricted after the index sync', async () => {
+    const userService = new UserService(connections)
+    const user = await userService.create({ userName: 'stalefrozenuser' })
+    // simulate a stale search index snapshot: still `active` there
+    await connections.knexSearch('search_index.user').insert({
+      id: user.id,
+      userName: user.userName,
+      displayName: 'stalefrozenuser',
+      displayNameOrig: 'stalefrozenuser',
+      description: '',
+      state: USER_STATE.active,
+      createdAt: new Date(),
+    })
+
+    const before = await searchService.searchUsers({
+      key: 'stalefrozenuser',
+      take: 3,
+      skip: 0,
+    })
+    expect(before.totalCount).toBe(1)
+
+    await connections
+      .knex('user')
+      .where({ id: user.id })
+      .update({ state: USER_STATE.frozen })
+
+    // fresh service to avoid the test-only dataloader cache
+    const freshSearchService = new SearchService(connections)
+    const after = await freshSearchService.searchUsers({
+      key: 'stalefrozenuser',
+      take: 3,
+      skip: 0,
+    })
+    expect(after.nodes.length).toBe(0)
+    expect(after.totalCount).toBe(0)
   })
 })

--- a/src/connectors/searchService.ts
+++ b/src/connectors/searchService.ts
@@ -24,6 +24,20 @@ const logger = getLogger('service-search')
 const SEARCH_TITLE_RANK_THRESHOLD = 0.001
 const SEARCH_DEFAULT_TEXT_RANK_THRESHOLD = 0.0001
 
+// user states excluded from search results; the search index snapshots
+// `state`/`author_state` and can lag behind freshly restricted accounts,
+// so results are also re-checked against the live user rows
+const SEARCH_EXCLUDED_USER_STATES = [
+  USER_STATE.archived,
+  USER_STATE.banned,
+  USER_STATE.frozen,
+] as const
+
+const isSearchExcludedUserState = (state?: string) =>
+  SEARCH_EXCLUDED_USER_STATES.includes(
+    state as (typeof SEARCH_EXCLUDED_USER_STATES)[number]
+  )
+
 export class SearchService {
   private connections: Connections
   private models: AtomService
@@ -148,12 +162,11 @@ export class SearchService {
               )
               .whereNotIn('id', articleIds)
               .whereIn('state', [ARTICLE_STATE.active])
-              .andWhere('author_state', 'NOT IN', [
-                // USER_STATE.active
-                USER_STATE.archived,
-                USER_STATE.banned,
-                USER_STATE.frozen,
-              ])
+              .andWhere(
+                'author_state',
+                'NOT IN',
+                SEARCH_EXCLUDED_USER_STATES as unknown as string[]
+              )
               .andWhere('author_id', 'NOT IN', blockedIds)
               .andWhereRaw(
                 `(query @@ title_jieba_ts OR query @@ summary_jieba_ts OR query @@ text_jieba_ts)`
@@ -187,11 +200,34 @@ export class SearchService {
         }
       })
 
-    const nodes = await this.models.articleIdLoader.loadMany(
-      records.map((item: { id: string }) => item.id).filter(Boolean)
+    const loaded = (
+      await this.models.articleIdLoader.loadMany(
+        records.map((item: { id: string }) => item.id).filter(Boolean)
+      )
+    ).filter((node): node is Article => !(node instanceof Error))
+
+    // drop articles whose authors were restricted after the last index sync
+    const authors = await this.models.userIdLoader.loadMany(
+      loaded.map(({ authorId }) => authorId)
+    )
+    const restrictedAuthorIds = new Set(
+      authors
+        .filter(
+          (author) =>
+            !(author instanceof Error) &&
+            isSearchExcludedUserState(author.state)
+        )
+        .map((author) => (author as { id: string }).id)
+    )
+    const nodes = loaded.filter(
+      ({ authorId }) => !restrictedAuthorIds.has(authorId)
     )
 
-    const totalCount = records.length === 0 ? 0 : +records[0].totalCount
+    const snapshotTotalCount = records.length === 0 ? 0 : +records[0].totalCount
+    const totalCount = Math.max(
+      0,
+      snapshotTotalCount - (loaded.length - nodes.length)
+    )
 
     logger.debug(
       `articleService::searchV2 knexSearch instance got ${nodes.length} nodes from: ${totalCount} total:`,
@@ -240,6 +276,12 @@ export class SearchService {
           .from('article_version_newest')
       )
       .where({ state: ARTICLE_STATE.active })
+      .whereNotIn(
+        'authorId',
+        this.knexRO('user')
+          .select('id')
+          .whereIn('state', SEARCH_EXCLUDED_USER_STATES as unknown as string[])
+      )
       // .modify(excludeSpam, spamThreshold)
       .orderBy('id', 'desc')
       .modify((builder: Knex.QueryBuilder) => {
@@ -458,12 +500,11 @@ export class SearchService {
       .crossJoin(
         this.knexSearch.raw(`plainto_tsquery('jiebacfg', ?) query`, key)
       )
-      .where('state', 'NOT IN', [
-        // USER_STATE.active,
-        USER_STATE.archived,
-        USER_STATE.banned,
-        USER_STATE.frozen,
-      ])
+      .where(
+        'state',
+        'NOT IN',
+        SEARCH_EXCLUDED_USER_STATES as unknown as string[]
+      )
       .andWhere('id', 'NOT IN', blockedIds)
       .andWhere((builder: Knex.QueryBuilder) => {
         builder
@@ -522,11 +563,19 @@ export class SearchService {
       { sample: records?.slice(0, 3) }
     )
 
-    const nodes = await this.models.userIdLoader.loadMany(
+    const loaded = await this.models.userIdLoader.loadMany(
       records.map(({ id }) => id)
     )
+    // drop accounts restricted after the last search index sync
+    const nodes = loaded.filter(
+      (node) =>
+        !(node instanceof Error) && !isSearchExcludedUserState(node.state)
+    )
 
-    return { nodes, totalCount }
+    return {
+      nodes,
+      totalCount: Math.max(0, totalCount - (loaded.length - nodes.length)),
+    }
   }
 
   public findFrequentSearches = async ({

--- a/src/queries/user/description.ts
+++ b/src/queries/user/description.ts
@@ -1,0 +1,29 @@
+import type { GQLUserInfoResolvers } from '#definitions/index.js'
+
+import { USER_STATE } from '#common/enums/index.js'
+
+// profile bios of restricted accounts should not be readable publicly,
+// mirroring the inactive states handled by the web client
+const RESTRICTED_USER_STATES = [
+  USER_STATE.archived,
+  USER_STATE.banned,
+  USER_STATE.frozen,
+] as const
+
+const resolver: GQLUserInfoResolvers['description'] = (
+  { id, state, description },
+  _,
+  { viewer }
+) => {
+  const isRestricted = RESTRICTED_USER_STATES.includes(
+    state as (typeof RESTRICTED_USER_STATES)[number]
+  )
+
+  if (isRestricted && viewer.id !== id && !viewer.hasRole('admin')) {
+    return null
+  }
+
+  return description
+}
+
+export default resolver

--- a/src/queries/user/index.ts
+++ b/src/queries/user/index.ts
@@ -40,6 +40,7 @@ import Collection from './collection/index.js'
 import collections from './collections.js'
 import commentCount from './commentCount.js'
 import cryptoWallet from './cryptoWallet.js'
+import description from './description.js'
 import donatedArticleCount from './donatedArticleCount.js'
 import featuredTags from './featuredTags.js'
 import features from './features.js'
@@ -160,6 +161,7 @@ const user: {
   UserInfo: {
     ipnsKey,
     badges,
+    description,
     userNameEditable,
     email: ({ email }) => email && email.replace(/#/g, '@'),
     emailVerified: ({ emailVerified }) => emailVerified || false,

--- a/src/types/__test__/2/user/user.test.ts
+++ b/src/types/__test__/2/user/user.test.ts
@@ -1406,3 +1406,41 @@ describe('query user writings', () => {
     expect(dataAfter.viewer.writings.pageInfo.hasNextPage).toBeFalsy()
   })
 })
+
+describe('restricted user description', () => {
+  const GET_USER_DESCRIPTION = /* GraphQL */ `
+    query ($input: UserInput!) {
+      user(input: $input) {
+        info {
+          description
+        }
+      }
+    }
+  `
+  test('hide description of restricted users from visitors', async () => {
+    const user = await userService.create({ userName: 'frozendescuser' })
+    await connections
+      .knex('user')
+      .where({ id: user.id })
+      .update({ description: 'spam self intro', state: USER_STATE.frozen })
+
+    const visitorServer = await testClient({ connections })
+    const { data } = await visitorServer.executeOperation({
+      query: GET_USER_DESCRIPTION,
+      variables: { input: { userName: 'frozendescuser' } },
+    })
+    expect(data.user.info.description).toBeNull()
+
+    // admin still sees it
+    const adminServer = await testClient({
+      isAuth: true,
+      isAdmin: true,
+      connections,
+    })
+    const { data: adminData } = await adminServer.executeOperation({
+      query: GET_USER_DESCRIPTION,
+      variables: { input: { userName: 'frozendescuser' } },
+    })
+    expect(adminData.user.info.description).toBe('spam self intro')
+  })
+})


### PR DESCRIPTION
## Problem

Two residual public surfaces still exposed frozen accounts (verified on production with `omisenote01` and the 2026-07-03 batch-frozen spam rings):

1. **User search still returns frozen accounts.** `searchUsers` / `searchArticles` filter on `search_index.user.state` / `search_index.article.author_state` — snapshot columns that lag behind the live `user` table. Accounts frozen after the last index sync keep appearing in search until (if ever) the snapshot refreshes. `quicksearchArticles` reads the live DB but has no author-state filter at all.
2. **`user.info.description` is publicly readable** for frozen accounts via the API. The web renders these profiles as inactive, but a direct GraphQL query returns the full bio (spam bios included).

## Fix

- `searchUsers`: after loading result nodes from the live DB (which already happens via `userIdLoader`), drop archived/banned/frozen accounts and adjust `totalCount`.
- `searchArticles`: same re-check against the live author rows.
- `quicksearchArticles`: add the missing author-state SQL filter (live DB, so filtered at query level).
- New `UserInfo.description` resolver: returns `null` for archived/banned/frozen users unless the viewer is an admin or the user themself — mirroring the inactive states the web client handles.
- The excluded-state list is shared as `SEARCH_EXCLUDED_USER_STATES` (same set the snapshot filters already used).

## Tests

- `searchService/user.test`: user indexed as `active`, then frozen in the live DB → dropped from results and count (simulates the stale snapshot)
- `searchService/article.test`: article indexed via `indexArticles`, author then frozen → excluded from both search and quicksearch
- `types/2/user/user.test`: frozen user's description is `null` for visitors, still visible to admin
- Full `searchService` suite 34/34, `user.test` + `search.test` types 48/48 pass locally

Note: local test runs on macOS need `psql` on the default `sh` PATH because `db/initDatabase.js` spawns the search-index rollup with a minimal env — unchanged here, CI unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)