### PR TITLE
fix(spam-ring): purge response caches when freezing/unfreezing rings

### DIFF
--- a/src/common/utils/__test__/spamRingResolvers.test.ts
+++ b/src/common/utils/__test__/spamRingResolvers.test.ts
@@ -36,9 +36,19 @@ const makeContext = (viewer: any = { id: '9' }) => {
     viewer,
     dataSources: {
       userService,
+      articleService: { findByAuthor: jest.fn(async () => []) },
+      connections: { redis: { __sentinel: 'redis' } },
       spamRingService: {
-        freezeRing: jest.fn(async () => ({ ring: {}, frozen: [], skipped: [] })),
-        unfreezeRing: jest.fn(async () => ({ ring: {}, unbanned: [], skipped: [] })),
+        freezeRing: jest.fn(async () => ({
+          ring: {},
+          frozen: [],
+          skipped: [],
+        })),
+        unfreezeRing: jest.fn(async () => ({
+          ring: {},
+          unbanned: [],
+          skipped: [],
+        })),
         dismissRing: jest.fn(async () => ({ id: '1' })),
         upsertCandidates: jest.fn(async () => ({
           created: 1,
@@ -99,6 +109,43 @@ describe('spam ring mutation resolvers', () => {
     })
   })
 
+  test('freezeSpamRing purges caches of frozen members', async () => {
+    const ctx = makeContext()
+    ctx.dataSources.spamRingService.freezeRing = jest.fn(async () => ({
+      ring: {},
+      frozen: [{ id: '11' }, { id: '12' }],
+      skipped: [],
+    }))
+    await (freezeSpamRing as any)(
+      null,
+      { input: { id: ringGlobalId('1') } },
+      ctx
+    )
+    expect(ctx.dataSources.articleService.findByAuthor).toHaveBeenCalledWith(
+      '11'
+    )
+    expect(ctx.dataSources.articleService.findByAuthor).toHaveBeenCalledWith(
+      '12'
+    )
+  })
+
+  test('unfreezeSpamRing purges caches of restored members', async () => {
+    const ctx = makeContext()
+    ctx.dataSources.spamRingService.unfreezeRing = jest.fn(async () => ({
+      ring: {},
+      unbanned: [{ id: '21' }],
+      skipped: [],
+    }))
+    await (unfreezeSpamRing as any)(
+      null,
+      { input: { id: ringGlobalId('2') } },
+      ctx
+    )
+    expect(ctx.dataSources.articleService.findByAuthor).toHaveBeenCalledWith(
+      '21'
+    )
+  })
+
   test('freezeSpamRing rejects when viewer has no id', async () => {
     await expect(
       (freezeSpamRing as any)(
@@ -155,9 +202,8 @@ describe('spam ring mutation resolvers', () => {
       },
       ctx
     )
-    const arg = (
-      ctx.dataSources.spamRingService.upsertCandidates as any
-    ).mock.calls[0][0]
+    const arg = (ctx.dataSources.spamRingService.upsertCandidates as any).mock
+      .calls[0][0]
     expect(arg[0].fingerprint).toBe('fp1')
     expect(arg[0].memberUserIds).toEqual(['u1', 'u2'])
     expect(arg[0].memberUserNames).toBeUndefined()
@@ -279,10 +325,9 @@ describe('SpamRing type resolvers', () => {
       { input: { first: 1 } },
       ctx
     )
-    expect(ctx.dataSources.spamRingService.findMembersAndCount).toHaveBeenCalledWith(
-      'r1',
-      { take: 1, skip: 0 }
-    )
+    expect(
+      ctx.dataSources.spamRingService.findMembersAndCount
+    ).toHaveBeenCalledWith('r1', { take: 1, skip: 0 })
     expect(memberConnection.totalCount).toBe(2)
     expect(memberConnection.edges.map((edge: any) => edge.node.id)).toEqual([
       'm1',
@@ -328,7 +373,9 @@ describe('SpamRing type resolvers', () => {
     await expect(
       (SpamRingEvent.actor as any)({ actorId: 'u9' }, null, ctx)
     ).resolves.toBe(actor)
-    expect((SpamRingEvent.actor as any)({ actorId: null }, null, ctx)).toBeNull()
+    expect(
+      (SpamRingEvent.actor as any)({ actorId: null }, null, ctx)
+    ).toBeNull()
     expect((SpamRingEvent.detail as any)({ detail: { reason: 'fp' } })).toBe(
       JSON.stringify({ reason: 'fp' })
     )

--- a/src/mutations/user/freezeSpamRing.ts
+++ b/src/mutations/user/freezeSpamRing.ts
@@ -3,21 +3,39 @@ import type { GQLMutationResolvers } from '#definitions/index.js'
 import { ForbiddenError } from '#common/errors.js'
 import { fromGlobalId } from '#common/utils/index.js'
 
+import { invalidateUserContentCaches } from './utils.js'
+
 const resolver: GQLMutationResolvers['freezeSpamRing'] = async (
   _,
   { input: { id, remark } },
-  { viewer, dataSources: { spamRingService, userService } }
+  {
+    viewer,
+    dataSources: {
+      spamRingService,
+      userService,
+      articleService,
+      connections: { redis },
+    },
+  }
 ) => {
   if (!viewer.id) {
     throw new ForbiddenError('viewer has no id')
   }
   const { id: ringId } = fromGlobalId(id)
-  return spamRingService.freezeRing({
+  const result = await spamRingService.freezeRing({
     ringId,
     actorId: viewer.id,
     remark,
     userService,
   })
+
+  // after the freeze transaction commits, purge cached public query
+  // responses so frozen members' content stops being served
+  for (const user of result.frozen) {
+    await invalidateUserContentCaches(user.id, { articleService, redis })
+  }
+
+  return result
 }
 
 export default resolver

--- a/src/mutations/user/unfreezeSpamRing.ts
+++ b/src/mutations/user/unfreezeSpamRing.ts
@@ -3,20 +3,38 @@ import type { GQLMutationResolvers } from '#definitions/index.js'
 import { ForbiddenError } from '#common/errors.js'
 import { fromGlobalId } from '#common/utils/index.js'
 
+import { invalidateUserContentCaches } from './utils.js'
+
 const resolver: GQLMutationResolvers['unfreezeSpamRing'] = async (
   _,
   { input: { id } },
-  { viewer, dataSources: { spamRingService, userService } }
+  {
+    viewer,
+    dataSources: {
+      spamRingService,
+      userService,
+      articleService,
+      connections: { redis },
+    },
+  }
 ) => {
   if (!viewer.id) {
     throw new ForbiddenError('viewer has no id')
   }
   const { id: ringId } = fromGlobalId(id)
-  return spamRingService.unfreezeRing({
+  const result = await spamRingService.unfreezeRing({
     ringId,
     actorId: viewer.id,
     userService,
   })
+
+  // after the unfreeze transaction commits, purge cached public query
+  // responses so restored members' content shows up again promptly
+  for (const user of result.unbanned) {
+    await invalidateUserContentCaches(user.id, { articleService, redis })
+  }
+
+  return result
 }
 
 export default resolver

--- a/src/mutations/user/updateUserState.ts
+++ b/src/mutations/user/updateUserState.ts
@@ -1,9 +1,10 @@
 import type { GQLMutationResolvers, User } from '#definitions/index.js'
 
-import { NODE_TYPES, USER_STATE } from '#common/enums/index.js'
+import { USER_STATE } from '#common/enums/index.js'
 import { ActionFailedError, UserInputError } from '#common/errors.js'
 import { fromGlobalId } from '#common/utils/index.js'
-import { invalidateFQC } from '@matters/apollo-response-cache'
+
+import { invalidateUserContentCaches } from './utils.js'
 
 const resolver: GQLMutationResolvers['updateUserState'] = async (
   _,
@@ -22,15 +23,8 @@ const resolver: GQLMutationResolvers['updateUserState'] = async (
 ) => {
   const id = globalId ? fromGlobalId(globalId).id : undefined
 
-  const invalidateUserCaches = async (userId: string) => {
-    await invalidateFQC({ node: { type: NODE_TYPES.User, id: userId }, redis })
-    for (const article of await articleService.findByAuthor(userId)) {
-      await invalidateFQC({
-        node: { type: NODE_TYPES.Article, id: article.id },
-        redis,
-      })
-    }
-  }
+  const invalidateUserCaches = (userId: string) =>
+    invalidateUserContentCaches(userId, { articleService, redis })
 
   /**
    * archive

--- a/src/mutations/user/utils.ts
+++ b/src/mutations/user/utils.ts
@@ -1,0 +1,27 @@
+import type { ArticleService } from '#connectors/index.js'
+import type { Redis } from 'ioredis'
+
+import { NODE_TYPES } from '#common/enums/index.js'
+import { invalidateFQC } from '@matters/apollo-response-cache'
+
+// purge cached public query responses of a user and their articles after a
+// state change (freeze/unfreeze/ban/archive), so restricted content stops
+// being served from the response cache for up to CACHE_TTL.PUBLIC_QUERY
+export const invalidateUserContentCaches = async (
+  userId: string,
+  {
+    articleService,
+    redis,
+  }: {
+    articleService: ArticleService
+    redis: Redis
+  }
+) => {
+  await invalidateFQC({ node: { type: NODE_TYPES.User, id: userId }, redis })
+  for (const article of await articleService.findByAuthor(userId)) {
+    await invalidateFQC({
+      node: { type: NODE_TYPES.Article, id: article.id },
+      redis,
+    })
+  }
+}


### PR DESCRIPTION
## Problem

`updateUserState` invalidates the FQC (response cache) entries of the user and all their articles on state changes (added in #4899), but the **spam-ring freeze/unfreeze path** (`freezeSpamRing` / `unfreezeSpamRing` → `spamRingService` → `userService.freezeUser`) never does.

Result: after a ring freeze, members' `writings` / article responses keep being served from the Redis response cache for up to `CACHE_TTL.PUBLIC_QUERY` (**1 day**). Verified against production: a frozen spam account's user page still carried its full article list in a cached public-query response while a fresh direct query correctly returned 0.

This also matters for matters-web#6007: the web is switching the restricted-surface queries from `no-cache` back to `network-only` to restore SSR, which relies on cached responses being purged on freeze.

## Fix

- Extract `updateUserState`'s local invalidation helper into `mutations/user/utils.ts` (`invalidateUserContentCaches`)
- Call it for every frozen member after `freezeRing` commits, and every restored member after `unfreezeRing` commits

## Tests

- `spamRingResolvers.test`: two new cases assert the purge runs per frozen/restored member; mocks extended with `connections.redis` + `articleService` (14/14 pass)
- `types/1/article` (covers `updateUserState`) 16/16, `types/2/user` 49/49 pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)