### PR TITLE
release: restricted-user search filter + spam-ring cache purge

### DIFF
--- a/src/common/utils/__test__/spamRingResolvers.test.ts
+++ b/src/common/utils/__test__/spamRingResolvers.test.ts
@@ -36,9 +36,19 @@ const makeContext = (viewer: any = { id: '9' }) => {
     viewer,
     dataSources: {
       userService,
+      articleService: { findByAuthor: jest.fn(async () => []) },
+      connections: { redis: { __sentinel: 'redis' } },
       spamRingService: {
-        freezeRing: jest.fn(async () => ({ ring: {}, frozen: [], skipped: [] })),
-        unfreezeRing: jest.fn(async () => ({ ring: {}, unbanned: [], skipped: [] })),
+        freezeRing: jest.fn(async () => ({
+          ring: {},
+          frozen: [],
+          skipped: [],
+        })),
+        unfreezeRing: jest.fn(async () => ({
+          ring: {},
+          unbanned: [],
+          skipped: [],
+        })),
         dismissRing: jest.fn(async () => ({ id: '1' })),
         upsertCandidates: jest.fn(async () => ({
           created: 1,
@@ -99,6 +109,43 @@ describe('spam ring mutation resolvers', () => {
     })
   })
 
+  test('freezeSpamRing purges caches of frozen members', async () => {
+    const ctx = makeContext()
+    ctx.dataSources.spamRingService.freezeRing = jest.fn(async () => ({
+      ring: {},
+      frozen: [{ id: '11' }, { id: '12' }],
+      skipped: [],
+    }))
+    await (freezeSpamRing as any)(
+      null,
+      { input: { id: ringGlobalId('1') } },
+      ctx
+    )
+    expect(ctx.dataSources.articleService.findByAuthor).toHaveBeenCalledWith(
+      '11'
+    )
+    expect(ctx.dataSources.articleService.findByAuthor).toHaveBeenCalledWith(
+      '12'
+    )
+  })
+
+  test('unfreezeSpamRing purges caches of restored members', async () => {
+    const ctx = makeContext()
+    ctx.dataSources.spamRingService.unfreezeRing = jest.fn(async () => ({
+      ring: {},
+      unbanned: [{ id: '21' }],
+      skipped: [],
+    }))
+    await (unfreezeSpamRing as any)(
+      null,
+      { input: { id: ringGlobalId('2') } },
+      ctx
+    )
+    expect(ctx.dataSources.articleService.findByAuthor).toHaveBeenCalledWith(
+      '21'
+    )
+  })
+
   test('freezeSpamRing rejects when viewer has no id', async () => {
     await expect(
       (freezeSpamRing as any)(
@@ -155,9 +202,8 @@ describe('spam ring mutation resolvers', () => {
       },
       ctx
     )
-    const arg = (
-      ctx.dataSources.spamRingService.upsertCandidates as any
-    ).mock.calls[0][0]
+    const arg = (ctx.dataSources.spamRingService.upsertCandidates as any).mock
+      .calls[0][0]
     expect(arg[0].fingerprint).toBe('fp1')
     expect(arg[0].memberUserIds).toEqual(['u1', 'u2'])
     expect(arg[0].memberUserNames).toBeUndefined()
@@ -279,10 +325,9 @@ describe('SpamRing type resolvers', () => {
       { input: { first: 1 } },
       ctx
     )
-    expect(ctx.dataSources.spamRingService.findMembersAndCount).toHaveBeenCalledWith(
-      'r1',
-      { take: 1, skip: 0 }
-    )
+    expect(
+      ctx.dataSources.spamRingService.findMembersAndCount
+    ).toHaveBeenCalledWith('r1', { take: 1, skip: 0 })
     expect(memberConnection.totalCount).toBe(2)
     expect(memberConnection.edges.map((edge: any) => edge.node.id)).toEqual([
       'm1',
@@ -328,7 +373,9 @@ describe('SpamRing type resolvers', () => {
     await expect(
       (SpamRingEvent.actor as any)({ actorId: 'u9' }, null, ctx)
     ).resolves.toBe(actor)
-    expect((SpamRingEvent.actor as any)({ actorId: null }, null, ctx)).toBeNull()
+    expect(
+      (SpamRingEvent.actor as any)({ actorId: null }, null, ctx)
+    ).toBeNull()
     expect((SpamRingEvent.detail as any)({ detail: { reason: 'fp' } })).toBe(
       JSON.stringify({ reason: 'fp' })
     )

--- a/src/connectors/__test__/searchService/article.test.ts
+++ b/src/connectors/__test__/searchService/article.test.ts
@@ -1,7 +1,8 @@
 import type { Connections } from '#definitions/index.js'
 
-import { FEATURE_NAME, FEATURE_FLAG } from '#common/enums/index.js'
+import { FEATURE_NAME, FEATURE_FLAG, USER_STATE } from '#common/enums/index.js'
 import { PublicationService } from '../../article/publicationService.js'
+import { UserService } from '../../userService.js'
 import { AtomService } from '../../atomService.js'
 import { SearchService } from '../../searchService.js'
 import { SystemService } from '../../systemService.js'
@@ -183,5 +184,49 @@ describe('quicksearch', () => {
       where: { id: article.id },
       data: { spamScore: spamThreshold + 0.1 },
     })
+  })
+})
+
+describe('restricted authors', () => {
+  test('exclude articles whose authors were restricted after the index sync', async () => {
+    const userService = new UserService(connections)
+    const author = await userService.create({ userName: 'stalefrozenauthor' })
+    const [article] = await publicationService.createArticle({
+      title: 'stalesearchable title',
+      content: 'stalesearchable body',
+      authorId: author.id,
+    })
+    // index while the author is still active
+    await searchService.indexArticles([article.id])
+
+    const before = await searchService.searchArticles({
+      key: 'stalesearchable',
+      take: 10,
+      skip: 0,
+    })
+    expect(before.nodes.map(({ id }) => id)).toContain(article.id)
+
+    await connections
+      .knex('user')
+      .where({ id: author.id })
+      .update({ state: USER_STATE.frozen })
+
+    // fresh service to avoid the test-only dataloader cache
+    const freshSearchService = new SearchService(connections)
+    const after = await freshSearchService.searchArticles({
+      key: 'stalesearchable',
+      take: 10,
+      skip: 0,
+    })
+    expect(after.nodes.map(({ id }) => id)).not.toContain(article.id)
+
+    // quicksearch reads the live database and excludes as well
+    const quick = await freshSearchService.searchArticles({
+      key: 'stalesearchable',
+      take: 10,
+      skip: 0,
+      quicksearch: true,
+    })
+    expect(quick.nodes.map(({ id }) => id)).not.toContain(article.id)
   })
 })

--- a/src/connectors/__test__/searchService/user.test.ts
+++ b/src/connectors/__test__/searchService/user.test.ts
@@ -1,7 +1,8 @@
 import type { Connections } from '#definitions/index.js'
 
-import { USER_ACTION } from '#common/enums/index.js'
+import { USER_ACTION, USER_STATE } from '#common/enums/index.js'
 import { SearchService } from '../../searchService.js'
+import { UserService } from '../../userService.js'
 
 import { genConnections, closeConnections } from '../utils.js'
 
@@ -120,5 +121,44 @@ describe('search', () => {
     })
     expect(res3.nodes.length).toBe(5)
     expect(res3.totalCount).toBe(6)
+  })
+})
+
+describe('restricted users', () => {
+  test('exclude users restricted after the index sync', async () => {
+    const userService = new UserService(connections)
+    const user = await userService.create({ userName: 'stalefrozenuser' })
+    // simulate a stale search index snapshot: still `active` there
+    await connections.knexSearch('search_index.user').insert({
+      id: user.id,
+      userName: user.userName,
+      displayName: 'stalefrozenuser',
+      displayNameOrig: 'stalefrozenuser',
+      description: '',
+      state: USER_STATE.active,
+      createdAt: new Date(),
+    })
+
+    const before = await searchService.searchUsers({
+      key: 'stalefrozenuser',
+      take: 3,
+      skip: 0,
+    })
+    expect(before.totalCount).toBe(1)
+
+    await connections
+      .knex('user')
+      .where({ id: user.id })
+      .update({ state: USER_STATE.frozen })
+
+    // fresh service to avoid the test-only dataloader cache
+    const freshSearchService = new SearchService(connections)
+    const after = await freshSearchService.searchUsers({
+      key: 'stalefrozenuser',
+      take: 3,
+      skip: 0,
+    })
+    expect(after.nodes.length).toBe(0)
+    expect(after.totalCount).toBe(0)
   })
 })

--- a/src/connectors/searchService.ts
+++ b/src/connectors/searchService.ts
@@ -24,6 +24,20 @@ const logger = getLogger('service-search')
 const SEARCH_TITLE_RANK_THRESHOLD = 0.001
 const SEARCH_DEFAULT_TEXT_RANK_THRESHOLD = 0.0001
 
+// user states excluded from search results; the search index snapshots
+// `state`/`author_state` and can lag behind freshly restricted accounts,
+// so results are also re-checked against the live user rows
+const SEARCH_EXCLUDED_USER_STATES = [
+  USER_STATE.archived,
+  USER_STATE.banned,
+  USER_STATE.frozen,
+] as const
+
+const isSearchExcludedUserState = (state?: string) =>
+  SEARCH_EXCLUDED_USER_STATES.includes(
+    state as (typeof SEARCH_EXCLUDED_USER_STATES)[number]
+  )
+
 export class SearchService {
   private connections: Connections
   private models: AtomService
@@ -148,12 +162,11 @@ export class SearchService {
               )
               .whereNotIn('id', articleIds)
               .whereIn('state', [ARTICLE_STATE.active])
-              .andWhere('author_state', 'NOT IN', [
-                // USER_STATE.active
-                USER_STATE.archived,
-                USER_STATE.banned,
-                USER_STATE.frozen,
-              ])
+              .andWhere(
+                'author_state',
+                'NOT IN',
+                SEARCH_EXCLUDED_USER_STATES as unknown as string[]
+              )
               .andWhere('author_id', 'NOT IN', blockedIds)
               .andWhereRaw(
                 `(query @@ title_jieba_ts OR query @@ summary_jieba_ts OR query @@ text_jieba_ts)`
@@ -187,11 +200,34 @@ export class SearchService {
         }
       })
 
-    const nodes = await this.models.articleIdLoader.loadMany(
-      records.map((item: { id: string }) => item.id).filter(Boolean)
+    const loaded = (
+      await this.models.articleIdLoader.loadMany(
+        records.map((item: { id: string }) => item.id).filter(Boolean)
+      )
+    ).filter((node): node is Article => !(node instanceof Error))
+
+    // drop articles whose authors were restricted after the last index sync
+    const authors = await this.models.userIdLoader.loadMany(
+      loaded.map(({ authorId }) => authorId)
+    )
+    const restrictedAuthorIds = new Set(
+      authors
+        .filter(
+          (author) =>
+            !(author instanceof Error) &&
+            isSearchExcludedUserState(author.state)
+        )
+        .map((author) => (author as { id: string }).id)
+    )
+    const nodes = loaded.filter(
+      ({ authorId }) => !restrictedAuthorIds.has(authorId)
     )
 
-    const totalCount = records.length === 0 ? 0 : +records[0].totalCount
+    const snapshotTotalCount = records.length === 0 ? 0 : +records[0].totalCount
+    const totalCount = Math.max(
+      0,
+      snapshotTotalCount - (loaded.length - nodes.length)
+    )
 
     logger.debug(
       `articleService::searchV2 knexSearch instance got ${nodes.length} nodes from: ${totalCount} total:`,
@@ -240,6 +276,12 @@ export class SearchService {
           .from('article_version_newest')
       )
       .where({ state: ARTICLE_STATE.active })
+      .whereNotIn(
+        'authorId',
+        this.knexRO('user')
+          .select('id')
+          .whereIn('state', SEARCH_EXCLUDED_USER_STATES as unknown as string[])
+      )
       // .modify(excludeSpam, spamThreshold)
       .orderBy('id', 'desc')
       .modify((builder: Knex.QueryBuilder) => {
@@ -458,12 +500,11 @@ export class SearchService {
       .crossJoin(
         this.knexSearch.raw(`plainto_tsquery('jiebacfg', ?) query`, key)
       )
-      .where('state', 'NOT IN', [
-        // USER_STATE.active,
-        USER_STATE.archived,
-        USER_STATE.banned,
-        USER_STATE.frozen,
-      ])
+      .where(
+        'state',
+        'NOT IN',
+        SEARCH_EXCLUDED_USER_STATES as unknown as string[]
+      )
       .andWhere('id', 'NOT IN', blockedIds)
       .andWhere((builder: Knex.QueryBuilder) => {
         builder
@@ -522,11 +563,19 @@ export class SearchService {
       { sample: records?.slice(0, 3) }
     )
 
-    const nodes = await this.models.userIdLoader.loadMany(
+    const loaded = await this.models.userIdLoader.loadMany(
       records.map(({ id }) => id)
     )
+    // drop accounts restricted after the last search index sync
+    const nodes = loaded.filter(
+      (node) =>
+        !(node instanceof Error) && !isSearchExcludedUserState(node.state)
+    )
 
-    return { nodes, totalCount }
+    return {
+      nodes,
+      totalCount: Math.max(0, totalCount - (loaded.length - nodes.length)),
+    }
   }
 
   public findFrequentSearches = async ({

--- a/src/mutations/user/freezeSpamRing.ts
+++ b/src/mutations/user/freezeSpamRing.ts
@@ -3,21 +3,39 @@ import type { GQLMutationResolvers } from '#definitions/index.js'
 import { ForbiddenError } from '#common/errors.js'
 import { fromGlobalId } from '#common/utils/index.js'
 
+import { invalidateUserContentCaches } from './utils.js'
+
 const resolver: GQLMutationResolvers['freezeSpamRing'] = async (
   _,
   { input: { id, remark } },
-  { viewer, dataSources: { spamRingService, userService } }
+  {
+    viewer,
+    dataSources: {
+      spamRingService,
+      userService,
+      articleService,
+      connections: { redis },
+    },
+  }
 ) => {
   if (!viewer.id) {
     throw new ForbiddenError('viewer has no id')
   }
   const { id: ringId } = fromGlobalId(id)
-  return spamRingService.freezeRing({
+  const result = await spamRingService.freezeRing({
     ringId,
     actorId: viewer.id,
     remark,
     userService,
   })
+
+  // after the freeze transaction commits, purge cached public query
+  // responses so frozen members' content stops being served
+  for (const user of result.frozen) {
+    await invalidateUserContentCaches(user.id, { articleService, redis })
+  }
+
+  return result
 }
 
 export default resolver

--- a/src/mutations/user/unfreezeSpamRing.ts
+++ b/src/mutations/user/unfreezeSpamRing.ts
@@ -3,20 +3,38 @@ import type { GQLMutationResolvers } from '#definitions/index.js'
 import { ForbiddenError } from '#common/errors.js'
 import { fromGlobalId } from '#common/utils/index.js'
 
+import { invalidateUserContentCaches } from './utils.js'
+
 const resolver: GQLMutationResolvers['unfreezeSpamRing'] = async (
   _,
   { input: { id } },
-  { viewer, dataSources: { spamRingService, userService } }
+  {
+    viewer,
+    dataSources: {
+      spamRingService,
+      userService,
+      articleService,
+      connections: { redis },
+    },
+  }
 ) => {
   if (!viewer.id) {
     throw new ForbiddenError('viewer has no id')
   }
   const { id: ringId } = fromGlobalId(id)
-  return spamRingService.unfreezeRing({
+  const result = await spamRingService.unfreezeRing({
     ringId,
     actorId: viewer.id,
     userService,
   })
+
+  // after the unfreeze transaction commits, purge cached public query
+  // responses so restored members' content shows up again promptly
+  for (const user of result.unbanned) {
+    await invalidateUserContentCaches(user.id, { articleService, redis })
+  }
+
+  return result
 }
 
 export default resolver

--- a/src/mutations/user/updateUserState.ts
+++ b/src/mutations/user/updateUserState.ts
@@ -1,9 +1,10 @@
 import type { GQLMutationResolvers, User } from '#definitions/index.js'
 
-import { NODE_TYPES, USER_STATE } from '#common/enums/index.js'
+import { USER_STATE } from '#common/enums/index.js'
 import { ActionFailedError, UserInputError } from '#common/errors.js'
 import { fromGlobalId } from '#common/utils/index.js'
-import { invalidateFQC } from '@matters/apollo-response-cache'
+
+import { invalidateUserContentCaches } from './utils.js'
 
 const resolver: GQLMutationResolvers['updateUserState'] = async (
   _,
@@ -22,15 +23,8 @@ const resolver: GQLMutationResolvers['updateUserState'] = async (
 ) => {
   const id = globalId ? fromGlobalId(globalId).id : undefined
 
-  const invalidateUserCaches = async (userId: string) => {
-    await invalidateFQC({ node: { type: NODE_TYPES.User, id: userId }, redis })
-    for (const article of await articleService.findByAuthor(userId)) {
-      await invalidateFQC({
-        node: { type: NODE_TYPES.Article, id: article.id },
-        redis,
-      })
-    }
-  }
+  const invalidateUserCaches = (userId: string) =>
+    invalidateUserContentCaches(userId, { articleService, redis })
 
   /**
    * archive

--- a/src/mutations/user/utils.ts
+++ b/src/mutations/user/utils.ts
@@ -1,0 +1,27 @@
+import type { ArticleService } from '#connectors/index.js'
+import type { Redis } from 'ioredis'
+
+import { NODE_TYPES } from '#common/enums/index.js'
+import { invalidateFQC } from '@matters/apollo-response-cache'
+
+// purge cached public query responses of a user and their articles after a
+// state change (freeze/unfreeze/ban/archive), so restricted content stops
+// being served from the response cache for up to CACHE_TTL.PUBLIC_QUERY
+export const invalidateUserContentCaches = async (
+  userId: string,
+  {
+    articleService,
+    redis,
+  }: {
+    articleService: ArticleService
+    redis: Redis
+  }
+) => {
+  await invalidateFQC({ node: { type: NODE_TYPES.User, id: userId }, redis })
+  for (const article of await articleService.findByAuthor(userId)) {
+    await invalidateFQC({
+      node: { type: NODE_TYPES.Article, id: article.id },
+      redis,
+    })
+  }
+}

--- a/src/queries/user/description.ts
+++ b/src/queries/user/description.ts
@@ -1,0 +1,29 @@
+import type { GQLUserInfoResolvers } from '#definitions/index.js'
+
+import { USER_STATE } from '#common/enums/index.js'
+
+// profile bios of restricted accounts should not be readable publicly,
+// mirroring the inactive states handled by the web client
+const RESTRICTED_USER_STATES = [
+  USER_STATE.archived,
+  USER_STATE.banned,
+  USER_STATE.frozen,
+] as const
+
+const resolver: GQLUserInfoResolvers['description'] = (
+  { id, state, description },
+  _,
+  { viewer }
+) => {
+  const isRestricted = RESTRICTED_USER_STATES.includes(
+    state as (typeof RESTRICTED_USER_STATES)[number]
+  )
+
+  if (isRestricted && viewer.id !== id && !viewer.hasRole('admin')) {
+    return null
+  }
+
+  return description
+}
+
+export default resolver

--- a/src/queries/user/index.ts
+++ b/src/queries/user/index.ts
@@ -40,6 +40,7 @@ import Collection from './collection/index.js'
 import collections from './collections.js'
 import commentCount from './commentCount.js'
 import cryptoWallet from './cryptoWallet.js'
+import description from './description.js'
 import donatedArticleCount from './donatedArticleCount.js'
 import featuredTags from './featuredTags.js'
 import features from './features.js'
@@ -160,6 +161,7 @@ const user: {
   UserInfo: {
     ipnsKey,
     badges,
+    description,
     userNameEditable,
     email: ({ email }) => email && email.replace(/#/g, '@'),
     emailVerified: ({ emailVerified }) => emailVerified || false,

--- a/src/types/__test__/2/user/user.test.ts
+++ b/src/types/__test__/2/user/user.test.ts
@@ -1406,3 +1406,41 @@ describe('query user writings', () => {
     expect(dataAfter.viewer.writings.pageInfo.hasNextPage).toBeFalsy()
   })
 })
+
+describe('restricted user description', () => {
+  const GET_USER_DESCRIPTION = /* GraphQL */ `
+    query ($input: UserInput!) {
+      user(input: $input) {
+        info {
+          description
+        }
+      }
+    }
+  `
+  test('hide description of restricted users from visitors', async () => {
+    const user = await userService.create({ userName: 'frozendescuser' })
+    await connections
+      .knex('user')
+      .where({ id: user.id })
+      .update({ description: 'spam self intro', state: USER_STATE.frozen })
+
+    const visitorServer = await testClient({ connections })
+    const { data } = await visitorServer.executeOperation({
+      query: GET_USER_DESCRIPTION,
+      variables: { input: { userName: 'frozendescuser' } },
+    })
+    expect(data.user.info.description).toBeNull()
+
+    // admin still sees it
+    const adminServer = await testClient({
+      isAuth: true,
+      isAdmin: true,
+      connections,
+    })
+    const { data: adminData } = await adminServer.executeOperation({
+      query: GET_USER_DESCRIPTION,
+      variables: { input: { userName: 'frozendescuser' } },
+    })
+    expect(adminData.user.info.description).toBe('spam self intro')
+  })
+})


### PR DESCRIPTION
## Release content (develop → master, whole branch)

Two changes ride this promote, both merged to develop last night — together they close out the frozen-account public-surface series:

1. **#4908** `fix(search)`: exclude freshly restricted users from search and hide their bios. Search results are re-checked against live user rows (the `search_index` snapshot lags behind freezes), `quicksearchArticles` gains the missing author-state filter, and `UserInfo.description` returns `null` for archived/banned/frozen users unless the viewer is an admin or the user themself.
2. **#4910** `fix(spam-ring)`: purge FQC response caches when freezing/unfreezing rings — same invalidation `updateUserState` already does (#4899), now shared and applied to ring members. Removes the up-to-1-day stale window for ring-frozen accounts.

## Notes

- No migrations, no schema change (`description` field already existed; only its resolver behavior changes).
- Staging (develop) deploy after both merges completed successfully (2026-07-03 23:36Z run).
- matters-web#6007 (already on production) relies on #4910 for its freshness guarantee — this promote closes that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)