### PR TITLE
feat(discovery): dark-launch discovery probation for new accounts

### DIFF
--- a/db/migrations/20260704000000_add_discovery_probation_feature_flag.js
+++ b/db/migrations/20260704000000_add_discovery_probation_feature_flag.js
@@ -1,0 +1,17 @@
+const table = 'feature_flag'
+const name = 'discovery_probation'
+
+// Dark launch: flag defaults to `off`, so discovery feeds behave exactly as
+// before. The row must exist for admins to toggle it via `setFeature`
+// (kill-switch). Probation window defaults to env
+// MATTERS_DISCOVERY_PROBATION_DAYS (3); `value` overrides it when set.
+export const up = async (knex) => {
+  await knex(table)
+    .insert({ name, flag: 'off', value: null })
+    .onConflict('name')
+    .ignore()
+}
+
+export const down = async (knex) => {
+  await knex(table).where({ name }).del()
+}

--- a/db/seeds/31_feature_flag.js
+++ b/db/seeds/31_feature_flag.js
@@ -50,5 +50,9 @@ export const seed = async (knex) => {
       name: 'hottest_moment_feed',
       flag: 'off',
     },
+    {
+      name: 'discovery_probation',
+      flag: 'off',
+    },
   ])
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -3015,6 +3015,7 @@ enum FeatureName {
   topic_channel_spam_filter
   article_channel
   hottest_moment_feed
+  discovery_probation
 }
 
 enum FeatureFlag {

--- a/src/common/enums/cache.ts
+++ b/src/common/enums/cache.ts
@@ -35,6 +35,7 @@ export const CACHE_PREFIX = {
   TAG_COVERS: 'cache-tag-covers',
   SPAM_THRESHOLD: 'cache-spam-threshold',
   TOPIC_CHANNEL_SPAM_THRESHOLD: 'cache-topic-channel-spam-threshold',
+  DISCOVERY_PROBATION_DAYS: 'cache-discovery-probation-days',
   ARTICLE_CHANNEL_THRESHOLD: 'cache-article-channel-threshold',
   RECOMMENDATION_TAGS: 'cache-recommendation-tags',
   RECOMMENDATION_AUTHORS: 'cache-recommendation-authors',

--- a/src/common/enums/feature.ts
+++ b/src/common/enums/feature.ts
@@ -11,6 +11,7 @@ export const FEATURE_NAME = {
   topic_channel_spam_filter: 'topic_channel_spam_filter',
   article_channel: 'article_channel',
   hottest_moment_feed: 'hottest_moment_feed',
+  discovery_probation: 'discovery_probation',
 } as const
 
 export const FEATURE_FLAG = {

--- a/src/common/environment.ts
+++ b/src/common/environment.ts
@@ -52,12 +52,10 @@ export const environment = {
   awsMailQueueUrl: process.env.MATTERS_AWS_MAIL_QUEUE_URL || '',
   awsExpressMailQueueUrl: process.env.MATTERS_AWS_EXPRESS_MAIL_QUEUE_URL || '',
   awsArchiveUserQueueUrl: process.env.MATTERS_AWS_ARCHIVE_USER_QUEUE_URL || '',
-  awsReportAlertQueueUrl:
-    process.env.MATTERS_AWS_REPORT_ALERT_QUEUE_URL || '',
+  awsReportAlertQueueUrl: process.env.MATTERS_AWS_REPORT_ALERT_QUEUE_URL || '',
   // Spam training-sample capture (axis-2 L2): de-identified moderation events
   // for the spam-model training corpus. Best-effort; off when unset.
-  awsSpamSampleQueueUrl:
-    process.env.MATTERS_AWS_SPAM_SAMPLE_QUEUE_URL || '',
+  awsSpamSampleQueueUrl: process.env.MATTERS_AWS_SPAM_SAMPLE_QUEUE_URL || '',
   spamSampleHashSalt: process.env.MATTERS_SPAM_SAMPLE_HASH_SALT || '',
   awsLikecoinLikeUrl: process.env.MATTERS_AWS_LIKECOIN_LIKE_QUEUE_URL || '',
   awsLikecoinSendPVUrl:
@@ -212,6 +210,13 @@ export const environment = {
   // Telegram chat for moderation. Notify-only: this flag NEVER hides a comment
   // (auto-action stays behind commentSpamAutoCollapse). Default off.
   commentSpamAlert: process.env.MATTERS_COMMENT_SPAM_ALERT === 'true',
+  // Default probation window (days) keeping brand-new accounts out of
+  // discovery surfaces; effective only while the `discovery_probation`
+  // feature flag is on. `feature_flag.value` overrides this default.
+  discoveryProbationDays: parseInt(
+    process.env.MATTERS_DISCOVERY_PROBATION_DAYS || '3',
+    10
+  ),
   channelClassificationApiUrl:
     process.env.MATTERS_CHANNEL_CLASSIFICATION_API_URL || '',
   languageDetectionApiUrl: process.env.MATTERS_LANGUAGE_DETECTION_API_URL || '',

--- a/src/common/utils/knex.ts
+++ b/src/common/utils/knex.ts
@@ -105,7 +105,8 @@ export const excludeProbationAuthors = (
       .select(1)
       .from('user')
       .where('user.id', qb.client.ref(`${table}.author_id`))
-      .whereRaw(`user.created_at >= now() - interval '1 day' * ?`, [days])
+      // "user" must be quoted in raw SQL — unquoted it parses as the USER keyword
+      .whereRaw(`"user".created_at >= now() - interval '1 day' * ?`, [days])
   )
 }
 

--- a/src/common/utils/knex.ts
+++ b/src/common/utils/knex.ts
@@ -88,6 +88,27 @@ export const excludeStateRestrictedAuthors = (
   )
 }
 
+/**
+ * Exclude articles whose author account is younger than `days` days
+ * (discovery probation). Applied only to discovery surfaces (hottest /
+ * newest / icymi / tag / channel feeds); direct links, profile pages,
+ * followee feeds and search are intentionally untouched so anonymous
+ * whistleblower accounts can still be reached and followed.
+ */
+export const excludeProbationAuthors = (
+  builder: Knex.QueryBuilder,
+  days: number,
+  table = 'article'
+) => {
+  builder.whereNotExists((qb) =>
+    qb
+      .select(1)
+      .from('user')
+      .where('user.id', qb.client.ref(`${table}.author_id`))
+      .whereRaw(`user.created_at >= now() - interval '1 day' * ?`, [days])
+  )
+}
+
 export const excludeExclusiveCampaignArticles = (
   builder: Knex.QueryBuilder,
   table = 'article'

--- a/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
+++ b/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
@@ -36,6 +36,10 @@ beforeEach(async () => {
     name: FEATURE_NAME.spam_detection,
     flag: FEATURE_FLAG.off,
   })
+  await systemService.setFeatureFlag({
+    name: FEATURE_NAME.discovery_probation,
+    flag: FEATURE_FLAG.off,
+  })
   await atomService.deleteMany({ table: 'topic_channel_article' })
   await atomService.deleteMany({ table: 'topic_channel' })
 
@@ -417,6 +421,79 @@ describe('findTopicChannelArticles', () => {
       expect(results.map((a) => a.id)).toContain(articles[0].id)
 
       await atomService.deleteMany({ table: 'user_restriction' })
+    })
+  })
+
+  describe('discovery probation', () => {
+    // articles[1]'s author does not own any other article in the channel
+    // (articles[0] and articles[3] share an author), so it is a clean target
+    const originalCreatedAt: Record<string, Date> = {}
+
+    beforeEach(async () => {
+      // age all channel article authors out of the probation window first
+      // (seed users are created at test run time, i.e. "new" accounts)
+      const authorIds = [
+        ...new Set(articles.slice(0, 4).map(({ authorId }) => authorId)),
+      ]
+      for (const authorId of authorIds) {
+        const author = await atomService.findUnique({
+          table: 'user',
+          where: { id: authorId },
+        })
+        originalCreatedAt[authorId] = author.createdAt
+        await atomService.update({
+          table: 'user',
+          where: { id: authorId },
+          data: { createdAt: new Date(Date.now() - 30 * 24 * 3600 * 1000) },
+        })
+      }
+      // make the target author a brand-new account (inside probation window)
+      await atomService.update({
+        table: 'user',
+        where: { id: articles[1].authorId },
+        data: { createdAt: new Date() },
+      })
+    })
+
+    afterEach(async () => {
+      // restore created_at to avoid leaking into other tests
+      for (const [authorId, createdAt] of Object.entries(originalCreatedAt)) {
+        await atomService.update({
+          table: 'user',
+          where: { id: authorId },
+          data: { createdAt },
+        })
+      }
+    })
+
+    test('flag off: results identical to before (zero diff)', async () => {
+      // flag is off via beforeEach; new-account article still shows up
+      const { query } = await channelService.findTopicChannelArticles(
+        channel.id
+      )
+      const results = await query
+
+      expect(results).toHaveLength(4)
+      expect(results.map((a) => a.id)).toContain(articles[1].id)
+    })
+
+    test('flag on: excludes articles from new accounts only', async () => {
+      await systemService.setFeatureFlag({
+        name: FEATURE_NAME.discovery_probation,
+        flag: FEATURE_FLAG.on,
+      })
+
+      const { query } = await channelService.findTopicChannelArticles(
+        channel.id
+      )
+      const results = await query
+
+      const ids = results.map((a) => a.id)
+      expect(ids).not.toContain(articles[1].id)
+      // articles by older accounts are not affected
+      expect(ids).toContain(articles[0].id)
+      expect(ids).toContain(articles[2].id)
+      expect(ids).toContain(articles[3].id)
     })
   })
 

--- a/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
+++ b/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
@@ -425,15 +425,29 @@ describe('findTopicChannelArticles', () => {
   })
 
   describe('discovery probation', () => {
-    // articles[1]'s author does not own any other article in the channel
-    // (articles[0] and articles[3] share an author), so it is a clean target
     const originalCreatedAt: Record<string, Date> = {}
+    let target: Article
+    let others: Article[]
 
     beforeEach(async () => {
+      // `articles` comes from an unordered findMany, so index→author mapping
+      // is not guaranteed — pick a target whose author owns exactly one of
+      // the four channel articles, so newing that author affects one article
+      const channelArticles = articles.slice(0, 4)
+      const authorCount: Record<string, number> = {}
+      for (const { authorId } of channelArticles) {
+        authorCount[authorId] = (authorCount[authorId] ?? 0) + 1
+      }
+      target = channelArticles.find(
+        ({ authorId }) => authorCount[authorId] === 1
+      ) as Article
+      expect(target).toBeDefined()
+      others = channelArticles.filter(({ id }) => id !== target.id)
+
       // age all channel article authors out of the probation window first
       // (seed users are created at test run time, i.e. "new" accounts)
       const authorIds = [
-        ...new Set(articles.slice(0, 4).map(({ authorId }) => authorId)),
+        ...new Set(channelArticles.map(({ authorId }) => authorId)),
       ]
       for (const authorId of authorIds) {
         const author = await atomService.findUnique({
@@ -450,13 +464,18 @@ describe('findTopicChannelArticles', () => {
       // make the target author a brand-new account (inside probation window)
       await atomService.update({
         table: 'user',
-        where: { id: articles[1].authorId },
+        where: { id: target.authorId },
         data: { createdAt: new Date() },
       })
     })
 
     afterEach(async () => {
-      // restore created_at to avoid leaking into other tests
+      // restore created_at and the flag, even when an assertion threw —
+      // a leaked flag would poison every later test in this file
+      await systemService.setFeatureFlag({
+        name: FEATURE_NAME.discovery_probation,
+        flag: FEATURE_FLAG.off,
+      })
       for (const [authorId, createdAt] of Object.entries(originalCreatedAt)) {
         await atomService.update({
           table: 'user',
@@ -474,7 +493,7 @@ describe('findTopicChannelArticles', () => {
       const results = await query
 
       expect(results).toHaveLength(4)
-      expect(results.map((a) => a.id)).toContain(articles[1].id)
+      expect(results.map((a) => a.id)).toContain(target.id)
     })
 
     test('flag on: excludes articles from new accounts only', async () => {
@@ -489,11 +508,11 @@ describe('findTopicChannelArticles', () => {
       const results = await query
 
       const ids = results.map((a) => a.id)
-      expect(ids).not.toContain(articles[1].id)
+      expect(ids).not.toContain(target.id)
       // articles by older accounts are not affected
-      expect(ids).toContain(articles[0].id)
-      expect(ids).toContain(articles[2].id)
-      expect(ids).toContain(articles[3].id)
+      for (const other of others) {
+        expect(ids).toContain(other.id)
+      }
     })
   })
 

--- a/src/connectors/__test__/recommendationService/findHottestArticles.test.ts
+++ b/src/connectors/__test__/recommendationService/findHottestArticles.test.ts
@@ -276,20 +276,23 @@ describe('findHottestArticles', () => {
       name: FEATURE_NAME.discovery_probation,
       flag: FEATURE_FLAG.on,
     })
-    const after = await recommendationService.findHottestArticles({
-      days: 5,
-      readersThreshold: 0,
-      commentsThreshold: 0,
-    })
-    const afterIds = after.map((r: any) => r.articleId)
-    expect(afterIds).not.toContain(article1.id)
-    expect(afterIds).toContain(article2.id)
-
-    // kill-switch: turning the flag off restores the previous behavior
-    await systemService.setFeatureFlag({
-      name: FEATURE_NAME.discovery_probation,
-      flag: FEATURE_FLAG.off,
-    })
+    try {
+      const after = await recommendationService.findHottestArticles({
+        days: 5,
+        readersThreshold: 0,
+        commentsThreshold: 0,
+      })
+      const afterIds = after.map((r: any) => r.articleId)
+      expect(afterIds).not.toContain(article1.id)
+      expect(afterIds).toContain(article2.id)
+    } finally {
+      // kill-switch — and cleanup even on failure, so a thrown assertion
+      // cannot leak the flag into the rest of this suite
+      await systemService.setFeatureFlag({
+        name: FEATURE_NAME.discovery_probation,
+        flag: FEATURE_FLAG.off,
+      })
+    }
     const restored = await recommendationService.findHottestArticles({
       days: 5,
       readersThreshold: 0,

--- a/src/connectors/__test__/recommendationService/findHottestArticles.test.ts
+++ b/src/connectors/__test__/recommendationService/findHottestArticles.test.ts
@@ -9,6 +9,8 @@ import {
   TRANSACTION_STATE,
   PAYMENT_CURRENCY,
   DAY,
+  FEATURE_NAME,
+  FEATURE_FLAG,
 } from '#common/enums/index.js'
 import {
   RecommendationService,
@@ -243,6 +245,57 @@ describe('findHottestArticles', () => {
     const articleIds = results.map((r: any) => r.articleId)
     expect(articleIds).toContain(article1.id)
     expect(articleIds).not.toContain(restrictedAuthorArticle.id)
+  })
+
+  test('discovery probation: flag off keeps new accounts, flag on excludes them', async () => {
+    await createArticleReadCount(author1.id, article1.id, 10)
+    await createArticleReadCount(author1.id, article2.id, 10)
+    await createComment(author3.id, article1.id)
+    await createComment(author3.id, article2.id)
+
+    // age author2 out of the probation window; author1 stays brand-new
+    // (users in this suite are created at test run time)
+    await atomService.update({
+      table: 'user',
+      where: { id: author2.id },
+      data: { createdAt: new Date(Date.now() - 30 * DAY) },
+    })
+
+    // flag off (seed default): both articles surface, zero diff
+    const before = await recommendationService.findHottestArticles({
+      days: 5,
+      readersThreshold: 0,
+      commentsThreshold: 0,
+    })
+    const beforeIds = before.map((r: any) => r.articleId)
+    expect(beforeIds).toContain(article1.id)
+    expect(beforeIds).toContain(article2.id)
+
+    // flag on: new-account article excluded, aged account unaffected
+    await systemService.setFeatureFlag({
+      name: FEATURE_NAME.discovery_probation,
+      flag: FEATURE_FLAG.on,
+    })
+    const after = await recommendationService.findHottestArticles({
+      days: 5,
+      readersThreshold: 0,
+      commentsThreshold: 0,
+    })
+    const afterIds = after.map((r: any) => r.articleId)
+    expect(afterIds).not.toContain(article1.id)
+    expect(afterIds).toContain(article2.id)
+
+    // kill-switch: turning the flag off restores the previous behavior
+    await systemService.setFeatureFlag({
+      name: FEATURE_NAME.discovery_probation,
+      flag: FEATURE_FLAG.off,
+    })
+    const restored = await recommendationService.findHottestArticles({
+      days: 5,
+      readersThreshold: 0,
+      commentsThreshold: 0,
+    })
+    expect(restored.map((r: any) => r.articleId)).toContain(article1.id)
   })
 
   test('applies minimum reader and comment thresholds', async () => {

--- a/src/connectors/__test__/systemService.test.ts
+++ b/src/connectors/__test__/systemService.test.ts
@@ -380,6 +380,33 @@ test('get topic channel spam threshold', async () => {
   expect(threshold).toBe(0.8)
 })
 
+test('get discovery probation days', async () => {
+  // flag off (seed default): null, discovery feeds stay unchanged
+  expect(await systemService.getDiscoveryProbationDays()).toBeNull()
+
+  // flag on without value: falls back to env default (3)
+  await systemService.setFeatureFlag({
+    name: FEATURE_NAME.discovery_probation,
+    flag: FEATURE_FLAG.on,
+  })
+  expect(await systemService.getDiscoveryProbationDays()).toBe(3)
+
+  // `value` overrides the env default
+  await systemService.setFeatureFlag({
+    name: FEATURE_NAME.discovery_probation,
+    flag: FEATURE_FLAG.on,
+    value: 7,
+  })
+  expect(await systemService.getDiscoveryProbationDays()).toBe(7)
+
+  // kill-switch: setFeature off restores null
+  await systemService.setFeatureFlag({
+    name: FEATURE_NAME.discovery_probation,
+    flag: FEATURE_FLAG.off,
+  })
+  expect(await systemService.getDiscoveryProbationDays()).toBeNull()
+})
+
 describe('announcement', () => {
   beforeEach(async () => {
     await atomService.deleteMany({ table: 'channel_announcement' })

--- a/src/connectors/__test__/tagService.test.ts
+++ b/src/connectors/__test__/tagService.test.ts
@@ -133,6 +133,79 @@ describe('findArticles', () => {
       data: { state: author?.state },
     })
   })
+  test('exclude articles by authors in discovery probation', async () => {
+    const articles = await tagService.findArticles({ id: '2' })
+    expect(articles.length).toBeGreaterThan(1)
+
+    // age all tag authors out of the probation window first
+    // (seed users are created at test run time, i.e. "new" accounts)
+    const authorIds: string[] = [
+      ...new Set<string>(
+        articles.map(({ authorId }: { authorId: string }) => authorId)
+      ),
+    ]
+    const originalCreatedAt: Record<string, Date> = {}
+    for (const authorId of authorIds) {
+      const author = await atomService.findUnique({
+        table: 'user',
+        where: { id: authorId },
+      })
+      originalCreatedAt[authorId] = author.createdAt
+      await atomService.update({
+        table: 'user',
+        where: { id: authorId },
+        data: { createdAt: new Date(Date.now() - 30 * 24 * 3600 * 1000) },
+      })
+    }
+
+    // make the target author a brand-new account (inside probation window)
+    const target = articles[0]
+    await atomService.update({
+      table: 'user',
+      where: { id: target.authorId },
+      data: { createdAt: new Date() },
+    })
+
+    // flag off (no probationDays passed): results identical to before
+    const unchanged = await tagService.findArticles({ id: '2' })
+    expect(toIds(unchanged)).toEqual(toIds(articles))
+
+    // flag on: new-account article is excluded, older accounts unaffected
+    const excluded = await tagService.findArticles({
+      id: '2',
+      probationDays: 3,
+    })
+    expect(toIds(excluded)).not.toContain(target.id)
+    expect(toIds(excluded)).toContain(articles[1].id)
+
+    // hottest tag tab follows the same rule
+    const hottestOff = await tagService.findHottestArticles('2')
+    expect(toIds(hottestOff)).toContain(target.id)
+    const hottestOn = await tagService.findHottestArticles('2', 3)
+    expect(toIds(hottestOn)).not.toContain(target.id)
+    expect(toIds(hottestOn)).toContain(articles[1].id)
+
+    // account older than the window is not affected
+    await atomService.update({
+      table: 'user',
+      where: { id: target.authorId },
+      data: { createdAt: new Date(Date.now() - 30 * 24 * 3600 * 1000) },
+    })
+    const included = await tagService.findArticles({
+      id: '2',
+      probationDays: 3,
+    })
+    expect(toIds(included)).toContain(target.id)
+
+    // restore original created_at to avoid leaking into other tests
+    for (const [authorId, createdAt] of Object.entries(originalCreatedAt)) {
+      await atomService.update({
+        table: 'user',
+        where: { id: authorId },
+        data: { createdAt },
+      })
+    }
+  })
 })
 
 test('create', async () => {

--- a/src/connectors/article/articleService.ts
+++ b/src/connectors/article/articleService.ts
@@ -40,6 +40,7 @@ import {
   excludeSpam as excludeSpamModifier,
   excludeRestrictedAuthors as excludeRestrictedModifier,
   excludeExclusiveCampaignArticles as excludeExclusiveCampaignArticlesModifier,
+  excludeProbationAuthors as excludeProbationModifier,
 } from '#common/utils/index.js'
 import DataLoader from 'dataloader'
 import { simplecc } from 'simplecc-wasm'
@@ -97,6 +98,7 @@ export class ArticleService extends BaseService<Article> {
       excludeExclusiveCampaignArticles,
       excludeChannelArticles,
       excludeComplaintAreaArticles,
+      excludeProbationAuthors,
       datetimeRange,
     }: {
       state?: ValueOf<typeof ARTICLE_STATE>
@@ -109,6 +111,8 @@ export class ArticleService extends BaseService<Article> {
       excludeExclusiveCampaignArticles?: boolean
       excludeChannelArticles?: boolean
       excludeComplaintAreaArticles?: boolean
+      // days; when set, exclude articles by authors younger than this
+      excludeProbationAuthors?: number
       datetimeRange?: { start: Date; end?: Date }
     } = { state: ARTICLE_STATE.active }
   ) => {
@@ -149,6 +153,10 @@ export class ArticleService extends BaseService<Article> {
 
     if (excludeExclusiveCampaignArticles) {
       query.modify(excludeExclusiveCampaignArticlesModifier)
+    }
+
+    if (excludeProbationAuthors) {
+      query.modify(excludeProbationModifier, excludeProbationAuthors)
     }
 
     if (excludeComplaintAreaArticles) {
@@ -192,10 +200,12 @@ export class ArticleService extends BaseService<Article> {
     spamThreshold,
     excludeChannelArticles,
     excludeExclusiveCampaignArticles,
+    probationDays,
   }: {
     spamThreshold?: number
     excludeChannelArticles?: boolean
     excludeExclusiveCampaignArticles?: boolean
+    probationDays?: number
   } = {}): Knex.QueryBuilder<Article, Article[]> => {
     const query = this.findArticles({
       state: ARTICLE_STATE.active,
@@ -208,6 +218,7 @@ export class ArticleService extends BaseService<Article> {
       excludeRestrictedAuthors: USER_RESTRICTION_TYPE.articleNewest,
       excludeChannelArticles,
       excludeExclusiveCampaignArticles,
+      excludeProbationAuthors: probationDays,
     })
     return query.orderBy('id', 'desc')
   }

--- a/src/connectors/channel/channelService.ts
+++ b/src/connectors/channel/channelService.ts
@@ -37,6 +37,7 @@ import {
   excludeSpam as excludeSpamModifier,
   excludeRestrictedAuthors as excludeRestrictedModifier,
   excludeStateRestrictedAuthors as excludeStateRestrictedModifier,
+  excludeProbationAuthors as excludeProbationModifier,
   excludeExclusiveCampaignArticles,
 } from '#common/utils/index.js'
 import { invalidateFQC } from '@matters/apollo-response-cache'
@@ -395,10 +396,13 @@ export class ChannelService {
 
     const pinnedArticleIds = channel.pinnedArticles || []
     const systemService = new SystemService(this.connections)
-    const [globalSpamThreshold, topicChannelSpamThreshold] = await Promise.all([
-      systemService.getSpamThreshold(),
-      systemService.getTopicChannelSpamThreshold(),
-    ])
+    const [globalSpamThreshold, topicChannelSpamThreshold, probationDays] =
+      await Promise.all([
+        systemService.getSpamThreshold(),
+        systemService.getTopicChannelSpamThreshold(),
+        // dark-launched discovery probation: `null` while flag is off (zero diff)
+        systemService.getDiscoveryProbationDays(),
+      ])
     const spamThreshold = topicChannelSpamThreshold ?? globalSpamThreshold
 
     const pinnedQuery = knexRO
@@ -442,6 +446,12 @@ export class ChannelService {
       })
       .modify(excludeRestrictedModifier)
       .modify(excludeStateRestrictedModifier)
+      .modify((builder) => {
+        // discovery probation (dark): only applied when the flag is on
+        if (probationDays) {
+          builder.modify(excludeProbationModifier, probationDays)
+        }
+      })
       .modify(excludeExclusiveCampaignArticles)
       .where((builder) => {
         if (channelThreshold) {

--- a/src/connectors/recommendationService.ts
+++ b/src/connectors/recommendationService.ts
@@ -25,6 +25,7 @@ import {
   ActionFailedError,
 } from '#common/errors.js'
 import { getLogger } from '#common/logger.js'
+import { excludeProbationAuthors as excludeProbationModifier } from '#common/utils/index.js'
 import { daysToDatetimeRange } from '#common/utils/time.js'
 import { quantile, median } from 'd3-array'
 import keyBy from 'lodash/keyBy.js'
@@ -347,6 +348,8 @@ export class RecommendationService {
       'article'
     )
     const spamThreshold = await this.systemService.getSpamThreshold()
+    // dark-launched discovery probation: `null` while flag is off (zero diff)
+    const probationDays = await this.systemService.getDiscoveryProbationDays()
     const startDate = new Date()
     startDate.setDate(startDate.getDate() - days)
 
@@ -365,6 +368,7 @@ export class RecommendationService {
                 excludeRestrictedAuthors: USER_RESTRICTION_TYPE.articleHottest,
                 excludeExclusiveCampaignArticles: true,
                 excludeComplaintAreaArticles: true,
+                excludeProbationAuthors: probationDays ?? undefined,
                 datetimeRange: {
                   start: startDate,
                 },
@@ -884,6 +888,8 @@ export class RecommendationService {
     skip?: number
   }) => {
     const MAX_ITEM_COUNT = DEFAULT_TAKE_PER_PAGE * 50
+    // dark-launched discovery probation: `null` while flag is off (zero diff)
+    const probationDays = await this.systemService.getDiscoveryProbationDays()
     const records = await this.knexRO
       .select(
         'article.*',
@@ -906,6 +912,11 @@ export class RecommendationService {
       )
       .leftJoin('article', 'choice.article_id', 'article.id')
       .where({ state: ARTICLE_STATE.active })
+      .modify((builder) => {
+        if (probationDays) {
+          builder.modify(excludeProbationModifier, probationDays)
+        }
+      })
       .modify((builder) => {
         if (skip !== undefined && Number.isFinite(skip)) {
           builder.offset(skip)

--- a/src/connectors/systemService.ts
+++ b/src/connectors/systemService.ts
@@ -38,7 +38,7 @@ import {
   AUDIT_LOG_ACTION,
   AUDIT_LOG_STATUS,
 } from '#common/enums/index.js'
-import { isTest } from '#common/environment.js'
+import { environment, isTest } from '#common/environment.js'
 import { AssetNotFoundError, UserInputError } from '#common/errors.js'
 import { getLogger, auditLog } from '#common/logger.js'
 import { invalidateFQC } from '@matters/apollo-response-cache'
@@ -194,6 +194,38 @@ export class SystemService extends BaseService<BaseDBSchema> {
       return null
     }
     return threshold.value
+  }
+
+  /**
+   * Get the discovery probation window (days) from the `discovery_probation`
+   * feature flag. Returns `null` when the flag is off or missing, which means
+   * discovery feeds behave exactly as before (dark launch, zero diff).
+   * `feature_flag.value` overrides the env default when set.
+   */
+  public getDiscoveryProbationDays = async (): Promise<number | null> => {
+    const cache = new Cache(
+      CACHE_PREFIX.DISCOVERY_PROBATION_DAYS,
+      this.connections.objectCacheRedis
+    )
+    const value = (await cache.getObject({
+      keys: { id: 'discovery_probation_days' },
+      getter: this._getDiscoveryProbationDays,
+      expire: isTest ? CACHE_TTL.INSTANT : CACHE_TTL.SHORT,
+    })) as number | null
+    return value
+  }
+  private _getDiscoveryProbationDays = async (): Promise<number | null> => {
+    const featureFlag = await this.models.findFirst({
+      table: 'feature_flag',
+      where: {
+        name: FEATURE_NAME.discovery_probation,
+        flag: FEATURE_FLAG.on,
+      },
+    })
+    if (!featureFlag) {
+      return null
+    }
+    return featureFlag.value || environment.discoveryProbationDays
   }
 
   /**

--- a/src/connectors/tagService.ts
+++ b/src/connectors/tagService.ts
@@ -21,6 +21,7 @@ import {
   normalizeTagInput,
   excludeSpam as excludeSpamModifier,
   excludeStateRestrictedAuthors as excludeStateRestrictedModifier,
+  excludeProbationAuthors as excludeProbationModifier,
 } from '#common/utils/index.js'
 import _ from 'lodash'
 
@@ -451,7 +452,7 @@ export class TagService extends BaseService<Tag> {
     return parseInt(result ? (result.count as string) : '0', 10)
   }
 
-  public findHottestArticles = (tagId: string) => {
+  public findHottestArticles = (tagId: string, probationDays?: number) => {
     return this.knexRO
       .with('tagged_articles', (builder) =>
         builder
@@ -475,6 +476,12 @@ export class TagService extends BaseService<Tag> {
           // hide articles by authors in a restricted state (frozen / banned /
           // archived) from the public hottest tag feed
           .modify(excludeStateRestrictedModifier)
+          .modify((qb) => {
+            // discovery probation (dark): only applied when the flag is on
+            if (probationDays) {
+              qb.modify(excludeProbationModifier, probationDays)
+            }
+          })
       )
       .with('scored_articles', (builder) =>
         builder
@@ -536,10 +543,12 @@ export class TagService extends BaseService<Tag> {
     id: tagId,
     spamThreshold,
     excludeRestricted,
+    probationDays,
   }: {
     id: string
     spamThreshold?: number
     excludeRestricted?: boolean
+    probationDays?: number
   }) => {
     return this.knexRO
       .select(['article.*', 'article_tag.pinned as tag_pinned'])
@@ -561,6 +570,10 @@ export class TagService extends BaseService<Tag> {
         builder.modify(excludeStateRestrictedModifier)
         if (spamThreshold) {
           builder.modify(excludeSpamModifier, spamThreshold, 'article')
+        }
+        // discovery probation (dark): only applied when the flag is on
+        if (probationDays) {
+          builder.modify(excludeProbationModifier, probationDays)
         }
 
         builder.orderBy('article.id', 'desc')

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -1892,6 +1892,7 @@ export type GQLFeatureName =
   | 'article_channel'
   | 'circle_interact'
   | 'circle_management'
+  | 'discovery_probation'
   | 'fingerprint'
   | 'hottest_moment_feed'
   | 'payment'

--- a/src/queries/article/tag/articles.ts
+++ b/src/queries/article/tag/articles.ts
@@ -9,11 +9,14 @@ const resolver: GQLTagResolvers['articles'] = async (
 ) => {
   const { sortBy } = input
   const spamThreshold = (await systemService.getSpamThreshold()) ?? undefined
+  // dark-launched discovery probation: `undefined` while flag is off (zero diff)
+  const probationDays =
+    (await systemService.getDiscoveryProbationDays()) ?? undefined
   const isHottest = sortBy === 'byHottestDesc'
 
   const query = isHottest
-    ? tagService.findHottestArticles(id)
-    : tagService.findArticles({ id, spamThreshold })
+    ? tagService.findHottestArticles(id, probationDays)
+    : tagService.findArticles({ id, spamThreshold, probationDays })
   const orderBy = { column: isHottest ? 'score' : 'id', order: 'desc' as const }
 
   const result = await connectionFromQuery({ query, args: input, orderBy })

--- a/src/queries/user/recommendation/newest.ts
+++ b/src/queries/user/recommendation/newest.ts
@@ -33,10 +33,13 @@ export const newest: GQLRecommendationResolvers['newest'] = async (
   }
 
   const spamThreshold = await systemService.getSpamThreshold()
+  // dark-launched discovery probation: `null` while flag is off (zero diff)
+  const probationDays = await systemService.getDiscoveryProbationDays()
   const query = articleService.findNewestArticles({
     spamThreshold: spamThreshold ?? undefined,
     excludeChannelArticles: true,
     excludeExclusiveCampaignArticles: true,
+    probationDays: probationDays ?? undefined,
   })
 
   return connectionFromQuery({

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -687,6 +687,7 @@ export default /* GraphQL */ `
     topic_channel_spam_filter
     article_channel
     hottest_moment_feed
+    discovery_probation
   }
 
   enum FeatureFlag {


### PR DESCRIPTION
## What

Adds a **discovery probation** period for brand-new accounts: articles by authors whose account is younger than N days are excluded from discovery surfaces. N comes from env `MATTERS_DISCOVERY_PROBATION_DAYS` (default **3**), and `feature_flag.value` overrides it at runtime.

Spec: `spam-detection-scaffold/docs/SPEC_RING_V2.md` — §2 (Goal: 觀察期 in scope, registration-side bot defenses explicitly out of scope), §3 (acceptance #5: flag off ⇒ zero behavior change; flag on ⇒ new-account articles out of hottest/newest/channel/tag feeds while direct links stay readable), §8 (feature-flag plan: Dark, default `off`, back-end guard on discovery queries, kill-switch = `setFeature` off).

## Dark-launch statement (SOP: Dark)

- Feature flag **`discovery_probation`**, default **`off`** (migration inserts the row as `off`; the row only exists so admins can toggle it).
- **Flag off ⇒ zero diff**: `SystemService.getDiscoveryProbationDays()` returns `null` unless a `feature_flag` row with `name=discovery_probation, flag=on` exists. Every hook point is guarded by `if (probationDays)`, so with the flag off no query gains a single clause — generated SQL is byte-identical to develop.
- **Kill-switch**: `setFeature { name: discovery_probation, flag: off }` — takes effect within the short cache TTL (same `CACHE_TTL.SHORT` pattern as `topic_channel_spam_filter`).

## Hook points (discovery surfaces)

| Surface | Where |
| --- | --- |
| Hottest | `RecommendationService._findHottestArticles` → `articleService.findArticles({ excludeProbationAuthors })` |
| Newest | `queries/user/recommendation/newest.ts` → `articleService.findNewestArticles({ probationDays })` |
| ICYMI | `RecommendationService.findIcymiArticles` |
| Tag feed + hottest tag tab | `TagService.findArticles` / `TagService.findHottestArticles` (wired in `queries/article/tag/articles.ts`) |
| Topic channel feed | `ChannelService.findTopicChannelArticles` (unpinned query; editor-pinned articles are curation and stay) |

The exclusion is a new `excludeProbationAuthors(days)` knex modifier — same `whereNotExists` sub-query shape as `excludeStateRestrictedAuthors` (#4891), no joins added to these hot queries.

## Explicitly NOT touched (by design)

- **Search**, **campaign/collection** (curated), **profile pages**, **followee feeds**, **direct links**.
- Rationale (SPEC §2 non-goals): this protects anonymous whistleblowers/journalists who publish from fresh accounts — they distribute via direct links and followers, which remain fully functional; only algorithmic discovery ranking waits N days. No registration-side friction is added.

## Changes

- `FEATURE_NAME.discovery_probation` + GraphQL `FeatureName` enum + migration (`off`) + test seed
- `environment.discoveryProbationDays` (env `MATTERS_DISCOVERY_PROBATION_DAYS`, default 3)
- `SystemService.getDiscoveryProbationDays()` (cached, mirrors `getTopicChannelSpamThreshold`)
- `excludeProbationAuthors` modifier in `common/utils/knex.ts`
- Conditional wiring at the five hook points above

## Tests

- `systemService.test.ts`: flag off ⇒ `null`; on ⇒ env default 3; `value` override; off again ⇒ `null` (kill-switch)
- `tagService.test.ts`: flag off ⇒ results identical; on ⇒ new-account article excluded from tag feed and hottest tag tab, aged accounts unaffected
- `findTopicChannelArticles.test.ts`: flag off ⇒ zero diff; flag on ⇒ only new-account article excluded
- `findHottestArticles.test.ts`: flag off/on/off round-trip incl. kill-switch restore

Local `tsc`, eslint, codegen and prettier all pass (full husky pre-commit pipeline). Runtime tests rely on CI Postgres/Redis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)