### PR TITLE
feat(spam-ring): scope freezeSpamRing to verified members (audit F1)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -3912,6 +3912,11 @@ type ArchiveUserFailure {
 input FreezeSpamRingInput {
   id: ID!
   remark: String
+
+  """
+  Restrict this freeze to these members (raw DB user ids, same semantics as SpamRingCandidateInput.memberUserIds). Members not listed are skipped, not frozen. Omit to process all members. Must be non-empty when provided.
+  """
+  memberUserIds: [String!]
 }
 
 type FreezeSpamRingResult {

--- a/src/common/utils/__test__/spamRingResolvers.test.ts
+++ b/src/common/utils/__test__/spamRingResolvers.test.ts
@@ -81,6 +81,28 @@ describe('spam ring mutation resolvers', () => {
     })
   })
 
+  test('freezeSpamRing forwards memberUserIds for a scoped freeze (audit F1)', async () => {
+    const ctx = makeContext()
+    await (freezeSpamRing as any)(
+      null,
+      {
+        input: {
+          id: ringGlobalId('1'),
+          remark: 'r',
+          memberUserIds: ['u1', 'u2'],
+        },
+      },
+      ctx
+    )
+    expect(ctx.dataSources.spamRingService.freezeRing).toHaveBeenCalledWith({
+      ringId: '1',
+      actorId: '9',
+      remark: 'r',
+      memberUserIds: ['u1', 'u2'],
+      userService: ctx.dataSources.userService,
+    })
+  })
+
   test('unfreezeSpamRing forwards ringId + userService', async () => {
     const ctx = makeContext()
     await (unfreezeSpamRing as any)(

--- a/src/connectors/__test__/spamRingService.test.ts
+++ b/src/connectors/__test__/spamRingService.test.ts
@@ -297,6 +297,117 @@ describe('SpamRingService.freezeRing', () => {
     expect(result.ring.status).toBe('frozen')
   })
 
+  test('memberUserIds restricts the freeze to verified members; others are skipped untouched', async () => {
+    // audit F1: spam_ring_member is a union of all past detection runs, so a
+    // scoped freeze must only touch members verified by the current run.
+    const ring = { id: '1', status: 'pending', signals: { nearDupRingSize: 1 } }
+    const members = [
+      { id: 'm1', userId: 'u1', status: 'pending', bannedByThisRing: false },
+      { id: 'm2', userId: 'u2', status: 'pending', bannedByThisRing: false },
+    ]
+    const users: Record<string, any> = {
+      u1: {
+        id: 'u1',
+        state: USER_STATE.active,
+        createdAt: new Date(Date.now() - DAY),
+      },
+      // stale member from an earlier detection run — must stay untouched
+      u2: {
+        id: 'u2',
+        state: USER_STATE.active,
+        createdAt: new Date(Date.now() - DAY),
+      },
+    }
+    const { connections, rec } = makeConnections({ ring, members, users })
+    const service = makeService(connections, users)
+    const userService = makeUserService(users)
+
+    const result = await service.freezeRing({
+      ringId: '1',
+      actorId: '9',
+      memberUserIds: ['u1'],
+      userService: userService as any,
+    })
+
+    // only the verified member is frozen; u2 is never passed to freezeUser
+    expect(userService.freezeUser).toHaveBeenCalledTimes(1)
+    expect(userService.freezeUser).toHaveBeenCalledWith(
+      'u1',
+      expect.objectContaining({ remark: USER_BAN_REMARK.spamRing })
+    )
+    expect(result.frozen.map((u: any) => u.id)).toEqual(['u1'])
+    expect(result.skipped).toEqual([
+      { user: users.u2, reason: 'not_in_verified_candidate' },
+    ])
+    // the stale member row is marked skipped with the scope reason
+    const m2Update = rec.memberUpdates.find((u) => u.where.id === 'm2')
+    expect(m2Update?.data).toMatchObject({
+      status: 'skipped',
+      skipReason: 'not_in_verified_candidate',
+      bannedByThisRing: false,
+    })
+    expect(rec.eventInserts.map((e) => e.action)).toEqual(
+      expect.arrayContaining(['member_frozen', 'member_skipped', 'frozen'])
+    )
+    // ring itself still transitions to frozen
+    expect(rec.ringUpdates.at(-1)).toMatchObject({ status: 'frozen' })
+  })
+
+  test('guardrails still apply to members inside the memberUserIds scope', async () => {
+    const ring = { id: '1', status: 'pending', signals: { nearDupRingSize: 1 } }
+    const members = [
+      { id: 'm1', userId: 'u1', status: 'pending', bannedByThisRing: false },
+      { id: 'm2', userId: 'u2', status: 'pending', bannedByThisRing: false },
+    ]
+    const users: Record<string, any> = {
+      // in scope but old account → guardrail wins, goes to human review
+      u1: {
+        id: 'u1',
+        state: USER_STATE.active,
+        createdAt: new Date(Date.now() - 100 * DAY),
+      },
+      u2: {
+        id: 'u2',
+        state: USER_STATE.active,
+        createdAt: new Date(Date.now() - DAY),
+      },
+    }
+    const { connections } = makeConnections({ ring, members, users })
+    const service = makeService(connections, users)
+    const userService = makeUserService(users)
+
+    const result = await service.freezeRing({
+      ringId: '1',
+      actorId: '9',
+      memberUserIds: ['u1', 'u2'],
+      userService: userService as any,
+    })
+
+    expect(userService.freezeUser).toHaveBeenCalledTimes(1)
+    expect(userService.freezeUser).toHaveBeenCalledWith(
+      'u2',
+      expect.objectContaining({ remark: USER_BAN_REMARK.spamRing })
+    )
+    expect(result.frozen.map((u: any) => u.id)).toEqual(['u2'])
+    expect(result.skipped.map((s: any) => s.user.id)).toEqual(['u1'])
+    expect(result.skipped[0].reason).toMatch(/old account/)
+  })
+
+  test('rejects an explicitly empty memberUserIds list', async () => {
+    const { connections } = makeConnections({
+      ring: { id: '1', status: 'pending' },
+    })
+    const service = makeService(connections, {})
+    await expect(
+      service.freezeRing({
+        ringId: '1',
+        actorId: '9',
+        memberUserIds: [],
+        userService: makeUserService({}) as any,
+      })
+    ).rejects.toThrow('memberUserIds must not be empty')
+  })
+
   test('refuses to freeze a dismissed ring', async () => {
     const { connections } = makeConnections({
       ring: { id: '1', status: 'dismissed' },

--- a/src/connectors/spamRingService.ts
+++ b/src/connectors/spamRingService.ts
@@ -237,17 +237,31 @@ export class SpamRingService extends BaseService<SpamRing> {
     ringId,
     actorId,
     remark,
+    memberUserIds,
     userService,
   }: {
     ringId: string
     actorId: string
     remark?: string | null
+    // 稽核 F1：本次偵測驗證過的成員（raw DB user id）。有給時凍結只作用於
+    // 「ring 成員 ∩ 此名單」；名單外成員記 skipped、不凍結、不發通知。
+    // 不給＝現行為（全成員，控制台人工一鍵）。
+    memberUserIds?: string[] | null
     userService: UserService
   }): Promise<{
     ring: SpamRing
     frozen: User[]
     skipped: Array<{ user: User; reason: string }>
   }> => {
+    // provided-but-empty is almost certainly a caller bug: it would mark every
+    // member skipped and still lock the ring as frozen — reject it instead.
+    if (memberUserIds && memberUserIds.length === 0) {
+      throw new UserInputError('memberUserIds must not be empty when provided')
+    }
+    const memberScope = memberUserIds
+      ? new Set(memberUserIds.map((id) => String(id)))
+      : null
+
     const frozen: User[] = []
     const skipped: Array<{ user: User; reason: string }> = []
 
@@ -299,6 +313,21 @@ export class SpamRingService extends BaseService<SpamRing> {
         // 本 ring 已凍結過此人 → idempotent，略過
         if (member.status === 'frozen' && member.bannedByThisRing) {
           frozen.push(user)
+          continue
+        }
+        // 稽核 F1：spam_ring_member 是歷次偵測的聯集（只增不減），可能含
+        // 歷史誤列的真人。成員不在本次驗證名單 → 只記 skipped，不凍結、
+        // 不發通知；下方既有護欄只對名單內成員照跑。
+        if (memberScope && !memberScope.has(String(member.userId))) {
+          await this.skipMember(
+            member.id,
+            user,
+            'not_in_verified_candidate',
+            actorId,
+            ringId,
+            trx
+          )
+          skipped.push({ user, reason: 'not_in_verified_candidate' })
           continue
         }
         if (user.state === USER_STATE.archived) {

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -1972,6 +1972,8 @@ export type GQLFollowingActivityEdge = {
 
 export type GQLFreezeSpamRingInput = {
   id: Scalars['ID']['input']
+  /** Restrict this freeze to these members (raw DB user ids, same semantics as SpamRingCandidateInput.memberUserIds). Members not listed are skipped, not frozen. Omit to process all members. Must be non-empty when provided. */
+  memberUserIds?: InputMaybe<Array<Scalars['String']['input']>>
   remark?: InputMaybe<Scalars['String']['input']>
 }
 

--- a/src/mutations/user/freezeSpamRing.ts
+++ b/src/mutations/user/freezeSpamRing.ts
@@ -7,7 +7,7 @@ import { invalidateUserContentCaches } from './utils.js'
 
 const resolver: GQLMutationResolvers['freezeSpamRing'] = async (
   _,
-  { input: { id, remark } },
+  { input: { id, remark, memberUserIds } },
   {
     viewer,
     dataSources: {
@@ -26,6 +26,8 @@ const resolver: GQLMutationResolvers['freezeSpamRing'] = async (
     ringId,
     actorId: viewer.id,
     remark,
+    // audit F1: restrict the freeze to members verified by this detection run
+    memberUserIds,
     userService,
   })
 

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -841,6 +841,8 @@ export default /* GraphQL */ `
   input FreezeSpamRingInput {
     id: ID!
     remark: String
+    "Restrict this freeze to these members (raw DB user ids, same semantics as SpamRingCandidateInput.memberUserIds). Members not listed are skipped, not frozen. Omit to process all members. Must be non-empty when provided."
+    memberUserIds: [String!]
   }
 
   type FreezeSpamRingResult {


### PR DESCRIPTION
## Why

Security-audit **HIGH blocker F1** — a prerequisite for enabling `AUTO_FREEZE` (SPEC_RING_V2 §10 rollout step 5: "security audit passes with no CRITICAL/HIGH → enable AUTO_FREEZE"; see also §3 criteria 1/6).

`spam_ring_member` is an **append-only union of every past detection run**: `upsertCandidates` → `upsertMembers` never disturbs existing rows, so members mis-listed by older runs stay in the ring forever. `freezeRing` processes **all** members of a ring. The new job-side pure-graph member filtering only shapes the candidate payload — it never shrinks the server-side member list. Result: an automated freeze could freeze real users that the current detection run has already excluded.

## What

Additive, backward-compatible scoping of the freeze to the members verified by the current detection run:

- **GraphQL** (`src/types/user.ts`): optional `FreezeSpamRingInput.memberUserIds: [String!]` — raw DB user ids, same semantics as `SpamRingCandidateInput.memberUserIds`. Rejected with `UserInputError` if provided but empty (an empty verified set must not silently skip-all and lock the ring).
- **Service** (`src/connectors/spamRingService.ts` `freezeRing`): when `memberUserIds` is given, the member iteration is restricted to the intersection. Out-of-scope members are marked `skipped` with reason `not_in_verified_candidate` (+ `member_skipped` audit event) — **not frozen, no user notification**. The scope check runs inside the same transaction + `FOR UPDATE` loop added in #4884 (lock pattern unchanged), after the idempotency check (never re-claims a member this ring already froze) and **before** the existing guardrails, which are untouched and still run for in-scope members.
- **Resolver** (`src/mutations/user/freezeSpamRing.ts`): passes the new field through.

## Behavior matrix

| `memberUserIds` | Behavior |
| --- | --- |
| omitted / `null` | **Unchanged** — freeze all ring members (manual one-click console flow) |
| `["u1", …]` | Only members in the intersection are processed; guardrails (old account / high karma / archived / banned / already frozen) still apply to them; everyone else → `skipped: not_in_verified_candidate` |
| `[]` | `UserInputError` (caller bug guard) |

## Tests

Extended `src/connectors/__test__/spamRingService.test.ts` and `src/common/utils/__test__/spamRingResolvers.test.ts`:

1. No `memberUserIds` → existing tests unchanged and passing (freeze-all behavior intact).
2. Scoped freeze: out-of-scope member skipped (`not_in_verified_candidate`, member row marked, event written, `freezeUser` never called for it); in-scope member frozen; ring still transitions to `frozen`.
3. In-scope but old account → guardrail still wins (guard precedence unchanged).
4. Empty list rejected; resolver forwards the field.

All 29 tests in the two suites pass; lint + build + gen clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
