### PR TITLE
release: spam-ring v2 server 端（日報 handler、觀察期 Dark、交集凍結）

### DIFF
--- a/db/migrations/20260704000000_add_discovery_probation_feature_flag.js
+++ b/db/migrations/20260704000000_add_discovery_probation_feature_flag.js
@@ -1,0 +1,17 @@
+const table = 'feature_flag'
+const name = 'discovery_probation'
+
+// Dark launch: flag defaults to `off`, so discovery feeds behave exactly as
+// before. The row must exist for admins to toggle it via `setFeature`
+// (kill-switch). Probation window defaults to env
+// MATTERS_DISCOVERY_PROBATION_DAYS (3); `value` overrides it when set.
+export const up = async (knex) => {
+  await knex(table)
+    .insert({ name, flag: 'off', value: null })
+    .onConflict('name')
+    .ignore()
+}
+
+export const down = async (knex) => {
+  await knex(table).where({ name }).del()
+}

--- a/db/seeds/31_feature_flag.js
+++ b/db/seeds/31_feature_flag.js
@@ -50,5 +50,9 @@ export const seed = async (knex) => {
       name: 'hottest_moment_feed',
       flag: 'off',
     },
+    {
+      name: 'discovery_probation',
+      flag: 'off',
+    },
   ])
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "start:dev": "npm-run-all clean build --parallel watch:build watch:server --print-label",
     "testcmd": "MATTERS_ENV=test node --experimental-vm-modules --no-experimental-fetch node_modules/.bin/jest",
     "test:connectors": "npm run testcmd -- build/connectors/ --forceExit --coverageDirectory coverage/connectors",
+    "test:handlers": "npm run testcmd -- build/handlers/ --forceExit --coverageDirectory coverage/handlers",
     "test:utils": "npm run testcmd -- build/common/utils/ --coverageDirectory coverage/utils",
     "test:routes": "npm run testcmd -- build/routes/ --forceExit --coverageDirectory coverage/routes",
     "test:types:1": "npm run testcmd -- build/types/__test__/1/ --forceExit --coverageDirectory coverage/types-1",

--- a/schema.graphql
+++ b/schema.graphql
@@ -3015,6 +3015,7 @@ enum FeatureName {
   topic_channel_spam_filter
   article_channel
   hottest_moment_feed
+  discovery_probation
 }
 
 enum FeatureFlag {

--- a/schema.graphql
+++ b/schema.graphql
@@ -3912,6 +3912,11 @@ type ArchiveUserFailure {
 input FreezeSpamRingInput {
   id: ID!
   remark: String
+
+  """
+  Restrict this freeze to these members (raw DB user ids, same semantics as SpamRingCandidateInput.memberUserIds). Members not listed are skipped, not frozen. Omit to process all members. Must be non-empty when provided.
+  """
+  memberUserIds: [String!]
 }
 
 type FreezeSpamRingResult {

--- a/src/common/enums/cache.ts
+++ b/src/common/enums/cache.ts
@@ -35,6 +35,7 @@ export const CACHE_PREFIX = {
   TAG_COVERS: 'cache-tag-covers',
   SPAM_THRESHOLD: 'cache-spam-threshold',
   TOPIC_CHANNEL_SPAM_THRESHOLD: 'cache-topic-channel-spam-threshold',
+  DISCOVERY_PROBATION_DAYS: 'cache-discovery-probation-days',
   ARTICLE_CHANNEL_THRESHOLD: 'cache-article-channel-threshold',
   RECOMMENDATION_TAGS: 'cache-recommendation-tags',
   RECOMMENDATION_AUTHORS: 'cache-recommendation-authors',

--- a/src/common/enums/feature.ts
+++ b/src/common/enums/feature.ts
@@ -11,6 +11,7 @@ export const FEATURE_NAME = {
   topic_channel_spam_filter: 'topic_channel_spam_filter',
   article_channel: 'article_channel',
   hottest_moment_feed: 'hottest_moment_feed',
+  discovery_probation: 'discovery_probation',
 } as const
 
 export const FEATURE_FLAG = {

--- a/src/common/environment.ts
+++ b/src/common/environment.ts
@@ -52,12 +52,10 @@ export const environment = {
   awsMailQueueUrl: process.env.MATTERS_AWS_MAIL_QUEUE_URL || '',
   awsExpressMailQueueUrl: process.env.MATTERS_AWS_EXPRESS_MAIL_QUEUE_URL || '',
   awsArchiveUserQueueUrl: process.env.MATTERS_AWS_ARCHIVE_USER_QUEUE_URL || '',
-  awsReportAlertQueueUrl:
-    process.env.MATTERS_AWS_REPORT_ALERT_QUEUE_URL || '',
+  awsReportAlertQueueUrl: process.env.MATTERS_AWS_REPORT_ALERT_QUEUE_URL || '',
   // Spam training-sample capture (axis-2 L2): de-identified moderation events
   // for the spam-model training corpus. Best-effort; off when unset.
-  awsSpamSampleQueueUrl:
-    process.env.MATTERS_AWS_SPAM_SAMPLE_QUEUE_URL || '',
+  awsSpamSampleQueueUrl: process.env.MATTERS_AWS_SPAM_SAMPLE_QUEUE_URL || '',
   spamSampleHashSalt: process.env.MATTERS_SPAM_SAMPLE_HASH_SALT || '',
   awsLikecoinLikeUrl: process.env.MATTERS_AWS_LIKECOIN_LIKE_QUEUE_URL || '',
   awsLikecoinSendPVUrl:
@@ -212,6 +210,13 @@ export const environment = {
   // Telegram chat for moderation. Notify-only: this flag NEVER hides a comment
   // (auto-action stays behind commentSpamAutoCollapse). Default off.
   commentSpamAlert: process.env.MATTERS_COMMENT_SPAM_ALERT === 'true',
+  // Default probation window (days) keeping brand-new accounts out of
+  // discovery surfaces; effective only while the `discovery_probation`
+  // feature flag is on. `feature_flag.value` overrides this default.
+  discoveryProbationDays: parseInt(
+    process.env.MATTERS_DISCOVERY_PROBATION_DAYS || '3',
+    10
+  ),
   channelClassificationApiUrl:
     process.env.MATTERS_CHANNEL_CLASSIFICATION_API_URL || '',
   languageDetectionApiUrl: process.env.MATTERS_LANGUAGE_DETECTION_API_URL || '',

--- a/src/common/notifications/telegram.ts
+++ b/src/common/notifications/telegram.ts
@@ -1,0 +1,37 @@
+import axios from 'axios'
+
+export const TELEGRAM_API_TIMEOUT_MS = 5000
+
+export type SendTelegramMessageParams = {
+  botToken: string
+  chatId: string
+  /** Optional forum topic id; empty string means "no topic". */
+  threadId?: string
+  /** Message body, rendered with Telegram HTML parse mode. */
+  text: string
+}
+
+/**
+ * Send a message to a Telegram chat via the Bot API (HTML parse mode,
+ * web-page previews disabled). Returns the created message id so callers
+ * can edit the message later.
+ */
+export const sendTelegramMessage = async ({
+  botToken,
+  chatId,
+  threadId,
+  text,
+}: SendTelegramMessageParams): Promise<number> => {
+  const resp = await axios.post(
+    `https://api.telegram.org/bot${botToken}/sendMessage`,
+    {
+      chat_id: chatId,
+      ...(threadId ? { message_thread_id: Number(threadId) } : {}),
+      text,
+      parse_mode: 'HTML',
+      disable_web_page_preview: true,
+    },
+    { timeout: TELEGRAM_API_TIMEOUT_MS }
+  )
+  return resp.data.result.message_id as number
+}

--- a/src/common/utils/__test__/spamRingResolvers.test.ts
+++ b/src/common/utils/__test__/spamRingResolvers.test.ts
@@ -81,6 +81,28 @@ describe('spam ring mutation resolvers', () => {
     })
   })
 
+  test('freezeSpamRing forwards memberUserIds for a scoped freeze (audit F1)', async () => {
+    const ctx = makeContext()
+    await (freezeSpamRing as any)(
+      null,
+      {
+        input: {
+          id: ringGlobalId('1'),
+          remark: 'r',
+          memberUserIds: ['u1', 'u2'],
+        },
+      },
+      ctx
+    )
+    expect(ctx.dataSources.spamRingService.freezeRing).toHaveBeenCalledWith({
+      ringId: '1',
+      actorId: '9',
+      remark: 'r',
+      memberUserIds: ['u1', 'u2'],
+      userService: ctx.dataSources.userService,
+    })
+  })
+
   test('unfreezeSpamRing forwards ringId + userService', async () => {
     const ctx = makeContext()
     await (unfreezeSpamRing as any)(

--- a/src/common/utils/knex.ts
+++ b/src/common/utils/knex.ts
@@ -105,7 +105,8 @@ export const excludeProbationAuthors = (
       .select(1)
       .from('user')
       .where('user.id', qb.client.ref(`${table}.author_id`))
-      .whereRaw(`user.created_at >= now() - interval '1 day' * ?`, [days])
+      // "user" must be quoted in raw SQL — unquoted it parses as the USER keyword
+      .whereRaw(`"user".created_at >= now() - interval '1 day' * ?`, [days])
   )
 }
 

--- a/src/common/utils/knex.ts
+++ b/src/common/utils/knex.ts
@@ -88,6 +88,27 @@ export const excludeStateRestrictedAuthors = (
   )
 }
 
+/**
+ * Exclude articles whose author account is younger than `days` days
+ * (discovery probation). Applied only to discovery surfaces (hottest /
+ * newest / icymi / tag / channel feeds); direct links, profile pages,
+ * followee feeds and search are intentionally untouched so anonymous
+ * whistleblower accounts can still be reached and followed.
+ */
+export const excludeProbationAuthors = (
+  builder: Knex.QueryBuilder,
+  days: number,
+  table = 'article'
+) => {
+  builder.whereNotExists((qb) =>
+    qb
+      .select(1)
+      .from('user')
+      .where('user.id', qb.client.ref(`${table}.author_id`))
+      .whereRaw(`user.created_at >= now() - interval '1 day' * ?`, [days])
+  )
+}
+
 export const excludeExclusiveCampaignArticles = (
   builder: Knex.QueryBuilder,
   table = 'article'

--- a/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
+++ b/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
@@ -36,6 +36,10 @@ beforeEach(async () => {
     name: FEATURE_NAME.spam_detection,
     flag: FEATURE_FLAG.off,
   })
+  await systemService.setFeatureFlag({
+    name: FEATURE_NAME.discovery_probation,
+    flag: FEATURE_FLAG.off,
+  })
   await atomService.deleteMany({ table: 'topic_channel_article' })
   await atomService.deleteMany({ table: 'topic_channel' })
 
@@ -417,6 +421,79 @@ describe('findTopicChannelArticles', () => {
       expect(results.map((a) => a.id)).toContain(articles[0].id)
 
       await atomService.deleteMany({ table: 'user_restriction' })
+    })
+  })
+
+  describe('discovery probation', () => {
+    // articles[1]'s author does not own any other article in the channel
+    // (articles[0] and articles[3] share an author), so it is a clean target
+    const originalCreatedAt: Record<string, Date> = {}
+
+    beforeEach(async () => {
+      // age all channel article authors out of the probation window first
+      // (seed users are created at test run time, i.e. "new" accounts)
+      const authorIds = [
+        ...new Set(articles.slice(0, 4).map(({ authorId }) => authorId)),
+      ]
+      for (const authorId of authorIds) {
+        const author = await atomService.findUnique({
+          table: 'user',
+          where: { id: authorId },
+        })
+        originalCreatedAt[authorId] = author.createdAt
+        await atomService.update({
+          table: 'user',
+          where: { id: authorId },
+          data: { createdAt: new Date(Date.now() - 30 * 24 * 3600 * 1000) },
+        })
+      }
+      // make the target author a brand-new account (inside probation window)
+      await atomService.update({
+        table: 'user',
+        where: { id: articles[1].authorId },
+        data: { createdAt: new Date() },
+      })
+    })
+
+    afterEach(async () => {
+      // restore created_at to avoid leaking into other tests
+      for (const [authorId, createdAt] of Object.entries(originalCreatedAt)) {
+        await atomService.update({
+          table: 'user',
+          where: { id: authorId },
+          data: { createdAt },
+        })
+      }
+    })
+
+    test('flag off: results identical to before (zero diff)', async () => {
+      // flag is off via beforeEach; new-account article still shows up
+      const { query } = await channelService.findTopicChannelArticles(
+        channel.id
+      )
+      const results = await query
+
+      expect(results).toHaveLength(4)
+      expect(results.map((a) => a.id)).toContain(articles[1].id)
+    })
+
+    test('flag on: excludes articles from new accounts only', async () => {
+      await systemService.setFeatureFlag({
+        name: FEATURE_NAME.discovery_probation,
+        flag: FEATURE_FLAG.on,
+      })
+
+      const { query } = await channelService.findTopicChannelArticles(
+        channel.id
+      )
+      const results = await query
+
+      const ids = results.map((a) => a.id)
+      expect(ids).not.toContain(articles[1].id)
+      // articles by older accounts are not affected
+      expect(ids).toContain(articles[0].id)
+      expect(ids).toContain(articles[2].id)
+      expect(ids).toContain(articles[3].id)
     })
   })
 

--- a/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
+++ b/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
@@ -425,15 +425,29 @@ describe('findTopicChannelArticles', () => {
   })
 
   describe('discovery probation', () => {
-    // articles[1]'s author does not own any other article in the channel
-    // (articles[0] and articles[3] share an author), so it is a clean target
     const originalCreatedAt: Record<string, Date> = {}
+    let target: Article
+    let others: Article[]
 
     beforeEach(async () => {
+      // `articles` comes from an unordered findMany, so index→author mapping
+      // is not guaranteed — pick a target whose author owns exactly one of
+      // the four channel articles, so newing that author affects one article
+      const channelArticles = articles.slice(0, 4)
+      const authorCount: Record<string, number> = {}
+      for (const { authorId } of channelArticles) {
+        authorCount[authorId] = (authorCount[authorId] ?? 0) + 1
+      }
+      target = channelArticles.find(
+        ({ authorId }) => authorCount[authorId] === 1
+      ) as Article
+      expect(target).toBeDefined()
+      others = channelArticles.filter(({ id }) => id !== target.id)
+
       // age all channel article authors out of the probation window first
       // (seed users are created at test run time, i.e. "new" accounts)
       const authorIds = [
-        ...new Set(articles.slice(0, 4).map(({ authorId }) => authorId)),
+        ...new Set(channelArticles.map(({ authorId }) => authorId)),
       ]
       for (const authorId of authorIds) {
         const author = await atomService.findUnique({
@@ -450,13 +464,18 @@ describe('findTopicChannelArticles', () => {
       // make the target author a brand-new account (inside probation window)
       await atomService.update({
         table: 'user',
-        where: { id: articles[1].authorId },
+        where: { id: target.authorId },
         data: { createdAt: new Date() },
       })
     })
 
     afterEach(async () => {
-      // restore created_at to avoid leaking into other tests
+      // restore created_at and the flag, even when an assertion threw —
+      // a leaked flag would poison every later test in this file
+      await systemService.setFeatureFlag({
+        name: FEATURE_NAME.discovery_probation,
+        flag: FEATURE_FLAG.off,
+      })
       for (const [authorId, createdAt] of Object.entries(originalCreatedAt)) {
         await atomService.update({
           table: 'user',
@@ -474,7 +493,7 @@ describe('findTopicChannelArticles', () => {
       const results = await query
 
       expect(results).toHaveLength(4)
-      expect(results.map((a) => a.id)).toContain(articles[1].id)
+      expect(results.map((a) => a.id)).toContain(target.id)
     })
 
     test('flag on: excludes articles from new accounts only', async () => {
@@ -489,11 +508,11 @@ describe('findTopicChannelArticles', () => {
       const results = await query
 
       const ids = results.map((a) => a.id)
-      expect(ids).not.toContain(articles[1].id)
+      expect(ids).not.toContain(target.id)
       // articles by older accounts are not affected
-      expect(ids).toContain(articles[0].id)
-      expect(ids).toContain(articles[2].id)
-      expect(ids).toContain(articles[3].id)
+      for (const other of others) {
+        expect(ids).toContain(other.id)
+      }
     })
   })
 

--- a/src/connectors/__test__/recommendationService/findHottestArticles.test.ts
+++ b/src/connectors/__test__/recommendationService/findHottestArticles.test.ts
@@ -276,20 +276,23 @@ describe('findHottestArticles', () => {
       name: FEATURE_NAME.discovery_probation,
       flag: FEATURE_FLAG.on,
     })
-    const after = await recommendationService.findHottestArticles({
-      days: 5,
-      readersThreshold: 0,
-      commentsThreshold: 0,
-    })
-    const afterIds = after.map((r: any) => r.articleId)
-    expect(afterIds).not.toContain(article1.id)
-    expect(afterIds).toContain(article2.id)
-
-    // kill-switch: turning the flag off restores the previous behavior
-    await systemService.setFeatureFlag({
-      name: FEATURE_NAME.discovery_probation,
-      flag: FEATURE_FLAG.off,
-    })
+    try {
+      const after = await recommendationService.findHottestArticles({
+        days: 5,
+        readersThreshold: 0,
+        commentsThreshold: 0,
+      })
+      const afterIds = after.map((r: any) => r.articleId)
+      expect(afterIds).not.toContain(article1.id)
+      expect(afterIds).toContain(article2.id)
+    } finally {
+      // kill-switch — and cleanup even on failure, so a thrown assertion
+      // cannot leak the flag into the rest of this suite
+      await systemService.setFeatureFlag({
+        name: FEATURE_NAME.discovery_probation,
+        flag: FEATURE_FLAG.off,
+      })
+    }
     const restored = await recommendationService.findHottestArticles({
       days: 5,
       readersThreshold: 0,

--- a/src/connectors/__test__/recommendationService/findHottestArticles.test.ts
+++ b/src/connectors/__test__/recommendationService/findHottestArticles.test.ts
@@ -9,6 +9,8 @@ import {
   TRANSACTION_STATE,
   PAYMENT_CURRENCY,
   DAY,
+  FEATURE_NAME,
+  FEATURE_FLAG,
 } from '#common/enums/index.js'
 import {
   RecommendationService,
@@ -243,6 +245,57 @@ describe('findHottestArticles', () => {
     const articleIds = results.map((r: any) => r.articleId)
     expect(articleIds).toContain(article1.id)
     expect(articleIds).not.toContain(restrictedAuthorArticle.id)
+  })
+
+  test('discovery probation: flag off keeps new accounts, flag on excludes them', async () => {
+    await createArticleReadCount(author1.id, article1.id, 10)
+    await createArticleReadCount(author1.id, article2.id, 10)
+    await createComment(author3.id, article1.id)
+    await createComment(author3.id, article2.id)
+
+    // age author2 out of the probation window; author1 stays brand-new
+    // (users in this suite are created at test run time)
+    await atomService.update({
+      table: 'user',
+      where: { id: author2.id },
+      data: { createdAt: new Date(Date.now() - 30 * DAY) },
+    })
+
+    // flag off (seed default): both articles surface, zero diff
+    const before = await recommendationService.findHottestArticles({
+      days: 5,
+      readersThreshold: 0,
+      commentsThreshold: 0,
+    })
+    const beforeIds = before.map((r: any) => r.articleId)
+    expect(beforeIds).toContain(article1.id)
+    expect(beforeIds).toContain(article2.id)
+
+    // flag on: new-account article excluded, aged account unaffected
+    await systemService.setFeatureFlag({
+      name: FEATURE_NAME.discovery_probation,
+      flag: FEATURE_FLAG.on,
+    })
+    const after = await recommendationService.findHottestArticles({
+      days: 5,
+      readersThreshold: 0,
+      commentsThreshold: 0,
+    })
+    const afterIds = after.map((r: any) => r.articleId)
+    expect(afterIds).not.toContain(article1.id)
+    expect(afterIds).toContain(article2.id)
+
+    // kill-switch: turning the flag off restores the previous behavior
+    await systemService.setFeatureFlag({
+      name: FEATURE_NAME.discovery_probation,
+      flag: FEATURE_FLAG.off,
+    })
+    const restored = await recommendationService.findHottestArticles({
+      days: 5,
+      readersThreshold: 0,
+      commentsThreshold: 0,
+    })
+    expect(restored.map((r: any) => r.articleId)).toContain(article1.id)
   })
 
   test('applies minimum reader and comment thresholds', async () => {

--- a/src/connectors/__test__/spamRingService.test.ts
+++ b/src/connectors/__test__/spamRingService.test.ts
@@ -297,6 +297,117 @@ describe('SpamRingService.freezeRing', () => {
     expect(result.ring.status).toBe('frozen')
   })
 
+  test('memberUserIds restricts the freeze to verified members; others are skipped untouched', async () => {
+    // audit F1: spam_ring_member is a union of all past detection runs, so a
+    // scoped freeze must only touch members verified by the current run.
+    const ring = { id: '1', status: 'pending', signals: { nearDupRingSize: 1 } }
+    const members = [
+      { id: 'm1', userId: 'u1', status: 'pending', bannedByThisRing: false },
+      { id: 'm2', userId: 'u2', status: 'pending', bannedByThisRing: false },
+    ]
+    const users: Record<string, any> = {
+      u1: {
+        id: 'u1',
+        state: USER_STATE.active,
+        createdAt: new Date(Date.now() - DAY),
+      },
+      // stale member from an earlier detection run — must stay untouched
+      u2: {
+        id: 'u2',
+        state: USER_STATE.active,
+        createdAt: new Date(Date.now() - DAY),
+      },
+    }
+    const { connections, rec } = makeConnections({ ring, members, users })
+    const service = makeService(connections, users)
+    const userService = makeUserService(users)
+
+    const result = await service.freezeRing({
+      ringId: '1',
+      actorId: '9',
+      memberUserIds: ['u1'],
+      userService: userService as any,
+    })
+
+    // only the verified member is frozen; u2 is never passed to freezeUser
+    expect(userService.freezeUser).toHaveBeenCalledTimes(1)
+    expect(userService.freezeUser).toHaveBeenCalledWith(
+      'u1',
+      expect.objectContaining({ remark: USER_BAN_REMARK.spamRing })
+    )
+    expect(result.frozen.map((u: any) => u.id)).toEqual(['u1'])
+    expect(result.skipped).toEqual([
+      { user: users.u2, reason: 'not_in_verified_candidate' },
+    ])
+    // the stale member row is marked skipped with the scope reason
+    const m2Update = rec.memberUpdates.find((u) => u.where.id === 'm2')
+    expect(m2Update?.data).toMatchObject({
+      status: 'skipped',
+      skipReason: 'not_in_verified_candidate',
+      bannedByThisRing: false,
+    })
+    expect(rec.eventInserts.map((e) => e.action)).toEqual(
+      expect.arrayContaining(['member_frozen', 'member_skipped', 'frozen'])
+    )
+    // ring itself still transitions to frozen
+    expect(rec.ringUpdates.at(-1)).toMatchObject({ status: 'frozen' })
+  })
+
+  test('guardrails still apply to members inside the memberUserIds scope', async () => {
+    const ring = { id: '1', status: 'pending', signals: { nearDupRingSize: 1 } }
+    const members = [
+      { id: 'm1', userId: 'u1', status: 'pending', bannedByThisRing: false },
+      { id: 'm2', userId: 'u2', status: 'pending', bannedByThisRing: false },
+    ]
+    const users: Record<string, any> = {
+      // in scope but old account → guardrail wins, goes to human review
+      u1: {
+        id: 'u1',
+        state: USER_STATE.active,
+        createdAt: new Date(Date.now() - 100 * DAY),
+      },
+      u2: {
+        id: 'u2',
+        state: USER_STATE.active,
+        createdAt: new Date(Date.now() - DAY),
+      },
+    }
+    const { connections } = makeConnections({ ring, members, users })
+    const service = makeService(connections, users)
+    const userService = makeUserService(users)
+
+    const result = await service.freezeRing({
+      ringId: '1',
+      actorId: '9',
+      memberUserIds: ['u1', 'u2'],
+      userService: userService as any,
+    })
+
+    expect(userService.freezeUser).toHaveBeenCalledTimes(1)
+    expect(userService.freezeUser).toHaveBeenCalledWith(
+      'u2',
+      expect.objectContaining({ remark: USER_BAN_REMARK.spamRing })
+    )
+    expect(result.frozen.map((u: any) => u.id)).toEqual(['u2'])
+    expect(result.skipped.map((s: any) => s.user.id)).toEqual(['u1'])
+    expect(result.skipped[0].reason).toMatch(/old account/)
+  })
+
+  test('rejects an explicitly empty memberUserIds list', async () => {
+    const { connections } = makeConnections({
+      ring: { id: '1', status: 'pending' },
+    })
+    const service = makeService(connections, {})
+    await expect(
+      service.freezeRing({
+        ringId: '1',
+        actorId: '9',
+        memberUserIds: [],
+        userService: makeUserService({}) as any,
+      })
+    ).rejects.toThrow('memberUserIds must not be empty')
+  })
+
   test('refuses to freeze a dismissed ring', async () => {
     const { connections } = makeConnections({
       ring: { id: '1', status: 'dismissed' },

--- a/src/connectors/__test__/spamRingService.test.ts
+++ b/src/connectors/__test__/spamRingService.test.ts
@@ -594,6 +594,12 @@ describe('SpamRingService.upsertCandidates', () => {
 
     expect(result.created).toBe(1)
     expect(result.updated).toBe(0)
+    // rings carries the upserted entities so the job can freeze by id
+    expect(result.rings).toHaveLength(1)
+    expect(result.rings[0]).toMatchObject({
+      fingerprint: 'fp-new',
+      status: 'pending',
+    })
     expect(rec.ringInserts[0]).toMatchObject({
       fingerprint: 'fp-new',
       status: 'pending',
@@ -640,6 +646,11 @@ describe('SpamRingService.upsertCandidates', () => {
     expect(result.created).toBe(0)
     expect(result.updated).toBe(1)
     expect(result.skipped).toBe(1)
+    // both the updated ring and the locked (skipped) ring are returned
+    expect(result.rings.map((r) => r.fingerprint).sort()).toEqual([
+      'fp-existing',
+      'fp-frozen',
+    ])
     expect(rec.ringUpdates[0]).toMatchObject({
       where: { id: 'r1' },
       data: {

--- a/src/connectors/__test__/systemService.test.ts
+++ b/src/connectors/__test__/systemService.test.ts
@@ -380,6 +380,33 @@ test('get topic channel spam threshold', async () => {
   expect(threshold).toBe(0.8)
 })
 
+test('get discovery probation days', async () => {
+  // flag off (seed default): null, discovery feeds stay unchanged
+  expect(await systemService.getDiscoveryProbationDays()).toBeNull()
+
+  // flag on without value: falls back to env default (3)
+  await systemService.setFeatureFlag({
+    name: FEATURE_NAME.discovery_probation,
+    flag: FEATURE_FLAG.on,
+  })
+  expect(await systemService.getDiscoveryProbationDays()).toBe(3)
+
+  // `value` overrides the env default
+  await systemService.setFeatureFlag({
+    name: FEATURE_NAME.discovery_probation,
+    flag: FEATURE_FLAG.on,
+    value: 7,
+  })
+  expect(await systemService.getDiscoveryProbationDays()).toBe(7)
+
+  // kill-switch: setFeature off restores null
+  await systemService.setFeatureFlag({
+    name: FEATURE_NAME.discovery_probation,
+    flag: FEATURE_FLAG.off,
+  })
+  expect(await systemService.getDiscoveryProbationDays()).toBeNull()
+})
+
 describe('announcement', () => {
   beforeEach(async () => {
     await atomService.deleteMany({ table: 'channel_announcement' })

--- a/src/connectors/__test__/tagService.test.ts
+++ b/src/connectors/__test__/tagService.test.ts
@@ -133,6 +133,79 @@ describe('findArticles', () => {
       data: { state: author?.state },
     })
   })
+  test('exclude articles by authors in discovery probation', async () => {
+    const articles = await tagService.findArticles({ id: '2' })
+    expect(articles.length).toBeGreaterThan(1)
+
+    // age all tag authors out of the probation window first
+    // (seed users are created at test run time, i.e. "new" accounts)
+    const authorIds: string[] = [
+      ...new Set<string>(
+        articles.map(({ authorId }: { authorId: string }) => authorId)
+      ),
+    ]
+    const originalCreatedAt: Record<string, Date> = {}
+    for (const authorId of authorIds) {
+      const author = await atomService.findUnique({
+        table: 'user',
+        where: { id: authorId },
+      })
+      originalCreatedAt[authorId] = author.createdAt
+      await atomService.update({
+        table: 'user',
+        where: { id: authorId },
+        data: { createdAt: new Date(Date.now() - 30 * 24 * 3600 * 1000) },
+      })
+    }
+
+    // make the target author a brand-new account (inside probation window)
+    const target = articles[0]
+    await atomService.update({
+      table: 'user',
+      where: { id: target.authorId },
+      data: { createdAt: new Date() },
+    })
+
+    // flag off (no probationDays passed): results identical to before
+    const unchanged = await tagService.findArticles({ id: '2' })
+    expect(toIds(unchanged)).toEqual(toIds(articles))
+
+    // flag on: new-account article is excluded, older accounts unaffected
+    const excluded = await tagService.findArticles({
+      id: '2',
+      probationDays: 3,
+    })
+    expect(toIds(excluded)).not.toContain(target.id)
+    expect(toIds(excluded)).toContain(articles[1].id)
+
+    // hottest tag tab follows the same rule
+    const hottestOff = await tagService.findHottestArticles('2')
+    expect(toIds(hottestOff)).toContain(target.id)
+    const hottestOn = await tagService.findHottestArticles('2', 3)
+    expect(toIds(hottestOn)).not.toContain(target.id)
+    expect(toIds(hottestOn)).toContain(articles[1].id)
+
+    // account older than the window is not affected
+    await atomService.update({
+      table: 'user',
+      where: { id: target.authorId },
+      data: { createdAt: new Date(Date.now() - 30 * 24 * 3600 * 1000) },
+    })
+    const included = await tagService.findArticles({
+      id: '2',
+      probationDays: 3,
+    })
+    expect(toIds(included)).toContain(target.id)
+
+    // restore original created_at to avoid leaking into other tests
+    for (const [authorId, createdAt] of Object.entries(originalCreatedAt)) {
+      await atomService.update({
+        table: 'user',
+        where: { id: authorId },
+        data: { createdAt },
+      })
+    }
+  })
 })
 
 test('create', async () => {

--- a/src/connectors/article/articleService.ts
+++ b/src/connectors/article/articleService.ts
@@ -40,6 +40,7 @@ import {
   excludeSpam as excludeSpamModifier,
   excludeRestrictedAuthors as excludeRestrictedModifier,
   excludeExclusiveCampaignArticles as excludeExclusiveCampaignArticlesModifier,
+  excludeProbationAuthors as excludeProbationModifier,
 } from '#common/utils/index.js'
 import DataLoader from 'dataloader'
 import { simplecc } from 'simplecc-wasm'
@@ -97,6 +98,7 @@ export class ArticleService extends BaseService<Article> {
       excludeExclusiveCampaignArticles,
       excludeChannelArticles,
       excludeComplaintAreaArticles,
+      excludeProbationAuthors,
       datetimeRange,
     }: {
       state?: ValueOf<typeof ARTICLE_STATE>
@@ -109,6 +111,8 @@ export class ArticleService extends BaseService<Article> {
       excludeExclusiveCampaignArticles?: boolean
       excludeChannelArticles?: boolean
       excludeComplaintAreaArticles?: boolean
+      // days; when set, exclude articles by authors younger than this
+      excludeProbationAuthors?: number
       datetimeRange?: { start: Date; end?: Date }
     } = { state: ARTICLE_STATE.active }
   ) => {
@@ -149,6 +153,10 @@ export class ArticleService extends BaseService<Article> {
 
     if (excludeExclusiveCampaignArticles) {
       query.modify(excludeExclusiveCampaignArticlesModifier)
+    }
+
+    if (excludeProbationAuthors) {
+      query.modify(excludeProbationModifier, excludeProbationAuthors)
     }
 
     if (excludeComplaintAreaArticles) {
@@ -192,10 +200,12 @@ export class ArticleService extends BaseService<Article> {
     spamThreshold,
     excludeChannelArticles,
     excludeExclusiveCampaignArticles,
+    probationDays,
   }: {
     spamThreshold?: number
     excludeChannelArticles?: boolean
     excludeExclusiveCampaignArticles?: boolean
+    probationDays?: number
   } = {}): Knex.QueryBuilder<Article, Article[]> => {
     const query = this.findArticles({
       state: ARTICLE_STATE.active,
@@ -208,6 +218,7 @@ export class ArticleService extends BaseService<Article> {
       excludeRestrictedAuthors: USER_RESTRICTION_TYPE.articleNewest,
       excludeChannelArticles,
       excludeExclusiveCampaignArticles,
+      excludeProbationAuthors: probationDays,
     })
     return query.orderBy('id', 'desc')
   }

--- a/src/connectors/channel/channelService.ts
+++ b/src/connectors/channel/channelService.ts
@@ -37,6 +37,7 @@ import {
   excludeSpam as excludeSpamModifier,
   excludeRestrictedAuthors as excludeRestrictedModifier,
   excludeStateRestrictedAuthors as excludeStateRestrictedModifier,
+  excludeProbationAuthors as excludeProbationModifier,
   excludeExclusiveCampaignArticles,
 } from '#common/utils/index.js'
 import { invalidateFQC } from '@matters/apollo-response-cache'
@@ -395,10 +396,13 @@ export class ChannelService {
 
     const pinnedArticleIds = channel.pinnedArticles || []
     const systemService = new SystemService(this.connections)
-    const [globalSpamThreshold, topicChannelSpamThreshold] = await Promise.all([
-      systemService.getSpamThreshold(),
-      systemService.getTopicChannelSpamThreshold(),
-    ])
+    const [globalSpamThreshold, topicChannelSpamThreshold, probationDays] =
+      await Promise.all([
+        systemService.getSpamThreshold(),
+        systemService.getTopicChannelSpamThreshold(),
+        // dark-launched discovery probation: `null` while flag is off (zero diff)
+        systemService.getDiscoveryProbationDays(),
+      ])
     const spamThreshold = topicChannelSpamThreshold ?? globalSpamThreshold
 
     const pinnedQuery = knexRO
@@ -442,6 +446,12 @@ export class ChannelService {
       })
       .modify(excludeRestrictedModifier)
       .modify(excludeStateRestrictedModifier)
+      .modify((builder) => {
+        // discovery probation (dark): only applied when the flag is on
+        if (probationDays) {
+          builder.modify(excludeProbationModifier, probationDays)
+        }
+      })
       .modify(excludeExclusiveCampaignArticles)
       .where((builder) => {
         if (channelThreshold) {

--- a/src/connectors/recommendationService.ts
+++ b/src/connectors/recommendationService.ts
@@ -25,6 +25,7 @@ import {
   ActionFailedError,
 } from '#common/errors.js'
 import { getLogger } from '#common/logger.js'
+import { excludeProbationAuthors as excludeProbationModifier } from '#common/utils/index.js'
 import { daysToDatetimeRange } from '#common/utils/time.js'
 import { quantile, median } from 'd3-array'
 import keyBy from 'lodash/keyBy.js'
@@ -347,6 +348,8 @@ export class RecommendationService {
       'article'
     )
     const spamThreshold = await this.systemService.getSpamThreshold()
+    // dark-launched discovery probation: `null` while flag is off (zero diff)
+    const probationDays = await this.systemService.getDiscoveryProbationDays()
     const startDate = new Date()
     startDate.setDate(startDate.getDate() - days)
 
@@ -365,6 +368,7 @@ export class RecommendationService {
                 excludeRestrictedAuthors: USER_RESTRICTION_TYPE.articleHottest,
                 excludeExclusiveCampaignArticles: true,
                 excludeComplaintAreaArticles: true,
+                excludeProbationAuthors: probationDays ?? undefined,
                 datetimeRange: {
                   start: startDate,
                 },
@@ -884,6 +888,8 @@ export class RecommendationService {
     skip?: number
   }) => {
     const MAX_ITEM_COUNT = DEFAULT_TAKE_PER_PAGE * 50
+    // dark-launched discovery probation: `null` while flag is off (zero diff)
+    const probationDays = await this.systemService.getDiscoveryProbationDays()
     const records = await this.knexRO
       .select(
         'article.*',
@@ -906,6 +912,11 @@ export class RecommendationService {
       )
       .leftJoin('article', 'choice.article_id', 'article.id')
       .where({ state: ARTICLE_STATE.active })
+      .modify((builder) => {
+        if (probationDays) {
+          builder.modify(excludeProbationModifier, probationDays)
+        }
+      })
       .modify((builder) => {
         if (skip !== undefined && Number.isFinite(skip)) {
           builder.offset(skip)

--- a/src/connectors/spamRingService.ts
+++ b/src/connectors/spamRingService.ts
@@ -237,17 +237,31 @@ export class SpamRingService extends BaseService<SpamRing> {
     ringId,
     actorId,
     remark,
+    memberUserIds,
     userService,
   }: {
     ringId: string
     actorId: string
     remark?: string | null
+    // 稽核 F1：本次偵測驗證過的成員（raw DB user id）。有給時凍結只作用於
+    // 「ring 成員 ∩ 此名單」；名單外成員記 skipped、不凍結、不發通知。
+    // 不給＝現行為（全成員，控制台人工一鍵）。
+    memberUserIds?: string[] | null
     userService: UserService
   }): Promise<{
     ring: SpamRing
     frozen: User[]
     skipped: Array<{ user: User; reason: string }>
   }> => {
+    // provided-but-empty is almost certainly a caller bug: it would mark every
+    // member skipped and still lock the ring as frozen — reject it instead.
+    if (memberUserIds && memberUserIds.length === 0) {
+      throw new UserInputError('memberUserIds must not be empty when provided')
+    }
+    const memberScope = memberUserIds
+      ? new Set(memberUserIds.map((id) => String(id)))
+      : null
+
     const frozen: User[] = []
     const skipped: Array<{ user: User; reason: string }> = []
 
@@ -299,6 +313,21 @@ export class SpamRingService extends BaseService<SpamRing> {
         // 本 ring 已凍結過此人 → idempotent，略過
         if (member.status === 'frozen' && member.bannedByThisRing) {
           frozen.push(user)
+          continue
+        }
+        // 稽核 F1：spam_ring_member 是歷次偵測的聯集（只增不減），可能含
+        // 歷史誤列的真人。成員不在本次驗證名單 → 只記 skipped，不凍結、
+        // 不發通知；下方既有護欄只對名單內成員照跑。
+        if (memberScope && !memberScope.has(String(member.userId))) {
+          await this.skipMember(
+            member.id,
+            user,
+            'not_in_verified_candidate',
+            actorId,
+            ringId,
+            trx
+          )
+          skipped.push({ user, reason: 'not_in_verified_candidate' })
           continue
         }
         if (user.state === USER_STATE.archived) {

--- a/src/connectors/systemService.ts
+++ b/src/connectors/systemService.ts
@@ -38,7 +38,7 @@ import {
   AUDIT_LOG_ACTION,
   AUDIT_LOG_STATUS,
 } from '#common/enums/index.js'
-import { isTest } from '#common/environment.js'
+import { environment, isTest } from '#common/environment.js'
 import { AssetNotFoundError, UserInputError } from '#common/errors.js'
 import { getLogger, auditLog } from '#common/logger.js'
 import { invalidateFQC } from '@matters/apollo-response-cache'
@@ -194,6 +194,38 @@ export class SystemService extends BaseService<BaseDBSchema> {
       return null
     }
     return threshold.value
+  }
+
+  /**
+   * Get the discovery probation window (days) from the `discovery_probation`
+   * feature flag. Returns `null` when the flag is off or missing, which means
+   * discovery feeds behave exactly as before (dark launch, zero diff).
+   * `feature_flag.value` overrides the env default when set.
+   */
+  public getDiscoveryProbationDays = async (): Promise<number | null> => {
+    const cache = new Cache(
+      CACHE_PREFIX.DISCOVERY_PROBATION_DAYS,
+      this.connections.objectCacheRedis
+    )
+    const value = (await cache.getObject({
+      keys: { id: 'discovery_probation_days' },
+      getter: this._getDiscoveryProbationDays,
+      expire: isTest ? CACHE_TTL.INSTANT : CACHE_TTL.SHORT,
+    })) as number | null
+    return value
+  }
+  private _getDiscoveryProbationDays = async (): Promise<number | null> => {
+    const featureFlag = await this.models.findFirst({
+      table: 'feature_flag',
+      where: {
+        name: FEATURE_NAME.discovery_probation,
+        flag: FEATURE_FLAG.on,
+      },
+    })
+    if (!featureFlag) {
+      return null
+    }
+    return featureFlag.value || environment.discoveryProbationDays
   }
 
   /**

--- a/src/connectors/tagService.ts
+++ b/src/connectors/tagService.ts
@@ -21,6 +21,7 @@ import {
   normalizeTagInput,
   excludeSpam as excludeSpamModifier,
   excludeStateRestrictedAuthors as excludeStateRestrictedModifier,
+  excludeProbationAuthors as excludeProbationModifier,
 } from '#common/utils/index.js'
 import _ from 'lodash'
 
@@ -451,7 +452,7 @@ export class TagService extends BaseService<Tag> {
     return parseInt(result ? (result.count as string) : '0', 10)
   }
 
-  public findHottestArticles = (tagId: string) => {
+  public findHottestArticles = (tagId: string, probationDays?: number) => {
     return this.knexRO
       .with('tagged_articles', (builder) =>
         builder
@@ -475,6 +476,12 @@ export class TagService extends BaseService<Tag> {
           // hide articles by authors in a restricted state (frozen / banned /
           // archived) from the public hottest tag feed
           .modify(excludeStateRestrictedModifier)
+          .modify((qb) => {
+            // discovery probation (dark): only applied when the flag is on
+            if (probationDays) {
+              qb.modify(excludeProbationModifier, probationDays)
+            }
+          })
       )
       .with('scored_articles', (builder) =>
         builder
@@ -536,10 +543,12 @@ export class TagService extends BaseService<Tag> {
     id: tagId,
     spamThreshold,
     excludeRestricted,
+    probationDays,
   }: {
     id: string
     spamThreshold?: number
     excludeRestricted?: boolean
+    probationDays?: number
   }) => {
     return this.knexRO
       .select(['article.*', 'article_tag.pinned as tag_pinned'])
@@ -561,6 +570,10 @@ export class TagService extends BaseService<Tag> {
         builder.modify(excludeStateRestrictedModifier)
         if (spamThreshold) {
           builder.modify(excludeSpamModifier, spamThreshold, 'article')
+        }
+        // discovery probation (dark): only applied when the flag is on
+        if (probationDays) {
+          builder.modify(excludeProbationModifier, probationDays)
         }
 
         builder.orderBy('article.id', 'desc')

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -1892,6 +1892,7 @@ export type GQLFeatureName =
   | 'article_channel'
   | 'circle_interact'
   | 'circle_management'
+  | 'discovery_probation'
   | 'fingerprint'
   | 'hottest_moment_feed'
   | 'payment'

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -1972,6 +1972,8 @@ export type GQLFollowingActivityEdge = {
 
 export type GQLFreezeSpamRingInput = {
   id: Scalars['ID']['input']
+  /** Restrict this freeze to these members (raw DB user ids, same semantics as SpamRingCandidateInput.memberUserIds). Members not listed are skipped, not frozen. Omit to process all members. Must be non-empty when provided. */
+  memberUserIds?: InputMaybe<Array<Scalars['String']['input']>>
   remark?: InputMaybe<Scalars['String']['input']>
 }
 

--- a/src/handlers/__test__/spamRingDigest.test.ts
+++ b/src/handlers/__test__/spamRingDigest.test.ts
@@ -1,0 +1,188 @@
+import type { SpamRingDigestStats } from '../spamRingDigest.js'
+
+import { jest } from '@jest/globals'
+
+// Minimal knex query-builder stub: each `knexRO('spam_ring')` call gets
+// the next queued result, matching the query order inside collectStats.
+const queuedResults: unknown[] = []
+const makeBuilder = (result: unknown) => {
+  const qb: any = {
+    where: () => qb,
+    count: () => qb,
+    orderBy: () => qb,
+    limit: () => qb,
+    first: async () => result,
+    select: async () => result,
+  }
+  return qb
+}
+const knexRO = jest.fn((_table: unknown) => makeBuilder(queuedResults.shift()))
+
+jest.unstable_mockModule('../../connections.js', () => ({
+  connections: { knexRO },
+}))
+
+// Mock axios BEFORE importing the SUT (ESM rule); the shared telegram
+// helper posts via axios.post.
+jest.unstable_mockModule('axios', () => ({
+  default: { post: jest.fn() },
+}))
+
+const { environment } = await import('#common/environment.js')
+const axios = (await import('axios')).default as unknown as {
+  post: jest.Mock<(...args: unknown[]) => unknown>
+}
+const { formatDigest, handler } = await import('../spamRingDigest.js')
+
+const makeStats = (
+  overrides: Partial<SpamRingDigestStats> = {}
+): SpamRingDigestStats => ({
+  pendingTotal: 3,
+  detectedLast24h: 2,
+  frozenLast24h: 1,
+  topPending: [
+    {
+      fingerprint: 'abcdef0123456789',
+      nAuthors: 12,
+      nArticles: 45,
+      newAccountRatio: 0.92,
+      severity: 'high',
+    },
+    {
+      fingerprint: 'ffff0000aaaa',
+      nAuthors: 4,
+      nArticles: 9,
+      newAccountRatio: null,
+      severity: null,
+    },
+  ],
+  ...overrides,
+})
+
+describe('formatDigest', () => {
+  it('renders counts, top pending rings and the console link', () => {
+    const text = formatDigest(makeStats())
+    expect(text).toContain('Spam Ring 日報')
+    expect(text).toContain('待處理 ring：3')
+    expect(text).toContain('近 24 小時新偵測：2')
+    expect(text).toContain('近 24 小時凍結：1')
+    // fingerprint truncated to first 8 chars, wrapped in <code>
+    expect(text).toContain('<code>abcdef01</code>')
+    expect(text).not.toContain('abcdef0123456789')
+    expect(text).toContain('成員 12')
+    expect(text).toContain('文章 45')
+    expect(text).toContain('新帳號比 92%')
+    expect(text).toContain('等級 高')
+    expect(text).toContain('href="https://oss.matters.town/next/rings"')
+  })
+
+  it('renders placeholders for missing ratio and severity', () => {
+    const text = formatDigest(makeStats())
+    expect(text).toContain('新帳號比 —')
+    expect(text).toContain('等級 —')
+  })
+
+  it('sends an all-clear one-liner when nothing is pending or new', () => {
+    const text = formatDigest(
+      makeStats({
+        pendingTotal: 0,
+        detectedLast24h: 0,
+        frozenLast24h: 0,
+        topPending: [],
+      })
+    )
+    expect(text).toContain('一切平安')
+    expect(text).not.toContain('待處理 Top')
+    // console link is always present
+    expect(text).toContain('href="https://oss.matters.town/next/rings"')
+  })
+
+  it('escapes HTML in fingerprints', () => {
+    const text = formatDigest(
+      makeStats({
+        topPending: [
+          {
+            fingerprint: '<script>',
+            nAuthors: 1,
+            nArticles: 1,
+            newAccountRatio: null,
+            severity: null,
+          },
+        ],
+      })
+    )
+    expect(text).not.toContain('<script>')
+    expect(text).toContain('&lt;script&gt;')
+  })
+})
+
+describe('handler', () => {
+  const originalTelegramBotToken = environment.telegramBotToken
+  const originalTelegramAlertChatId = environment.telegramAlertChatId
+  const originalTelegramAlertThreadId = environment.telegramAlertThreadId
+
+  beforeEach(() => {
+    axios.post.mockReset()
+    knexRO.mockClear()
+    queuedResults.length = 0
+    ;(environment as { telegramBotToken: string }).telegramBotToken = 'tkn'
+    ;(environment as { telegramAlertChatId: string }).telegramAlertChatId =
+      '-100'
+    ;(environment as { telegramAlertThreadId: string }).telegramAlertThreadId =
+      '42'
+  })
+
+  afterEach(() => {
+    ;(environment as { telegramBotToken: string }).telegramBotToken =
+      originalTelegramBotToken
+    ;(environment as { telegramAlertChatId: string }).telegramAlertChatId =
+      originalTelegramAlertChatId
+    ;(environment as { telegramAlertThreadId: string }).telegramAlertThreadId =
+      originalTelegramAlertThreadId
+  })
+
+  it('skips silently when telegram config is missing', async () => {
+    ;(environment as { telegramBotToken: string }).telegramBotToken = ''
+
+    await handler()
+
+    expect(knexRO).not.toHaveBeenCalled()
+    expect(axios.post).not.toHaveBeenCalled()
+  })
+
+  it('collects stats and posts the digest with thread id', async () => {
+    // query order in collectStats: pending / detected / frozen / top rows
+    queuedResults.push({ count: '3' }, { count: '2' }, { count: '1' }, [
+      {
+        fingerprint: 'abcdef0123456789',
+        nAuthors: 12,
+        nArticles: 45,
+        newAccountRatio: '0.92',
+        severity: 'high',
+      },
+    ])
+    axios.post.mockResolvedValueOnce({
+      data: { ok: true, result: { message_id: 7 } },
+    } as never)
+
+    await handler()
+
+    expect(axios.post).toHaveBeenCalledTimes(1)
+    const [url, body] = axios.post.mock.calls[0] as [
+      string,
+      Record<string, unknown>
+    ]
+    expect(url).toContain('/sendMessage')
+    expect(body).toMatchObject({
+      chat_id: '-100',
+      message_thread_id: 42,
+      parse_mode: 'HTML',
+      disable_web_page_preview: true,
+    })
+    const text = (body as { text: string }).text
+    expect(text).toContain('待處理 ring：3')
+    expect(text).toContain('<code>abcdef01</code>')
+    // pg numeric string is normalized before formatting
+    expect(text).toContain('新帳號比 92%')
+  })
+})

--- a/src/handlers/reportTelegramAlert.ts
+++ b/src/handlers/reportTelegramAlert.ts
@@ -3,6 +3,10 @@ import type { SQSEvent, SQSBatchResponse } from 'aws-lambda'
 
 import { environment } from '#common/environment.js'
 import { getLogger } from '#common/logger.js'
+import {
+  sendTelegramMessage,
+  TELEGRAM_API_TIMEOUT_MS,
+} from '#common/notifications/telegram.js'
 import * as Sentry from '@sentry/node'
 import axios from 'axios'
 
@@ -16,8 +20,6 @@ const logger = getLogger('handler-report-telegram-alert')
  * instead of posting a new one, so the admin chat doesn't get flooded.
  */
 const DEDUP_WINDOW_S = 60 * 60 * 24 // 24h
-
-const TELEGRAM_API_TIMEOUT_MS = 5000
 
 const SOURCE_LABELS: Record<ReportAlertRequested['source'], string> = {
   direct: '🚨 站內檢舉',
@@ -96,26 +98,6 @@ const isValidPayload = (raw: unknown): raw is ReportAlertRequested => {
   )
 }
 
-const sendMessage = async (
-  botToken: string,
-  chatId: string,
-  threadId: string,
-  text: string
-): Promise<number> => {
-  const resp = await axios.post(
-    `https://api.telegram.org/bot${botToken}/sendMessage`,
-    {
-      chat_id: chatId,
-      ...(threadId ? { message_thread_id: Number(threadId) } : {}),
-      text,
-      parse_mode: 'HTML',
-      disable_web_page_preview: true,
-    },
-    { timeout: TELEGRAM_API_TIMEOUT_MS }
-  )
-  return resp.data.result.message_id as number
-}
-
 const editMessage = async (
   botToken: string,
   chatId: string,
@@ -179,12 +161,12 @@ export const processRecord = async (
     }
   }
 
-  const messageId = await sendMessage(
+  const messageId = await sendTelegramMessage({
     botToken,
     chatId,
     threadId,
-    formatText({ ...payload, count: 1 })
-  )
+    text: formatText({ ...payload, count: 1 }),
+  })
   await redis.set(
     key,
     JSON.stringify({ messageId, count: 1 }),

--- a/src/handlers/spamRingDigest.ts
+++ b/src/handlers/spamRingDigest.ts
@@ -1,0 +1,155 @@
+import type { SpamRingSeverity } from '#definitions/index.js'
+
+import { environment } from '#common/environment.js'
+import { getLogger } from '#common/logger.js'
+import { sendTelegramMessage } from '#common/notifications/telegram.js'
+
+import { connections } from '../connections.js'
+
+const logger = getLogger('handler-spam-ring-digest')
+
+const OSS_RINGS_URL = 'https://oss.matters.town/next/rings'
+const LOOKBACK_MS = 24 * 60 * 60 * 1000
+const TOP_PENDING_LIMIT = 5
+const FINGERPRINT_DISPLAY_LENGTH = 8
+
+export type SpamRingDigestTopRing = {
+  fingerprint: string
+  nAuthors: number
+  nArticles: number
+  newAccountRatio: number | null
+  severity: SpamRingSeverity | null
+}
+
+export type SpamRingDigestStats = {
+  pendingTotal: number
+  detectedLast24h: number
+  frozenLast24h: number
+  topPending: SpamRingDigestTopRing[]
+}
+
+const SEVERITY_LABELS: Record<SpamRingSeverity, string> = {
+  low: '低',
+  medium: '中',
+  high: '高',
+  critical: '嚴重',
+}
+
+/** Escape dynamic text for Telegram HTML parse mode. */
+const escapeHtml = (text: string): string =>
+  text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+
+const formatRatio = (ratio: number | null): string =>
+  ratio === null ? '—' : `${Math.round(ratio * 100)}%`
+
+const formatSeverity = (severity: SpamRingSeverity | null): string =>
+  severity ? SEVERITY_LABELS[severity] ?? severity : '—'
+
+/**
+ * Render the daily spam-ring digest as Telegram HTML.
+ * Pure function (stats in, string out) so layout is unit-testable
+ * without a database or the Telegram API.
+ */
+export const formatDigest = (stats: SpamRingDigestStats): string => {
+  const lines: string[] = ['<b>🕸️ Spam Ring 日報</b>']
+
+  if (stats.pendingTotal === 0 && stats.detectedLast24h === 0) {
+    // All-clear one-liner: still send so admins know the job ran.
+    lines.push('過去 24 小時無新偵測，也沒有待處理的 ring，一切平安。')
+  } else {
+    lines.push(
+      `待處理 ring：${stats.pendingTotal}`,
+      `近 24 小時新偵測：${stats.detectedLast24h}`,
+      `近 24 小時凍結：${stats.frozenLast24h}`
+    )
+    if (stats.topPending.length > 0) {
+      lines.push('', `<b>待處理 Top ${TOP_PENDING_LIMIT}（依成員數）</b>`)
+      stats.topPending.forEach((ring, index) => {
+        const fingerprint = escapeHtml(
+          ring.fingerprint.slice(0, FINGERPRINT_DISPLAY_LENGTH)
+        )
+        lines.push(
+          `${index + 1}. <code>${fingerprint}</code>` +
+            `｜成員 ${ring.nAuthors}` +
+            `｜文章 ${ring.nArticles}` +
+            `｜新帳號比 ${formatRatio(ring.newAccountRatio)}` +
+            `｜等級 ${formatSeverity(ring.severity)}`
+        )
+      })
+    }
+  }
+
+  lines.push('', `<a href="${OSS_RINGS_URL}">前往控制台處理</a>`)
+  return lines.join('\n')
+}
+
+const toCount = (row: unknown): number =>
+  Number((row as { count?: string | number } | undefined)?.count ?? 0)
+
+/** Read-only aggregation over the spam_ring table (replica connection). */
+export const collectStats = async (): Promise<SpamRingDigestStats> => {
+  const knexRO = connections.knexRO
+  const since = new Date(Date.now() - LOOKBACK_MS)
+
+  const [pendingRow, detectedRow, frozenRow, topRows] = await Promise.all([
+    knexRO('spam_ring').where({ status: 'pending' }).count().first(),
+    knexRO('spam_ring').where('detectedAt', '>=', since).count().first(),
+    knexRO('spam_ring').where('frozenAt', '>=', since).count().first(),
+    knexRO('spam_ring')
+      .where({ status: 'pending' })
+      .orderBy('nAuthors', 'desc')
+      .limit(TOP_PENDING_LIMIT)
+      .select(
+        'fingerprint',
+        'nAuthors',
+        'nArticles',
+        'newAccountRatio',
+        'severity'
+      ),
+  ])
+
+  return {
+    pendingTotal: toCount(pendingRow),
+    detectedLast24h: toCount(detectedRow),
+    frozenLast24h: toCount(frozenRow),
+    topPending: (topRows as SpamRingDigestTopRing[]).map((row) => ({
+      fingerprint: row.fingerprint,
+      nAuthors: Number(row.nAuthors),
+      nArticles: Number(row.nArticles),
+      // pg returns numeric columns as strings; normalize for formatting
+      newAccountRatio:
+        row.newAccountRatio === null ? null : Number(row.newAccountRatio),
+      severity: row.severity,
+    })),
+  }
+}
+
+/**
+ * Cron-invoked Lambda handler: post the daily spam-ring digest to the
+ * admin Telegram chat. Read-only; scheduling (EventBridge) is wired on
+ * the infra side and is NOT part of this repo.
+ */
+export const handler = async (): Promise<void> => {
+  const botToken = environment.telegramBotToken
+  const chatId = environment.telegramAlertChatId
+  const threadId = environment.telegramAlertThreadId
+
+  // Cron trigger has no SQS retry semantics; missing config is a no-op.
+  if (!botToken || !chatId) {
+    logger.warn('spam-ring-digest: missing telegram config; skipped')
+    return
+  }
+
+  const stats = await collectStats()
+  await sendTelegramMessage({
+    botToken,
+    chatId,
+    threadId,
+    text: formatDigest(stats),
+  })
+  logger.info('spam-ring-digest sent: %j', {
+    pendingTotal: stats.pendingTotal,
+    detectedLast24h: stats.detectedLast24h,
+    frozenLast24h: stats.frozenLast24h,
+  })
+}

--- a/src/mutations/user/freezeSpamRing.ts
+++ b/src/mutations/user/freezeSpamRing.ts
@@ -7,7 +7,7 @@ import { invalidateUserContentCaches } from './utils.js'
 
 const resolver: GQLMutationResolvers['freezeSpamRing'] = async (
   _,
-  { input: { id, remark } },
+  { input: { id, remark, memberUserIds } },
   {
     viewer,
     dataSources: {
@@ -26,6 +26,8 @@ const resolver: GQLMutationResolvers['freezeSpamRing'] = async (
     ringId,
     actorId: viewer.id,
     remark,
+    // audit F1: restrict the freeze to members verified by this detection run
+    memberUserIds,
     userService,
   })
 

--- a/src/queries/article/tag/articles.ts
+++ b/src/queries/article/tag/articles.ts
@@ -9,11 +9,14 @@ const resolver: GQLTagResolvers['articles'] = async (
 ) => {
   const { sortBy } = input
   const spamThreshold = (await systemService.getSpamThreshold()) ?? undefined
+  // dark-launched discovery probation: `undefined` while flag is off (zero diff)
+  const probationDays =
+    (await systemService.getDiscoveryProbationDays()) ?? undefined
   const isHottest = sortBy === 'byHottestDesc'
 
   const query = isHottest
-    ? tagService.findHottestArticles(id)
-    : tagService.findArticles({ id, spamThreshold })
+    ? tagService.findHottestArticles(id, probationDays)
+    : tagService.findArticles({ id, spamThreshold, probationDays })
   const orderBy = { column: isHottest ? 'score' : 'id', order: 'desc' as const }
 
   const result = await connectionFromQuery({ query, args: input, orderBy })

--- a/src/queries/user/recommendation/newest.ts
+++ b/src/queries/user/recommendation/newest.ts
@@ -33,10 +33,13 @@ export const newest: GQLRecommendationResolvers['newest'] = async (
   }
 
   const spamThreshold = await systemService.getSpamThreshold()
+  // dark-launched discovery probation: `null` while flag is off (zero diff)
+  const probationDays = await systemService.getDiscoveryProbationDays()
   const query = articleService.findNewestArticles({
     spamThreshold: spamThreshold ?? undefined,
     excludeChannelArticles: true,
     excludeExclusiveCampaignArticles: true,
+    probationDays: probationDays ?? undefined,
   })
 
   return connectionFromQuery({

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -687,6 +687,7 @@ export default /* GraphQL */ `
     topic_channel_spam_filter
     article_channel
     hottest_moment_feed
+    discovery_probation
   }
 
   enum FeatureFlag {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -841,6 +841,8 @@ export default /* GraphQL */ `
   input FreezeSpamRingInput {
     id: ID!
     remark: String
+    "Restrict this freeze to these members (raw DB user ids, same semantics as SpamRingCandidateInput.memberUserIds). Members not listed are skipped, not frozen. Omit to process all members. Must be non-empty when provided."
+    memberUserIds: [String!]
   }
 
   type FreezeSpamRingResult {


### PR DESCRIPTION
## Whole-branch promote（develop → master）

本次 develop 領先 master 的內容**全部**來自 spam-ring v2（SPEC：spam-detection-scaffold `docs/SPEC_RING_V2.md`），無其他未完成工作：

| PR | 內容 | 上線後行為 |
|---|---|---|
| #4914 | Telegram 日報 handler（`spamRingDigest`）＋共用 `sendTelegramMessage`＋upsert rings 契約測試＋`test:handlers` CI 缺口修補 | **Inert**——handler 未接排程前不執行；reportTelegramAlert 重構零行為變化（審查逐行驗證） |
| #4915 | 新帳號發現面觀察期（hottest/newest/icymi/tag/channel） | **Dark**——flag `discovery_probation` 預設 off，零行為變化（flag-off 測試＋審查驗證）；kill-switch=setFeature off |
| #4916 | `FreezeSpamRingInput.memberUserIds` 交集凍結（security gate F1 修復） | **Additive**——不帶參數＝現行為，控制台人工一鍵不變；`member_skipped` 已確認在 event constraint 內 |

## 部署後續

1. 本 PR merge → deploy-eb-production → **AUTO_FREEZE 前置 ②（#4916 上 prod）達成**
2. infra：建立日報 Lambda＋每日排程（建議 01:00 UTC＝台北 09:00）
3. AUTO_FREEZE：首週人工抽查 FREEZE 決策無誤傷後，於 CodeBuild `spam-vpc-runner` 設 `AUTO_FREEZE=1`
4. 觀察期 flag：staging 驗收＋產品拍板 N 天後再開

🤖 Generated with [Claude Code](https://claude.com/claude-code)