### PR TITLE
[codex] Deploy spam ring digest Lambda

### DIFF
--- a/.github/workflows/lambda-deploy.yml
+++ b/.github/workflows/lambda-deploy.yml
@@ -574,6 +574,30 @@ jobs:
             lambdaMemorySize=512,
             cronExpression="cron(0 1 * * ? *)"
 
+  deploy-spam-ring-digest:
+    needs: build-lambda-image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@master
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Deploy Lambda
+        uses: aws-actions/aws-cloudformation-github-deploy@v1
+        with:
+          name: spam-ring-digest-${{ inputs.environment }}
+          template: ./deployment/lambda/cronjob.yml
+          parameter-overrides: >-
+            mattersEnv=${{ env.MATTERS_ENV }},
+            imageUri=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:matters-server-${{ github.SHA }},
+            lambdaCMD=spamRingDigest.handler,
+            lambdaTimeout=900,
+            lambdaMemorySize=512,
+            cronExpression="cron(0 1 * * ? *)"
+
   deploy-user-retention:
     needs: build-lambda-image
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- add `deploy-spam-ring-digest` to `lambda-deploy.yml`
- deploy `spamRingDigest.handler` through the existing cronjob Lambda template
- schedule it at `cron(0 1 * * ? *)`, matching 09:00 Taipei time

## Why

`spamRingDigest.ts` is present on `origin/master`, but the deploy workflow did not include a Lambda deployment entry for `spamRingDigest.handler`. That means the daily Telegram digest can exist in code while not being formally scheduled or deployed, which matches the stale operator-room symptom.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file("/Users/mashbean/Developer/repos/matters-server/.github/workflows/lambda-deploy.yml"); puts "yaml ok"'`
- existing pre-commit hook completed `eslint`, `tsc`, schema generation, codegen, and prettier checks during commit

## Release note

This PR targets `master` as a production deploy-path repair. After merge, back-merge the workflow change into `develop` so the branch model stays aligned.

## Ops note

AWS CLI in the local Codex session reports an expired session, so I could not verify whether a manually-created EventBridge rule already exists. If this PR merges, the normal Deploy workflow should create/update `spam-ring-digest-production` through CloudFormation.