### PR TITLE
fix(feed): exclude frozen authors from recommendation surfaces

### DIFF
--- a/src/common/utils/__test__/spamRingResolvers.test.ts
+++ b/src/common/utils/__test__/spamRingResolvers.test.ts
@@ -37,7 +37,11 @@ const makeContext = (viewer: any = { id: '9' }) => {
     dataSources: {
       userService,
       articleService: { findByAuthor: jest.fn(async () => []) },
-      connections: { redis: { __sentinel: 'redis' } },
+      atomService: { findMany: jest.fn(async () => []) },
+      connections: {
+        redis: { __sentinel: 'redis' },
+        objectCacheRedis: { del: jest.fn(async () => 1) },
+      },
       spamRingService: {
         freezeRing: jest.fn(async () => ({
           ring: {},
@@ -149,6 +153,8 @@ describe('spam ring mutation resolvers', () => {
     expect(ctx.dataSources.articleService.findByAuthor).toHaveBeenCalledWith(
       '12'
     )
+    // the recommended-authors pool cache is also dropped
+    expect(ctx.dataSources.connections.objectCacheRedis.del).toHaveBeenCalled()
   })
 
   test('unfreezeSpamRing purges caches of restored members', async () => {
@@ -166,6 +172,8 @@ describe('spam ring mutation resolvers', () => {
     expect(ctx.dataSources.articleService.findByAuthor).toHaveBeenCalledWith(
       '21'
     )
+    // the recommended-authors pool cache is also dropped
+    expect(ctx.dataSources.connections.objectCacheRedis.del).toHaveBeenCalled()
   })
 
   test('freezeSpamRing rejects when viewer has no id', async () => {

--- a/src/connectors/__test__/articleService/articleService.test.ts
+++ b/src/connectors/__test__/articleService/articleService.test.ts
@@ -424,6 +424,28 @@ describe('latestArticles', () => {
     expect(articles[0].authorId).toBeDefined()
     expect(articles[0].state).toBeDefined()
   })
+  test('state-restricted authors are excluded', async () => {
+    const articles = await articleService.findNewestArticles()
+    const targetAuthorId = articles[0].authorId
+
+    await atomService.update({
+      table: 'user',
+      where: { id: targetAuthorId },
+      data: { state: USER_STATE.frozen },
+    })
+    const excluded = await articleService.findNewestArticles()
+    expect(excluded.map(({ authorId }) => authorId)).not.toContain(
+      targetAuthorId
+    )
+
+    await atomService.update({
+      table: 'user',
+      where: { id: targetAuthorId },
+      data: { state: USER_STATE.active },
+    })
+    const restored = await articleService.findNewestArticles()
+    expect(restored.map(({ authorId }) => authorId)).toContain(targetAuthorId)
+  })
   test('spam are excluded', async () => {
     const articles = await articleService.findNewestArticles({
       spamThreshold: 0.5,

--- a/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
+++ b/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
@@ -1,6 +1,6 @@
 import type { Connections, Article, TopicChannel } from '#definitions/index.js'
 
-import { FEATURE_FLAG, FEATURE_NAME } from '#common/enums/index.js'
+import { FEATURE_FLAG, FEATURE_NAME, USER_STATE } from '#common/enums/index.js'
 import { AtomService } from '../../atomService.js'
 import { CampaignService } from '../../campaignService.js'
 import { ChannelService } from '../../channel/channelService.js'
@@ -117,6 +117,36 @@ describe('findTopicChannelArticles', () => {
     expect(results).toHaveLength(4)
     expect(results[0].id).toBe(articles[0].id) // Pinned should be first
     expect(results[1].id).not.toBe(articles[0].id) // Rest should be unpinned
+  })
+
+  test('pinned articles by state-restricted authors are excluded', async () => {
+    await atomService.update({
+      table: 'topic_channel',
+      where: { id: channel.id },
+      data: { pinnedArticles: [articles[0].id] },
+    })
+    const pinnedAuthorId = articles[0].authorId
+
+    await atomService.update({
+      table: 'user',
+      where: { id: pinnedAuthorId },
+      data: { state: USER_STATE.frozen },
+    })
+    const { query } = await channelService.findTopicChannelArticles(channel.id)
+    const results = await query
+    expect(results.map(({ authorId }) => authorId)).not.toContain(
+      pinnedAuthorId
+    )
+
+    await atomService.update({
+      table: 'user',
+      where: { id: pinnedAuthorId },
+      data: { state: USER_STATE.active },
+    })
+    const { query: restoredQuery } =
+      await channelService.findTopicChannelArticles(channel.id)
+    const restored = await restoredQuery
+    expect(restored.map(({ id }) => id)).toContain(articles[0].id)
   })
 
   test('orders pinned articles by pinnedArticles array order', async () => {

--- a/src/connectors/article/articleService.ts
+++ b/src/connectors/article/articleService.ts
@@ -39,6 +39,7 @@ import {
 import {
   excludeSpam as excludeSpamModifier,
   excludeRestrictedAuthors as excludeRestrictedModifier,
+  excludeStateRestrictedAuthors as excludeStateRestrictedModifier,
   excludeExclusiveCampaignArticles as excludeExclusiveCampaignArticlesModifier,
   excludeProbationAuthors as excludeProbationModifier,
 } from '#common/utils/index.js'
@@ -215,19 +216,16 @@ export class ArticleService extends BaseService<Article> {
             spamThreshold,
           }
         : undefined,
-      // freezing only flips user.state, not user_restriction, so the
-      // restricted-authors filter alone still surfaces frozen accounts in
-      // newest / recommended-authors / recommended-tags pools
-      excludeAuthorStates: [
-        USER_STATE.frozen,
-        USER_STATE.banned,
-        USER_STATE.archived,
-      ],
       excludeRestrictedAuthors: USER_RESTRICTION_TYPE.articleNewest,
       excludeChannelArticles,
       excludeExclusiveCampaignArticles,
       excludeProbationAuthors: probationDays,
     })
+    // freezing only flips user.state, not user_restriction, so the
+    // restricted-authors filter alone still surfaces frozen accounts in
+    // newest / recommended-authors / recommended-tags pools; the correlated
+    // modifier probes user pkey per row instead of scanning the user table
+    excludeStateRestrictedModifier(query)
     return query.orderBy('id', 'desc')
   }
 

--- a/src/connectors/article/articleService.ts
+++ b/src/connectors/article/articleService.ts
@@ -215,6 +215,14 @@ export class ArticleService extends BaseService<Article> {
             spamThreshold,
           }
         : undefined,
+      // freezing only flips user.state, not user_restriction, so the
+      // restricted-authors filter alone still surfaces frozen accounts in
+      // newest / recommended-authors / recommended-tags pools
+      excludeAuthorStates: [
+        USER_STATE.frozen,
+        USER_STATE.banned,
+        USER_STATE.archived,
+      ],
       excludeRestrictedAuthors: USER_RESTRICTION_TYPE.articleNewest,
       excludeChannelArticles,
       excludeExclusiveCampaignArticles,

--- a/src/connectors/channel/channelService.ts
+++ b/src/connectors/channel/channelService.ts
@@ -418,6 +418,10 @@ export class ChannelService {
         'article.channel_enabled': true,
       })
       .whereIn('article.id', pinnedArticleIds)
+    // pinning happens before an author may get frozen; keep parity with the
+    // unpinned query below (applied outside the chain so knex's loosely-typed
+    // `.modify()` does not widen the query's row type)
+    excludeStateRestrictedModifier(pinnedQuery)
 
     const unpinnedQuery = knexRO
       .select(

--- a/src/connectors/recommendationService.ts
+++ b/src/connectors/recommendationService.ts
@@ -25,7 +25,10 @@ import {
   ActionFailedError,
 } from '#common/errors.js'
 import { getLogger } from '#common/logger.js'
-import { excludeProbationAuthors as excludeProbationModifier } from '#common/utils/index.js'
+import {
+  excludeProbationAuthors as excludeProbationModifier,
+  excludeStateRestrictedAuthors as excludeStateRestrictedModifier,
+} from '#common/utils/index.js'
 import { daysToDatetimeRange } from '#common/utils/time.js'
 import { quantile, median } from 'd3-array'
 import keyBy from 'lodash/keyBy.js'
@@ -912,6 +915,9 @@ export class RecommendationService {
       )
       .leftJoin('article', 'choice.article_id', 'article.id')
       .where({ state: ARTICLE_STATE.active })
+      // matters_choice is curated before an author may get frozen, so the
+      // author state must be re-checked at read time
+      .modify(excludeStateRestrictedModifier)
       .modify((builder) => {
         if (probationDays) {
           builder.modify(excludeProbationModifier, probationDays)

--- a/src/mutations/user/freezeSpamRing.ts
+++ b/src/mutations/user/freezeSpamRing.ts
@@ -3,7 +3,10 @@ import type { GQLMutationResolvers } from '#definitions/index.js'
 import { ForbiddenError } from '#common/errors.js'
 import { fromGlobalId } from '#common/utils/index.js'
 
-import { invalidateUserContentCaches } from './utils.js'
+import {
+  invalidateRecommendationAuthorsCache,
+  invalidateUserContentCaches,
+} from './utils.js'
 
 const resolver: GQLMutationResolvers['freezeSpamRing'] = async (
   _,
@@ -14,7 +17,8 @@ const resolver: GQLMutationResolvers['freezeSpamRing'] = async (
       spamRingService,
       userService,
       articleService,
-      connections: { redis },
+      atomService,
+      connections: { redis, objectCacheRedis },
     },
   }
 ) => {
@@ -35,6 +39,12 @@ const resolver: GQLMutationResolvers['freezeSpamRing'] = async (
   // responses so frozen members' content stops being served
   for (const user of result.frozen) {
     await invalidateUserContentCaches(user.id, { articleService, redis })
+  }
+  if (result.frozen.length > 0) {
+    await invalidateRecommendationAuthorsCache({
+      atomService,
+      objectCacheRedis,
+    })
   }
 
   return result

--- a/src/mutations/user/unfreezeSpamRing.ts
+++ b/src/mutations/user/unfreezeSpamRing.ts
@@ -3,7 +3,10 @@ import type { GQLMutationResolvers } from '#definitions/index.js'
 import { ForbiddenError } from '#common/errors.js'
 import { fromGlobalId } from '#common/utils/index.js'
 
-import { invalidateUserContentCaches } from './utils.js'
+import {
+  invalidateRecommendationAuthorsCache,
+  invalidateUserContentCaches,
+} from './utils.js'
 
 const resolver: GQLMutationResolvers['unfreezeSpamRing'] = async (
   _,
@@ -14,7 +17,8 @@ const resolver: GQLMutationResolvers['unfreezeSpamRing'] = async (
       spamRingService,
       userService,
       articleService,
-      connections: { redis },
+      atomService,
+      connections: { redis, objectCacheRedis },
     },
   }
 ) => {
@@ -32,6 +36,12 @@ const resolver: GQLMutationResolvers['unfreezeSpamRing'] = async (
   // responses so restored members' content shows up again promptly
   for (const user of result.unbanned) {
     await invalidateUserContentCaches(user.id, { articleService, redis })
+  }
+  if (result.unbanned.length > 0) {
+    await invalidateRecommendationAuthorsCache({
+      atomService,
+      objectCacheRedis,
+    })
   }
 
   return result

--- a/src/mutations/user/updateUserState.ts
+++ b/src/mutations/user/updateUserState.ts
@@ -4,7 +4,10 @@ import { USER_STATE } from '#common/enums/index.js'
 import { ActionFailedError, UserInputError } from '#common/errors.js'
 import { fromGlobalId } from '#common/utils/index.js'
 
-import { invalidateUserContentCaches } from './utils.js'
+import {
+  invalidateRecommendationAuthorsCache,
+  invalidateUserContentCaches,
+} from './utils.js'
 
 const resolver: GQLMutationResolvers['updateUserState'] = async (
   _,
@@ -16,15 +19,20 @@ const resolver: GQLMutationResolvers['updateUserState'] = async (
       articleService,
       notificationService,
       atomService,
-      connections: { redis },
+      connections: { redis, objectCacheRedis },
       queues: { userQueue },
     },
   }
 ) => {
   const id = globalId ? fromGlobalId(globalId).id : undefined
 
-  const invalidateUserCaches = (userId: string) =>
-    invalidateUserContentCaches(userId, { articleService, redis })
+  const invalidateUserCaches = async (userId: string) => {
+    await invalidateUserContentCaches(userId, { articleService, redis })
+    await invalidateRecommendationAuthorsCache({
+      atomService,
+      objectCacheRedis,
+    })
+  }
 
   /**
    * archive

--- a/src/mutations/user/utils.ts
+++ b/src/mutations/user/utils.ts
@@ -1,7 +1,8 @@
-import type { ArticleService } from '#connectors/index.js'
+import type { ArticleService, AtomService } from '#connectors/index.js'
 import type { Redis } from 'ioredis'
 
-import { NODE_TYPES } from '#common/enums/index.js'
+import { CACHE_PREFIX, NODE_TYPES } from '#common/enums/index.js'
+import { Cache } from '#connectors/cache/index.js'
 import { invalidateFQC } from '@matters/apollo-response-cache'
 
 // purge cached public query responses of a user and their articles after a
@@ -22,6 +23,33 @@ export const invalidateUserContentCaches = async (
     await invalidateFQC({
       node: { type: NODE_TYPES.Article, id: article.id },
       redis,
+    })
+  }
+}
+
+// the recommended-authors pool (值得追蹤) is cached outside FQC with
+// CACHE_TTL.LONG, one key per channel plus a sitewide one; drop all of them
+// after a state change so a frozen author leaves (or an unfrozen one
+// re-enters) the pool without waiting out the TTL
+export const invalidateRecommendationAuthorsCache = async ({
+  atomService,
+  objectCacheRedis,
+}: {
+  atomService: AtomService
+  objectCacheRedis: Redis
+}) => {
+  const cache = new Cache(CACHE_PREFIX.RECOMMENDATION_AUTHORS, objectCacheRedis)
+  const channels = await atomService.findMany({
+    table: 'topic_channel',
+    select: ['id'],
+  })
+  const channelIds: Array<string | undefined> = [
+    undefined, // sitewide key
+    ...channels.map(({ id }) => id),
+  ]
+  for (const channelId of channelIds) {
+    await cache.removeObject({
+      keys: { type: 'recommendationAuthors', args: { channelId } },
     })
   }
 }

--- a/src/queries/user/recommendation/authors.ts
+++ b/src/queries/user/recommendation/authors.ts
@@ -1,6 +1,6 @@
 import type { GQLRecommendationResolvers } from '#definitions/index.js'
 
-import { CACHE_PREFIX, CACHE_TTL } from '#common/enums/index.js'
+import { CACHE_PREFIX, CACHE_TTL, USER_STATE } from '#common/enums/index.js'
 import { ForbiddenError } from '#common/errors.js'
 import {
   connectionFromArray,
@@ -77,8 +77,21 @@ export const authors: GQLRecommendationResolvers['authors'] = async (
   const chunks = circleChunk(filtered, draw)
   const index = Math.min(filter?.random || 0, limit, chunks.length - 1)
   const randomAuthorIds = chunks[index] || []
-  const randomAuthors = await atomService.userIdLoader.loadMany(
+  const loadedAuthors = await atomService.userIdLoader.loadMany(
     randomAuthorIds.map(({ authorId }) => authorId)
+  )
+  // the cached pool may predate a freeze (CACHE_TTL.LONG), so author state
+  // must be re-checked at read time
+  const restrictedStates: string[] = [
+    USER_STATE.frozen,
+    USER_STATE.banned,
+    USER_STATE.archived,
+  ]
+  const randomAuthors = loadedAuthors.filter(
+    (author) =>
+      author &&
+      !(author instanceof Error) &&
+      !restrictedStates.includes(author.state)
   )
   return connectionFromArray(randomAuthors, input, authorIds.length)
 }

--- a/src/types/__test__/2/recommendation/authors.test.ts
+++ b/src/types/__test__/2/recommendation/authors.test.ts
@@ -1,8 +1,13 @@
 import type { Connections } from '#definitions/index.js'
 
-import { MATERIALIZED_VIEW, NODE_TYPES } from '#common/enums/index.js'
+import {
+  CACHE_PREFIX,
+  MATERIALIZED_VIEW,
+  NODE_TYPES,
+  USER_STATE,
+} from '#common/enums/index.js'
 import { refreshView } from '#connectors/__test__/utils.js'
-import { ChannelService } from '#connectors/index.js'
+import { AtomService, Cache, ChannelService } from '#connectors/index.js'
 import { toGlobalId } from '#common/utils/index.js'
 
 import { testClient, genConnections, closeConnections } from '../../utils.js'
@@ -99,5 +104,118 @@ describe('authors', () => {
       },
     })
     expect(errors2).toBeUndefined()
+  })
+
+  test('state-restricted authors are excluded at read time even when cached', async () => {
+    const atomService = new AtomService(connections)
+    // two non-viewer authors from seeds, forced to a known baseline state
+    const [activeAuthor, toFreezeAuthor] = await atomService.findMany({
+      table: 'user',
+      whereIn: ['id', ['2', '3']],
+      orderBy: [{ column: 'id', order: 'asc' }],
+    })
+    for (const { id } of [activeAuthor, toFreezeAuthor]) {
+      await atomService.update({
+        table: 'user',
+        where: { id },
+        data: { state: USER_STATE.active },
+      })
+    }
+    const cache = new Cache(
+      CACHE_PREFIX.RECOMMENDATION_AUTHORS,
+      connections.objectCacheRedis
+    )
+    // simulate a pool cached before the freeze happened
+    await cache.storeObject({
+      keys: { type: 'recommendationAuthors', args: { channelId: undefined } },
+      data: [{ authorId: activeAuthor.id }, { authorId: toFreezeAuthor.id }],
+      expire: 60,
+    })
+    await atomService.update({
+      table: 'user',
+      where: { id: toFreezeAuthor.id },
+      data: { state: USER_STATE.frozen },
+    })
+
+    const server = await testClient({ isAuth: true, connections })
+    const { errors, data } = await server.executeOperation({
+      query: GET_AUTHOR_RECOMMENDATION,
+      variables: { input: { first: 5 } },
+    })
+    expect(errors).toBeUndefined()
+    const ids = data.viewer.recommendation.authors.edges.map(
+      ({ node }: { node: { id: string } }) => node.id
+    )
+    expect(ids).toContain(
+      toGlobalId({ type: NODE_TYPES.User, id: activeAuthor.id })
+    )
+    expect(ids).not.toContain(
+      toGlobalId({ type: NODE_TYPES.User, id: toFreezeAuthor.id })
+    )
+
+    await atomService.update({
+      table: 'user',
+      where: { id: toFreezeAuthor.id },
+      data: { state: USER_STATE.active },
+    })
+  })
+
+  test('freezing a user purges the recommended-authors cache', async () => {
+    const atomService = new AtomService(connections)
+    const target = await atomService.findUnique({
+      table: 'user',
+      where: { id: '3' },
+    })
+    await atomService.update({
+      table: 'user',
+      where: { id: target.id },
+      data: { state: USER_STATE.active },
+    })
+    const cache = new Cache(
+      CACHE_PREFIX.RECOMMENDATION_AUTHORS,
+      connections.objectCacheRedis
+    )
+    const sitewideKey = cache.genKey({
+      type: 'recommendationAuthors',
+      args: { channelId: undefined },
+    })
+    await cache.storeObject({
+      keys: { type: 'recommendationAuthors', args: { channelId: undefined } },
+      data: [{ authorId: target.id }],
+      expire: 60,
+    })
+
+    const server = await testClient({
+      isAuth: true,
+      isAdmin: true,
+      connections,
+    })
+    const UPDATE_USER_STATE = /* GraphQL */ `
+      mutation ($input: UpdateUserStateInput!) {
+        updateUserState(input: $input) {
+          id
+          status {
+            state
+          }
+        }
+      }
+    `
+    const { errors } = await server.executeOperation({
+      query: UPDATE_USER_STATE,
+      variables: {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.User, id: target.id }),
+          state: 'frozen',
+        },
+      },
+    })
+    expect(errors).toBeUndefined()
+    expect(await connections.objectCacheRedis.get(sitewideKey)).toBeNull()
+
+    await atomService.update({
+      table: 'user',
+      where: { id: target.id },
+      data: { state: USER_STATE.active },
+    })
   })
 })

--- a/src/types/__test__/2/recommendation/icymi.test.ts
+++ b/src/types/__test__/2/recommendation/icymi.test.ts
@@ -6,6 +6,7 @@ import {
   NODE_TYPES,
   MATTERS_CHOICE_TOPIC_STATE,
   LANGUAGE,
+  USER_STATE,
 } from '#common/enums/index.js'
 import { RecommendationService, AtomService } from '#connectors/index.js'
 import { toGlobalId } from '#common/utils/index.js'
@@ -70,6 +71,52 @@ describe('icymi', () => {
     })
     expect(errors).toBeUndefined()
     expect(data.viewer.recommendation.icymi.totalCount).toBeGreaterThan(0)
+  })
+  test('articles by state-restricted authors are excluded', async () => {
+    const server = await testClient({ connections })
+    const article = await atomService.findUnique({
+      table: 'article',
+      where: { id: '1' },
+    })
+    await atomService.upsert({
+      table: 'matters_choice',
+      where: { articleId: article.id },
+      create: { articleId: article.id },
+      update: {},
+    })
+
+    await atomService.update({
+      table: 'user',
+      where: { id: article.authorId },
+      data: { state: USER_STATE.frozen },
+    })
+    const { errors, data } = await server.executeOperation({
+      query: GET_VIEWER_RECOMMENDATION_ICYMI,
+      variables: { input: { first: 10 } },
+    })
+    expect(errors).toBeUndefined()
+    const ids = data.viewer.recommendation.icymi.edges.map(
+      ({ node }: { node: { id: string } }) => node.id
+    )
+    expect(ids).not.toContain(
+      toGlobalId({ type: NODE_TYPES.Article, id: article.id })
+    )
+
+    await atomService.update({
+      table: 'user',
+      where: { id: article.authorId },
+      data: { state: USER_STATE.active },
+    })
+    const { data: restoredData } = await server.executeOperation({
+      query: GET_VIEWER_RECOMMENDATION_ICYMI,
+      variables: { input: { first: 10 } },
+    })
+    const restoredIds = restoredData.viewer.recommendation.icymi.edges.map(
+      ({ node }: { node: { id: string } }) => node.id
+    )
+    expect(restoredIds).toContain(
+      toGlobalId({ type: NODE_TYPES.Article, id: article.id })
+    )
   })
 })
 


### PR DESCRIPTION
## Why

Freezing a spam-ring account only flips `user.state`, not `user_restriction`, so discovery surfaces that relied solely on the restricted-authors filter kept **promoting frozen accounts** — reported live on 值得追蹤 (recommendation.authors).

Per-surface audit (against develop):

| Surface | Leaked frozen? | Root cause |
| --- | --- | --- |
| recommendation.authors (值得追蹤) | yes | pool = `findNewestArticles()` → only `user_restriction` filter; results cached 1 day (+ cache-ahead handler) with no state re-check on read |
| recommendation.newest | yes | same shared pool |
| recommendation.tags | yes (indirect) | same shared pool |
| recommendation.icymi | yes | no author-state filter on curated picks |
| channel.articles (pinned) | yes | unpinned query has `excludeStateRestrictedModifier`, pinned didn't |
| hottest / hottestMoments / tag feed / search / tag authors view | no | already filtered |

## What

- `findNewestArticles()` now excludes `frozen/banned/archived` authors (fixes newest / authors / tags pools at the source)
- `findIcymiArticles()` and the channel **pinned** query gain the same state filter
- `recommendation.authors` resolver re-checks author state **at read time**, so stale Redis pools (CACHE_TTL.LONG = 1 day) can never surface a frozen account
- `freezeSpamRing` / `unfreezeSpamRing` / `updateUserState` now also drop all `cache-recommendation-authors` keys (sitewide + per-channel), so the pool refreshes immediately instead of waiting out the TTL

No schema changes, no migrations, no UI. Ships as a plain fix (no flag) per owner sign-off — same class as cd36d96dd / 39eb090a2.

## Tests

- `findNewestArticles` excludes then restores a frozen author (connectors)
- channel pinned article by frozen author excluded, restored on unfreeze (connectors)
- icymi hides curated article once its author is frozen (GraphQL)
- authors resolver filters a frozen id **seeded directly into the cache** (GraphQL)
- `updateUserState` freeze purges the recommendation-authors cache key (GraphQL)
- spamRing resolver unit tests updated for the new purge dependency

All touched suites pass locally (`articleService` 49, `findTopicChannelArticles` 19, recommendation `authors`/`icymi` 15, `spamRingResolvers` + `recommendationService` 39, `user` 43). Pre-existing local-only teardown failure in `recommendation/articles.test` (missing `search_index` schema) reproduces on clean develop — unrelated.

## Post-deploy

After the prod promote, freeze/unfreeze events self-purge the cache; no manual purge needed. Watch newest-feed p95 (adds a `whereNotIn` author subquery — same shape already used by hottest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)