### PR TITLE
fix(cloudflare): surface Images API failures instead of swallowing them

### DIFF
--- a/src/connectors/__test__/cloudflare.test.ts
+++ b/src/connectors/__test__/cloudflare.test.ts
@@ -1,7 +1,36 @@
+import { jest } from '@jest/globals'
+
 import { environment } from '#common/environment.js'
+import { ServerError } from '#common/errors.js'
+import { Readable } from 'stream'
 import { cfsvc } from '../cloudflare/index.js'
 
 const ACCOUNT_HASH = 'kDRCwexxxx-pYA'
+
+const mockFetchResponse = (
+  body: unknown,
+  { ok = true, status = 200 }: { ok?: boolean; status?: number } = {}
+) => {
+  const fetchMock = jest.fn(async () => ({
+    ok,
+    status,
+    json: async () => body,
+  }))
+  // @ts-expect-error minimal fetch stub for tests
+  global.fetch = fetchMock
+  return fetchMock
+}
+
+const upload = {
+  createReadStream: () => Readable.from(['fake-image-bytes']),
+  mimetype: 'image/jpeg',
+  filename: 'test.jpg',
+}
+
+afterEach(() => {
+  // @ts-expect-error cleanup fetch stub
+  delete global.fetch
+})
 
 test('genUrl', () => {
   expect(environment.cloudflareAccountId).toBe(undefined)
@@ -21,4 +50,84 @@ test('uploadByUrl', async () => {
       'uuid'
     )
   ).toBe('cover/uuid-or-path-to-image.jpeg')
+})
+
+test('baseUploadFileByUrl returns key on success', async () => {
+  mockFetchResponse({ success: true, result: {} })
+  // NOTE: the double dot reflects long-standing genKey + path.extname behavior
+  expect(
+    await cfsvc.baseUploadFileByUrl(
+      'cover',
+      'https://example.com/some-image.jpeg',
+      'uuid'
+    )
+  ).toBe('cover/uuid..jpeg')
+})
+
+test('baseUploadFileByUrl throws on success:false', async () => {
+  mockFetchResponse(
+    { success: false, errors: [{ code: 5455, message: 'quota exceeded' }] },
+    { ok: false, status: 409 }
+  )
+  await expect(
+    cfsvc.baseUploadFileByUrl(
+      'cover',
+      'https://example.com/some-image.jpeg',
+      'uuid'
+    )
+  ).rejects.toBeInstanceOf(ServerError)
+})
+
+test('baseUploadFile returns key on success', async () => {
+  mockFetchResponse({ success: true, result: {} })
+  expect(await cfsvc.baseUploadFile('moment', upload, 'uuid')).toBe(
+    'moment/uuid.jpeg'
+  )
+})
+
+test('baseUploadFile throws on success:false', async () => {
+  mockFetchResponse(
+    { success: false, errors: [{ code: 10000, message: 'auth error' }] },
+    { ok: false, status: 403 }
+  )
+  await expect(
+    cfsvc.baseUploadFile('moment', upload, 'uuid')
+  ).rejects.toBeInstanceOf(ServerError)
+})
+
+test('directUploadImage returns key, id and uploadURL on success', async () => {
+  mockFetchResponse({
+    success: true,
+    result: {
+      id: 'non-prod/moment/uuid.jpeg',
+      uploadURL: 'https://upload.imagedelivery.net/hash/non-prod-id',
+    },
+  })
+  expect(await cfsvc.directUploadImage('moment', 'uuid', 'jpeg')).toEqual({
+    key: 'moment/uuid.jpeg',
+    id: 'non-prod/moment/uuid.jpeg',
+    uploadURL: 'https://upload.imagedelivery.net/hash/non-prod-id',
+  })
+})
+
+test('directUploadImage throws on success:false instead of returning undefined', async () => {
+  // shape observed during the 2026-07 Cloudflare direct upload outage
+  mockFetchResponse(
+    {
+      result: null,
+      success: false,
+      errors: [{ message: 'Internal Server Error', code: 5550 }],
+    },
+    { ok: false, status: 415 }
+  )
+  await expect(
+    cfsvc.directUploadImage('moment', 'uuid', 'jpeg')
+  ).rejects.toBeInstanceOf(ServerError)
+})
+
+test('directUploadImage throws on incomplete result', async () => {
+  mockFetchResponse({ success: true, result: { id: 'only-id' } })
+  await expect(
+    cfsvc.directUploadImage('moment', 'uuid', 'jpeg')
+  ).rejects.toBeInstanceOf(ServerError)
 })

--- a/src/connectors/cloudflare/index.ts
+++ b/src/connectors/cloudflare/index.ts
@@ -1,5 +1,9 @@
 import { environment, isProd, isTest } from '#common/environment.js'
-import { ActionFailedError, UserInputError } from '#common/errors.js'
+import {
+  ActionFailedError,
+  ServerError,
+  UserInputError,
+} from '#common/errors.js'
 import { getLogger } from '#common/logger.js'
 import { GQLAssetType } from '#definitions/index.js'
 import * as Sentry from '@sentry/node'
@@ -15,6 +19,12 @@ const envPrefix = isProd ? 'prod' : 'non-prod'
 const CLOUDFLARE_IMAGES_URL = `https://api.cloudflare.com/client/v4/accounts/${environment.cloudflareAccountId}/images/v1`
 const CLOUDFLARE_IMAGES_DIRECT_UPLOAD_ENDPOINT = `https://api.cloudflare.com/client/v4/accounts/${environment.cloudflareAccountId}/images/v2/direct_upload`
 const CLOUDFLARE_IMAGE_ENDPOINT = `https://imagedelivery.net/${environment.cloudflareAccountHash}/${envPrefix}`
+
+interface CloudflareAPIResponse {
+  success?: boolean
+  errors?: Array<{ code?: number; message?: string }>
+  result?: { id?: string; uploadURL?: string }
+}
 
 export class CloudflareService {
   public baseUploadFileByUrl = async (
@@ -45,12 +55,7 @@ export class CloudflareService {
       body: formData,
     })
 
-    try {
-      await res.json()
-    } catch (err) {
-      Sentry.captureException(err)
-      throw err
-    }
+    await this.parseResponse(res, 'upload by url')
 
     return key
   }
@@ -72,7 +77,7 @@ export class CloudflareService {
     const extension = mime.extension(mimetype)
 
     if (!extension) {
-      throw new Error('Invalid file type.')
+      throw new UserInputError('Invalid file type.')
     }
 
     const key = this.genKey(folder, uuid, extension)
@@ -89,12 +94,8 @@ export class CloudflareService {
       body: formData,
     })
 
-    try {
-      await res.json()
-    } catch (err) {
-      Sentry.captureException(err)
-      throw err
-    }
+    await this.parseResponse(res, 'file upload')
+
     return key
   }
 
@@ -118,21 +119,50 @@ export class CloudflareService {
       body: formData,
     })
 
+    const resData = await this.parseResponse(res, 'direct upload')
+    const { id, uploadURL } = resData.result || {}
+
+    if (!id || !uploadURL) {
+      logger.error('cloudflare direct upload returned incomplete result: %j', {
+        result: resData.result,
+      })
+      throw new ServerError('cloudflare direct upload failed')
+    }
+
+    return { key, id, uploadURL }
+  }
+
+  /**
+   * Parse a Cloudflare Images API response; log and throw on failure instead
+   * of letting `success: false` (expired token, quota, rate limit) pass
+   * silently and corrupt assets downstream.
+   */
+  private parseResponse = async (
+    res: { ok: boolean; status: number; json: () => Promise<unknown> },
+    context: string
+  ): Promise<CloudflareAPIResponse> => {
+    let resData: CloudflareAPIResponse
     try {
-      const resData = (await res.json()) as {
-        success: boolean
-        result: { id: string; uploadURL: string }
-      }
-      if (resData?.success) {
-        return {
-          key,
-          ...(resData.result as { id: string; uploadURL: string }),
-        }
-      }
+      resData = (await res.json()) as CloudflareAPIResponse
     } catch (err) {
+      logger.error('cloudflare %s returned invalid JSON: %j', context, {
+        status: res.status,
+      })
       Sentry.captureException(err)
       throw err
     }
+
+    if (!res.ok || resData?.success !== true) {
+      logger.error('cloudflare %s failed: %j', context, {
+        status: res.status,
+        errors: resData?.errors,
+      })
+      const error = new ServerError(`cloudflare ${context} failed`)
+      Sentry.captureException(error)
+      throw error
+    }
+
+    return resData
   }
 
   // TODO:

--- a/src/mutations/system/directImageUpload.ts
+++ b/src/mutations/system/directImageUpload.ts
@@ -82,7 +82,7 @@ const resolver: GQLMutationResolvers['directImageUpload'] = async (
     }
     try {
       const ext = mime.split('/')[1]
-      const result = (await cfsvc.directUploadImage(type, uuid, ext))!
+      const result = await cfsvc.directUploadImage(type, uuid, ext)
       ;({ key, uploadURL } = result)
     } catch (err) {
       logger.error('cloudflare upload image ERROR:', err)


### PR DESCRIPTION
## Summary

`CloudflareService` silently swallowed Cloudflare Images API failures:

- `baseUploadFile` / `baseUploadFileByUrl` parsed the response but never checked `success`, returning the key even when Cloudflare rejected the upload — creating assets that point at images that were never stored. `baseUploadFile` is now the load-bearing path for the `singleFileUpload` fallback (matters-web #6017), so a silent failure here would reintroduce broken images with no trace.
- `directUploadImage` returned `undefined` on `success: false`; the resolver's `result!` assertion turned that into a bare `Cannot destructure property 'key' of undefined` TypeError, losing Cloudflare's actual error (expired token, quota, rate limit).

During the 2026-07 direct-upload outage (`upload.imagedelivery.net` returning `415 {"code":5550}`), this gap meant nothing about the Cloudflare failure appeared in server logs — diagnosis required replaying uploadURLs from log lines with curl.

## Change

- New private `parseResponse` helper: parses every Images API response, and on `!res.ok || success !== true` logs the HTTP status plus Cloudflare's `errors` array, reports to Sentry, and throws `ServerError`.
- `directUploadImage` now always returns a complete `{ key, id, uploadURL }` or throws; dropped the resolver's obsolete non-null assertion.
- Replaced a generic `Error('Invalid file type.')` with `UserInputError` per error-handling conventions.

## Tests

Extended `src/connectors/__test__/cloudflare.test.ts` with mocked-fetch cases: success, `success:false` (including the exact 415/5550 outage shape), and incomplete `result` — 9/9 passing; `tsc`, eslint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)