### PR TITLE
chore: back-merge master into develop after #4919

### DIFF
--- a/.github/workflows/lambda-deploy.yml
+++ b/.github/workflows/lambda-deploy.yml
@@ -574,6 +574,30 @@ jobs:
             lambdaMemorySize=512,
             cronExpression="cron(0 1 * * ? *)"
 
+  deploy-spam-ring-digest:
+    needs: build-lambda-image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@master
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Deploy Lambda
+        uses: aws-actions/aws-cloudformation-github-deploy@v1
+        with:
+          name: spam-ring-digest-${{ inputs.environment }}
+          template: ./deployment/lambda/cronjob.yml
+          parameter-overrides: >-
+            mattersEnv=${{ env.MATTERS_ENV }},
+            imageUri=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:matters-server-${{ github.SHA }},
+            lambdaCMD=spamRingDigest.handler,
+            lambdaTimeout=900,
+            lambdaMemorySize=512,
+            cronExpression="cron(0 1 * * ? *)"
+
   deploy-user-retention:
     needs: build-lambda-image
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Back-merge `master` into `develop` after the #4919 production hotfix deploy, per `thematters/matters-agent-sop` selective-release cleanup rule.

## Scope

- Carries #4919 commit `bed43a6a4 ci(lambda): deploy spam ring digest` back onto current `develop`
- PR diff relative to `origin/develop` is only `.github/workflows/lambda-deploy.yml`
- Merge was conflict-free from latest `origin/develop`

## SOP evidence

#4919 production state:

- PR #4919 merged to `master` at merge commit `dc0b5b5bee88d2c39b008cf021ab77444525319c`
- `Create Release` run `28775333250` completed success
- `Push Schema to Apollo` run `28775333333` completed success
- `Deploy` run `28775333526` completed success

Production AWS smoke, read-only:

- CloudFormation stack `spam-ring-digest-production` is `CREATE_COMPLETE`
- Lambda `spam-ring-digest-production-Lambda-7AxRFNtdntxI` is `Active`, `LastUpdateStatus=Successful`
- Lambda image tag is `matters-server-dc0b5b5bee88d2c39b008cf021ab77444525319c`
- EventBridge rule `spam-ring-digest-production-CronEvent-lsSZpjEAKJSH` is `ENABLED`
- Schedule is `cron(0 1 * * ? *)`
- Rule target points to the digest Lambda

Back-merge verification before this PR:

```bash
git log --oneline --no-merges origin/develop..origin/master
# bed43a6a4 ci(lambda): deploy spam ring digest

git log --oneline --no-merges HEAD..origin/master
# empty

git diff --name-status origin/develop...HEAD
# M .github/workflows/lambda-deploy.yml

ruby -e 'require "yaml"; YAML.load_file(".github/workflows/lambda-deploy.yml"); puts "lambda-deploy yaml ok"'
# lambda-deploy yaml ok
```

After this PR is merged, the SOP final check should be empty:

```bash
git fetch origin master develop
git log origin/develop..origin/master --no-merges
```
