### PR TITLE
release: exclude frozen authors from discovery surfaces + quote wall; surface Cloudflare upload errors

### DIFF
--- a/src/common/utils/__test__/spamRingResolvers.test.ts
+++ b/src/common/utils/__test__/spamRingResolvers.test.ts
@@ -37,7 +37,11 @@ const makeContext = (viewer: any = { id: '9' }) => {
     dataSources: {
       userService,
       articleService: { findByAuthor: jest.fn(async () => []) },
-      connections: { redis: { __sentinel: 'redis' } },
+      atomService: { findMany: jest.fn(async () => []) },
+      connections: {
+        redis: { __sentinel: 'redis' },
+        objectCacheRedis: { del: jest.fn(async () => 1) },
+      },
       spamRingService: {
         freezeRing: jest.fn(async () => ({
           ring: {},
@@ -149,6 +153,8 @@ describe('spam ring mutation resolvers', () => {
     expect(ctx.dataSources.articleService.findByAuthor).toHaveBeenCalledWith(
       '12'
     )
+    // the recommended-authors pool cache is also dropped
+    expect(ctx.dataSources.connections.objectCacheRedis.del).toHaveBeenCalled()
   })
 
   test('unfreezeSpamRing purges caches of restored members', async () => {
@@ -166,6 +172,8 @@ describe('spam ring mutation resolvers', () => {
     expect(ctx.dataSources.articleService.findByAuthor).toHaveBeenCalledWith(
       '21'
     )
+    // the recommended-authors pool cache is also dropped
+    expect(ctx.dataSources.connections.objectCacheRedis.del).toHaveBeenCalled()
   })
 
   test('freezeSpamRing rejects when viewer has no id', async () => {

--- a/src/connectors/__test__/articleService/articleService.test.ts
+++ b/src/connectors/__test__/articleService/articleService.test.ts
@@ -424,6 +424,28 @@ describe('latestArticles', () => {
     expect(articles[0].authorId).toBeDefined()
     expect(articles[0].state).toBeDefined()
   })
+  test('state-restricted authors are excluded', async () => {
+    const articles = await articleService.findNewestArticles()
+    const targetAuthorId = articles[0].authorId
+
+    await atomService.update({
+      table: 'user',
+      where: { id: targetAuthorId },
+      data: { state: USER_STATE.frozen },
+    })
+    const excluded = await articleService.findNewestArticles()
+    expect(excluded.map(({ authorId }) => authorId)).not.toContain(
+      targetAuthorId
+    )
+
+    await atomService.update({
+      table: 'user',
+      where: { id: targetAuthorId },
+      data: { state: USER_STATE.active },
+    })
+    const restored = await articleService.findNewestArticles()
+    expect(restored.map(({ authorId }) => authorId)).toContain(targetAuthorId)
+  })
   test('spam are excluded', async () => {
     const articles = await articleService.findNewestArticles({
       spamThreshold: 0.5,

--- a/src/connectors/__test__/campaignService.test.ts
+++ b/src/connectors/__test__/campaignService.test.ts
@@ -259,6 +259,26 @@ describe('find and count articles', () => {
       data: { state: ARTICLE_STATE.active },
     })
   })
+  test('state-restricted authors are excluded', async () => {
+    const before = await campaignService.findArticles(campaign.id)
+    expect(before.length).toBeGreaterThan(0)
+
+    await atomService.update({
+      table: 'user',
+      where: { id: '1' },
+      data: { state: USER_STATE.frozen },
+    })
+    const excluded = await campaignService.findArticles(campaign.id)
+    expect(excluded.length).toBe(0)
+
+    await atomService.update({
+      table: 'user',
+      where: { id: '1' },
+      data: { state: USER_STATE.active },
+    })
+    const restored = await campaignService.findArticles(campaign.id)
+    expect(restored.length).toBe(before.length)
+  })
   // test('spam are excluded', async () => {
   //   const spamThreshold = 0.5
   //   const _articles1 = await campaignService.findArticles(campaign.id)

--- a/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
+++ b/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
@@ -1,6 +1,6 @@
 import type { Connections, Article, TopicChannel } from '#definitions/index.js'
 
-import { FEATURE_FLAG, FEATURE_NAME } from '#common/enums/index.js'
+import { FEATURE_FLAG, FEATURE_NAME, USER_STATE } from '#common/enums/index.js'
 import { AtomService } from '../../atomService.js'
 import { CampaignService } from '../../campaignService.js'
 import { ChannelService } from '../../channel/channelService.js'
@@ -117,6 +117,36 @@ describe('findTopicChannelArticles', () => {
     expect(results).toHaveLength(4)
     expect(results[0].id).toBe(articles[0].id) // Pinned should be first
     expect(results[1].id).not.toBe(articles[0].id) // Rest should be unpinned
+  })
+
+  test('pinned articles by state-restricted authors are excluded', async () => {
+    await atomService.update({
+      table: 'topic_channel',
+      where: { id: channel.id },
+      data: { pinnedArticles: [articles[0].id] },
+    })
+    const pinnedAuthorId = articles[0].authorId
+
+    await atomService.update({
+      table: 'user',
+      where: { id: pinnedAuthorId },
+      data: { state: USER_STATE.frozen },
+    })
+    const { query } = await channelService.findTopicChannelArticles(channel.id)
+    const results = await query
+    expect(results.map(({ authorId }) => authorId)).not.toContain(
+      pinnedAuthorId
+    )
+
+    await atomService.update({
+      table: 'user',
+      where: { id: pinnedAuthorId },
+      data: { state: USER_STATE.active },
+    })
+    const { query: restoredQuery } =
+      await channelService.findTopicChannelArticles(channel.id)
+    const restored = await restoredQuery
+    expect(restored.map(({ id }) => id)).toContain(articles[0].id)
   })
 
   test('orders pinned articles by pinnedArticles array order', async () => {

--- a/src/connectors/__test__/cloudflare.test.ts
+++ b/src/connectors/__test__/cloudflare.test.ts
@@ -1,7 +1,36 @@
+import { jest } from '@jest/globals'
+
 import { environment } from '#common/environment.js'
+import { ServerError } from '#common/errors.js'
+import { Readable } from 'stream'
 import { cfsvc } from '../cloudflare/index.js'
 
 const ACCOUNT_HASH = 'kDRCwexxxx-pYA'
+
+const mockFetchResponse = (
+  body: unknown,
+  { ok = true, status = 200 }: { ok?: boolean; status?: number } = {}
+) => {
+  const fetchMock = jest.fn(async () => ({
+    ok,
+    status,
+    json: async () => body,
+  }))
+  // @ts-expect-error minimal fetch stub for tests
+  global.fetch = fetchMock
+  return fetchMock
+}
+
+const upload = {
+  createReadStream: () => Readable.from(['fake-image-bytes']),
+  mimetype: 'image/jpeg',
+  filename: 'test.jpg',
+}
+
+afterEach(() => {
+  // @ts-expect-error cleanup fetch stub
+  delete global.fetch
+})
 
 test('genUrl', () => {
   expect(environment.cloudflareAccountId).toBe(undefined)
@@ -21,4 +50,84 @@ test('uploadByUrl', async () => {
       'uuid'
     )
   ).toBe('cover/uuid-or-path-to-image.jpeg')
+})
+
+test('baseUploadFileByUrl returns key on success', async () => {
+  mockFetchResponse({ success: true, result: {} })
+  // NOTE: the double dot reflects long-standing genKey + path.extname behavior
+  expect(
+    await cfsvc.baseUploadFileByUrl(
+      'cover',
+      'https://example.com/some-image.jpeg',
+      'uuid'
+    )
+  ).toBe('cover/uuid..jpeg')
+})
+
+test('baseUploadFileByUrl throws on success:false', async () => {
+  mockFetchResponse(
+    { success: false, errors: [{ code: 5455, message: 'quota exceeded' }] },
+    { ok: false, status: 409 }
+  )
+  await expect(
+    cfsvc.baseUploadFileByUrl(
+      'cover',
+      'https://example.com/some-image.jpeg',
+      'uuid'
+    )
+  ).rejects.toBeInstanceOf(ServerError)
+})
+
+test('baseUploadFile returns key on success', async () => {
+  mockFetchResponse({ success: true, result: {} })
+  expect(await cfsvc.baseUploadFile('moment', upload, 'uuid')).toBe(
+    'moment/uuid.jpeg'
+  )
+})
+
+test('baseUploadFile throws on success:false', async () => {
+  mockFetchResponse(
+    { success: false, errors: [{ code: 10000, message: 'auth error' }] },
+    { ok: false, status: 403 }
+  )
+  await expect(
+    cfsvc.baseUploadFile('moment', upload, 'uuid')
+  ).rejects.toBeInstanceOf(ServerError)
+})
+
+test('directUploadImage returns key, id and uploadURL on success', async () => {
+  mockFetchResponse({
+    success: true,
+    result: {
+      id: 'non-prod/moment/uuid.jpeg',
+      uploadURL: 'https://upload.imagedelivery.net/hash/non-prod-id',
+    },
+  })
+  expect(await cfsvc.directUploadImage('moment', 'uuid', 'jpeg')).toEqual({
+    key: 'moment/uuid.jpeg',
+    id: 'non-prod/moment/uuid.jpeg',
+    uploadURL: 'https://upload.imagedelivery.net/hash/non-prod-id',
+  })
+})
+
+test('directUploadImage throws on success:false instead of returning undefined', async () => {
+  // shape observed during the 2026-07 Cloudflare direct upload outage
+  mockFetchResponse(
+    {
+      result: null,
+      success: false,
+      errors: [{ message: 'Internal Server Error', code: 5550 }],
+    },
+    { ok: false, status: 415 }
+  )
+  await expect(
+    cfsvc.directUploadImage('moment', 'uuid', 'jpeg')
+  ).rejects.toBeInstanceOf(ServerError)
+})
+
+test('directUploadImage throws on incomplete result', async () => {
+  mockFetchResponse({ success: true, result: { id: 'only-id' } })
+  await expect(
+    cfsvc.directUploadImage('moment', 'uuid', 'jpeg')
+  ).rejects.toBeInstanceOf(ServerError)
 })

--- a/src/connectors/article/articleService.ts
+++ b/src/connectors/article/articleService.ts
@@ -39,6 +39,7 @@ import {
 import {
   excludeSpam as excludeSpamModifier,
   excludeRestrictedAuthors as excludeRestrictedModifier,
+  excludeStateRestrictedAuthors as excludeStateRestrictedModifier,
   excludeExclusiveCampaignArticles as excludeExclusiveCampaignArticlesModifier,
   excludeProbationAuthors as excludeProbationModifier,
 } from '#common/utils/index.js'
@@ -215,19 +216,16 @@ export class ArticleService extends BaseService<Article> {
             spamThreshold,
           }
         : undefined,
-      // freezing only flips user.state, not user_restriction, so the
-      // restricted-authors filter alone still surfaces frozen accounts in
-      // newest / recommended-authors / recommended-tags pools
-      excludeAuthorStates: [
-        USER_STATE.frozen,
-        USER_STATE.banned,
-        USER_STATE.archived,
-      ],
       excludeRestrictedAuthors: USER_RESTRICTION_TYPE.articleNewest,
       excludeChannelArticles,
       excludeExclusiveCampaignArticles,
       excludeProbationAuthors: probationDays,
     })
+    // freezing only flips user.state, not user_restriction, so the
+    // restricted-authors filter alone still surfaces frozen accounts in
+    // newest / recommended-authors / recommended-tags pools; the correlated
+    // modifier probes user pkey per row instead of scanning the user table
+    excludeStateRestrictedModifier(query)
     return query.orderBy('id', 'desc')
   }
 

--- a/src/connectors/article/articleService.ts
+++ b/src/connectors/article/articleService.ts
@@ -215,6 +215,14 @@ export class ArticleService extends BaseService<Article> {
             spamThreshold,
           }
         : undefined,
+      // freezing only flips user.state, not user_restriction, so the
+      // restricted-authors filter alone still surfaces frozen accounts in
+      // newest / recommended-authors / recommended-tags pools
+      excludeAuthorStates: [
+        USER_STATE.frozen,
+        USER_STATE.banned,
+        USER_STATE.archived,
+      ],
       excludeRestrictedAuthors: USER_RESTRICTION_TYPE.articleNewest,
       excludeChannelArticles,
       excludeExclusiveCampaignArticles,

--- a/src/connectors/campaignService.ts
+++ b/src/connectors/campaignService.ts
@@ -33,6 +33,7 @@ import {
   toDatetimeRangeString,
   fromDatetimeRangeString,
   fromGlobalId,
+  excludeStateRestrictedAuthors,
   // excludeSpam,
 } from '#common/utils/index.js'
 import { invalidateFQC } from '@matters/apollo-response-cache'
@@ -350,6 +351,11 @@ export class CampaignService {
     if (featured) {
       query.where({ featured })
     }
+
+    // freezing only flips user.state, so without this the public campaign
+    // feed keeps listing frozen authors' articles (applied as a plain call:
+    // knex's loosely-typed `.modify()` would widen the query's row type)
+    excludeStateRestrictedAuthors(query)
 
     return query
   }

--- a/src/connectors/channel/channelService.ts
+++ b/src/connectors/channel/channelService.ts
@@ -418,6 +418,10 @@ export class ChannelService {
         'article.channel_enabled': true,
       })
       .whereIn('article.id', pinnedArticleIds)
+    // pinning happens before an author may get frozen; keep parity with the
+    // unpinned query below (applied outside the chain so knex's loosely-typed
+    // `.modify()` does not widen the query's row type)
+    excludeStateRestrictedModifier(pinnedQuery)
 
     const unpinnedQuery = knexRO
       .select(

--- a/src/connectors/cloudflare/index.ts
+++ b/src/connectors/cloudflare/index.ts
@@ -1,5 +1,9 @@
 import { environment, isProd, isTest } from '#common/environment.js'
-import { ActionFailedError, UserInputError } from '#common/errors.js'
+import {
+  ActionFailedError,
+  ServerError,
+  UserInputError,
+} from '#common/errors.js'
 import { getLogger } from '#common/logger.js'
 import { GQLAssetType } from '#definitions/index.js'
 import * as Sentry from '@sentry/node'
@@ -15,6 +19,12 @@ const envPrefix = isProd ? 'prod' : 'non-prod'
 const CLOUDFLARE_IMAGES_URL = `https://api.cloudflare.com/client/v4/accounts/${environment.cloudflareAccountId}/images/v1`
 const CLOUDFLARE_IMAGES_DIRECT_UPLOAD_ENDPOINT = `https://api.cloudflare.com/client/v4/accounts/${environment.cloudflareAccountId}/images/v2/direct_upload`
 const CLOUDFLARE_IMAGE_ENDPOINT = `https://imagedelivery.net/${environment.cloudflareAccountHash}/${envPrefix}`
+
+interface CloudflareAPIResponse {
+  success?: boolean
+  errors?: Array<{ code?: number; message?: string }>
+  result?: { id?: string; uploadURL?: string }
+}
 
 export class CloudflareService {
   public baseUploadFileByUrl = async (
@@ -45,12 +55,7 @@ export class CloudflareService {
       body: formData,
     })
 
-    try {
-      await res.json()
-    } catch (err) {
-      Sentry.captureException(err)
-      throw err
-    }
+    await this.parseResponse(res, 'upload by url')
 
     return key
   }
@@ -72,7 +77,7 @@ export class CloudflareService {
     const extension = mime.extension(mimetype)
 
     if (!extension) {
-      throw new Error('Invalid file type.')
+      throw new UserInputError('Invalid file type.')
     }
 
     const key = this.genKey(folder, uuid, extension)
@@ -89,12 +94,8 @@ export class CloudflareService {
       body: formData,
     })
 
-    try {
-      await res.json()
-    } catch (err) {
-      Sentry.captureException(err)
-      throw err
-    }
+    await this.parseResponse(res, 'file upload')
+
     return key
   }
 
@@ -118,21 +119,50 @@ export class CloudflareService {
       body: formData,
     })
 
+    const resData = await this.parseResponse(res, 'direct upload')
+    const { id, uploadURL } = resData.result || {}
+
+    if (!id || !uploadURL) {
+      logger.error('cloudflare direct upload returned incomplete result: %j', {
+        result: resData.result,
+      })
+      throw new ServerError('cloudflare direct upload failed')
+    }
+
+    return { key, id, uploadURL }
+  }
+
+  /**
+   * Parse a Cloudflare Images API response; log and throw on failure instead
+   * of letting `success: false` (expired token, quota, rate limit) pass
+   * silently and corrupt assets downstream.
+   */
+  private parseResponse = async (
+    res: { ok: boolean; status: number; json: () => Promise<unknown> },
+    context: string
+  ): Promise<CloudflareAPIResponse> => {
+    let resData: CloudflareAPIResponse
     try {
-      const resData = (await res.json()) as {
-        success: boolean
-        result: { id: string; uploadURL: string }
-      }
-      if (resData?.success) {
-        return {
-          key,
-          ...(resData.result as { id: string; uploadURL: string }),
-        }
-      }
+      resData = (await res.json()) as CloudflareAPIResponse
     } catch (err) {
+      logger.error('cloudflare %s returned invalid JSON: %j', context, {
+        status: res.status,
+      })
       Sentry.captureException(err)
       throw err
     }
+
+    if (!res.ok || resData?.success !== true) {
+      logger.error('cloudflare %s failed: %j', context, {
+        status: res.status,
+        errors: resData?.errors,
+      })
+      const error = new ServerError(`cloudflare ${context} failed`)
+      Sentry.captureException(error)
+      throw error
+    }
+
+    return resData
   }
 
   // TODO:

--- a/src/connectors/recommendationService.ts
+++ b/src/connectors/recommendationService.ts
@@ -367,7 +367,13 @@ export class RecommendationService {
                   isSpam: false,
                   spamThreshold: spamThreshold ?? 0,
                 },
-                excludeAuthorStates: [USER_STATE.frozen, USER_STATE.archived],
+                // keep in sync with excludeStateRestrictedAuthors: banned
+                // authors' works must not resurface in hottest either
+                excludeAuthorStates: [
+                  USER_STATE.frozen,
+                  USER_STATE.banned,
+                  USER_STATE.archived,
+                ],
                 excludeRestrictedAuthors: USER_RESTRICTION_TYPE.articleHottest,
                 excludeExclusiveCampaignArticles: true,
                 excludeComplaintAreaArticles: true,

--- a/src/connectors/recommendationService.ts
+++ b/src/connectors/recommendationService.ts
@@ -25,7 +25,10 @@ import {
   ActionFailedError,
 } from '#common/errors.js'
 import { getLogger } from '#common/logger.js'
-import { excludeProbationAuthors as excludeProbationModifier } from '#common/utils/index.js'
+import {
+  excludeProbationAuthors as excludeProbationModifier,
+  excludeStateRestrictedAuthors as excludeStateRestrictedModifier,
+} from '#common/utils/index.js'
 import { daysToDatetimeRange } from '#common/utils/time.js'
 import { quantile, median } from 'd3-array'
 import keyBy from 'lodash/keyBy.js'
@@ -912,6 +915,9 @@ export class RecommendationService {
       )
       .leftJoin('article', 'choice.article_id', 'article.id')
       .where({ state: ARTICLE_STATE.active })
+      // matters_choice is curated before an author may get frozen, so the
+      // author state must be re-checked at read time
+      .modify(excludeStateRestrictedModifier)
       .modify((builder) => {
         if (probationDays) {
           builder.modify(excludeProbationModifier, probationDays)

--- a/src/mutations/system/directImageUpload.ts
+++ b/src/mutations/system/directImageUpload.ts
@@ -82,7 +82,7 @@ const resolver: GQLMutationResolvers['directImageUpload'] = async (
     }
     try {
       const ext = mime.split('/')[1]
-      const result = (await cfsvc.directUploadImage(type, uuid, ext))!
+      const result = await cfsvc.directUploadImage(type, uuid, ext)
       ;({ key, uploadURL } = result)
     } catch (err) {
       logger.error('cloudflare upload image ERROR:', err)

--- a/src/mutations/user/freezeSpamRing.ts
+++ b/src/mutations/user/freezeSpamRing.ts
@@ -3,7 +3,10 @@ import type { GQLMutationResolvers } from '#definitions/index.js'
 import { ForbiddenError } from '#common/errors.js'
 import { fromGlobalId } from '#common/utils/index.js'
 
-import { invalidateUserContentCaches } from './utils.js'
+import {
+  invalidateRecommendationAuthorsCache,
+  invalidateUserContentCaches,
+} from './utils.js'
 
 const resolver: GQLMutationResolvers['freezeSpamRing'] = async (
   _,
@@ -14,7 +17,8 @@ const resolver: GQLMutationResolvers['freezeSpamRing'] = async (
       spamRingService,
       userService,
       articleService,
-      connections: { redis },
+      atomService,
+      connections: { redis, objectCacheRedis },
     },
   }
 ) => {
@@ -35,6 +39,12 @@ const resolver: GQLMutationResolvers['freezeSpamRing'] = async (
   // responses so frozen members' content stops being served
   for (const user of result.frozen) {
     await invalidateUserContentCaches(user.id, { articleService, redis })
+  }
+  if (result.frozen.length > 0) {
+    await invalidateRecommendationAuthorsCache({
+      atomService,
+      objectCacheRedis,
+    })
   }
 
   return result

--- a/src/mutations/user/unfreezeSpamRing.ts
+++ b/src/mutations/user/unfreezeSpamRing.ts
@@ -3,7 +3,10 @@ import type { GQLMutationResolvers } from '#definitions/index.js'
 import { ForbiddenError } from '#common/errors.js'
 import { fromGlobalId } from '#common/utils/index.js'
 
-import { invalidateUserContentCaches } from './utils.js'
+import {
+  invalidateRecommendationAuthorsCache,
+  invalidateUserContentCaches,
+} from './utils.js'
 
 const resolver: GQLMutationResolvers['unfreezeSpamRing'] = async (
   _,
@@ -14,7 +17,8 @@ const resolver: GQLMutationResolvers['unfreezeSpamRing'] = async (
       spamRingService,
       userService,
       articleService,
-      connections: { redis },
+      atomService,
+      connections: { redis, objectCacheRedis },
     },
   }
 ) => {
@@ -32,6 +36,12 @@ const resolver: GQLMutationResolvers['unfreezeSpamRing'] = async (
   // responses so restored members' content shows up again promptly
   for (const user of result.unbanned) {
     await invalidateUserContentCaches(user.id, { articleService, redis })
+  }
+  if (result.unbanned.length > 0) {
+    await invalidateRecommendationAuthorsCache({
+      atomService,
+      objectCacheRedis,
+    })
   }
 
   return result

--- a/src/mutations/user/updateUserState.ts
+++ b/src/mutations/user/updateUserState.ts
@@ -4,7 +4,10 @@ import { USER_STATE } from '#common/enums/index.js'
 import { ActionFailedError, UserInputError } from '#common/errors.js'
 import { fromGlobalId } from '#common/utils/index.js'
 
-import { invalidateUserContentCaches } from './utils.js'
+import {
+  invalidateRecommendationAuthorsCache,
+  invalidateUserContentCaches,
+} from './utils.js'
 
 const resolver: GQLMutationResolvers['updateUserState'] = async (
   _,
@@ -16,15 +19,20 @@ const resolver: GQLMutationResolvers['updateUserState'] = async (
       articleService,
       notificationService,
       atomService,
-      connections: { redis },
+      connections: { redis, objectCacheRedis },
       queues: { userQueue },
     },
   }
 ) => {
   const id = globalId ? fromGlobalId(globalId).id : undefined
 
-  const invalidateUserCaches = (userId: string) =>
-    invalidateUserContentCaches(userId, { articleService, redis })
+  const invalidateUserCaches = async (userId: string) => {
+    await invalidateUserContentCaches(userId, { articleService, redis })
+    await invalidateRecommendationAuthorsCache({
+      atomService,
+      objectCacheRedis,
+    })
+  }
 
   /**
    * archive

--- a/src/mutations/user/utils.ts
+++ b/src/mutations/user/utils.ts
@@ -1,7 +1,8 @@
-import type { ArticleService } from '#connectors/index.js'
+import type { ArticleService, AtomService } from '#connectors/index.js'
 import type { Redis } from 'ioredis'
 
-import { NODE_TYPES } from '#common/enums/index.js'
+import { CACHE_PREFIX, NODE_TYPES } from '#common/enums/index.js'
+import { Cache } from '#connectors/cache/index.js'
 import { invalidateFQC } from '@matters/apollo-response-cache'
 
 // purge cached public query responses of a user and their articles after a
@@ -22,6 +23,33 @@ export const invalidateUserContentCaches = async (
     await invalidateFQC({
       node: { type: NODE_TYPES.Article, id: article.id },
       redis,
+    })
+  }
+}
+
+// the recommended-authors pool (值得追蹤) is cached outside FQC with
+// CACHE_TTL.LONG, one key per channel plus a sitewide one; drop all of them
+// after a state change so a frozen author leaves (or an unfrozen one
+// re-enters) the pool without waiting out the TTL
+export const invalidateRecommendationAuthorsCache = async ({
+  atomService,
+  objectCacheRedis,
+}: {
+  atomService: AtomService
+  objectCacheRedis: Redis
+}) => {
+  const cache = new Cache(CACHE_PREFIX.RECOMMENDATION_AUTHORS, objectCacheRedis)
+  const channels = await atomService.findMany({
+    table: 'topic_channel',
+    select: ['id'],
+  })
+  const channelIds: Array<string | undefined> = [
+    undefined, // sitewide key
+    ...channels.map(({ id }) => id),
+  ]
+  for (const channelId of channelIds) {
+    await cache.removeObject({
+      keys: { type: 'recommendationAuthors', args: { channelId } },
     })
   }
 }

--- a/src/queries/campaign/quoteCount.ts
+++ b/src/queries/campaign/quoteCount.ts
@@ -1,18 +1,32 @@
 import type { GQLWritingChallengeResolvers } from '#definitions/index.js'
 
 import { QUOTE_STATE } from '#common/enums/index.js'
+import { excludeStateRestrictedAuthors } from '#common/utils/index.js'
 
 const resolver: GQLWritingChallengeResolvers['quoteCount'] = async (
   { id },
   _,
-  { dataSources: { atomService } }
+  {
+    viewer,
+    dataSources: {
+      connections: { knexRO },
+    },
+  }
 ) => {
-  const count = await atomService.count({
-    table: 'quote',
-    where: { campaignId: id, state: QUOTE_STATE.active },
-  })
+  // keep in sync with the `quotes` resolver: restricted authors' quotes are
+  // hidden from the public wall, so they must not inflate the public count
+  const countResult = await knexRO('quote')
+    .join('article', 'article.id', 'quote.articleId')
+    .where({ 'quote.campaignId': id, 'quote.state': QUOTE_STATE.active })
+    .modify((builder) => {
+      if (!viewer.hasRole('admin')) {
+        builder.modify(excludeStateRestrictedAuthors)
+      }
+    })
+    .count()
+    .first()
 
-  return count
+  return parseInt(String(countResult?.count ?? 0), 10)
 }
 
 export default resolver

--- a/src/queries/campaign/quotes.ts
+++ b/src/queries/campaign/quotes.ts
@@ -1,7 +1,11 @@
 import type { GQLWritingChallengeResolvers } from '#definitions/index.js'
 
 import { QUOTE_STATE } from '#common/enums/index.js'
-import { connectionFromArray, fromConnectionArgs } from '#common/utils/index.js'
+import {
+  connectionFromArray,
+  excludeStateRestrictedAuthors,
+  fromConnectionArgs,
+} from '#common/utils/index.js'
 
 const DEFAULT_TAKE = 12
 
@@ -11,8 +15,8 @@ const resolver: GQLWritingChallengeResolvers['quotes'] = async (
   { id },
   { input },
   {
+    viewer,
     dataSources: {
-      atomService,
       connections: { knexRO },
     },
   }
@@ -22,23 +26,33 @@ const resolver: GQLWritingChallengeResolvers['quotes'] = async (
     defaultTake: DEFAULT_TAKE,
   })
 
-  const [quotes, totalCount] = await Promise.all([
+  // hide quotes whose article author is frozen / banned / archived from the
+  // public wall; admins still see them so the OSS management list stays whole
+  const baseQuery = () =>
     knexRO('quote')
-      .select()
-      .where({ campaignId: id, state: QUOTE_STATE.active })
+      .join('article', 'article.id', 'quote.articleId')
+      .where({ 'quote.campaignId': id, 'quote.state': QUOTE_STATE.active })
+      .modify((builder) => {
+        if (!viewer.hasRole('admin')) {
+          builder.modify(excludeStateRestrictedAuthors)
+        }
+      })
+
+  const [quotes, countResult] = await Promise.all([
+    baseQuery()
+      .select('quote.*')
       .modify((builder) => {
         if (random) {
           builder.orderByRaw('random()')
         } else {
-          builder.orderBy('id', 'desc').offset(skip)
+          builder.orderBy('quote.id', 'desc').offset(skip)
         }
       })
       .limit(take),
-    atomService.count({
-      table: 'quote',
-      where: { campaignId: id, state: QUOTE_STATE.active },
-    }),
+    baseQuery().count().first(),
   ])
+
+  const totalCount = parseInt(String(countResult?.count ?? 0), 10)
 
   return connectionFromArray(
     quotes,

--- a/src/queries/quote/index.ts
+++ b/src/queries/quote/index.ts
@@ -1,13 +1,34 @@
 import type { GQLResolvers } from '#definitions/index.js'
 
-import { NODE_TYPES } from '#common/enums/index.js'
+import { NODE_TYPES, USER_STATE } from '#common/enums/index.js'
+import { ArticleNotFoundError } from '#common/errors.js'
 import { toGlobalId } from '#common/utils/index.js'
+
+const restrictedAuthorStates = new Set<string>([
+  USER_STATE.frozen,
+  USER_STATE.banned,
+  USER_STATE.archived,
+])
 
 const schema: GQLResolvers = {
   Quote: {
     id: ({ id }) => toGlobalId({ type: NODE_TYPES.Quote, id }),
-    article: ({ articleId }, _, { dataSources: { atomService } }) =>
-      atomService.articleIdLoader.load(articleId),
+    // defense in depth: even if a quote row slips through list-level filters,
+    // do not resolve the article of a restricted author (mirrors Query.node)
+    article: async (
+      { articleId },
+      _,
+      { viewer, dataSources: { atomService } }
+    ) => {
+      const article = await atomService.articleIdLoader.load(articleId)
+      if (viewer.id !== article.authorId && !viewer.hasRole('admin')) {
+        const author = await atomService.userIdLoader.load(article.authorId)
+        if (author && restrictedAuthorStates.has(author.state)) {
+          throw new ArticleNotFoundError('target article does not exists')
+        }
+      }
+      return article
+    },
     poster: ({ userId }, _, { dataSources: { atomService } }) =>
       atomService.userIdLoader.load(userId),
     createdAt: ({ createdAt }) => createdAt,

--- a/src/queries/user/recommendation/authors.ts
+++ b/src/queries/user/recommendation/authors.ts
@@ -1,6 +1,6 @@
 import type { GQLRecommendationResolvers } from '#definitions/index.js'
 
-import { CACHE_PREFIX, CACHE_TTL } from '#common/enums/index.js'
+import { CACHE_PREFIX, CACHE_TTL, USER_STATE } from '#common/enums/index.js'
 import { ForbiddenError } from '#common/errors.js'
 import {
   connectionFromArray,
@@ -77,8 +77,21 @@ export const authors: GQLRecommendationResolvers['authors'] = async (
   const chunks = circleChunk(filtered, draw)
   const index = Math.min(filter?.random || 0, limit, chunks.length - 1)
   const randomAuthorIds = chunks[index] || []
-  const randomAuthors = await atomService.userIdLoader.loadMany(
+  const loadedAuthors = await atomService.userIdLoader.loadMany(
     randomAuthorIds.map(({ authorId }) => authorId)
+  )
+  // the cached pool may predate a freeze (CACHE_TTL.LONG), so author state
+  // must be re-checked at read time
+  const restrictedStates: string[] = [
+    USER_STATE.frozen,
+    USER_STATE.banned,
+    USER_STATE.archived,
+  ]
+  const randomAuthors = loadedAuthors.filter(
+    (author) =>
+      author &&
+      !(author instanceof Error) &&
+      !restrictedStates.includes(author.state)
   )
   return connectionFromArray(randomAuthors, input, authorIds.length)
 }

--- a/src/types/__test__/2/quote.test.ts
+++ b/src/types/__test__/2/quote.test.ts
@@ -253,6 +253,36 @@ describe('putQuote', () => {
     expect(count).toBe(1)
   })
 
+  test('article of a restricted author does not resolve in the response', async () => {
+    // article.state stays `active` when its author is frozen, so putQuote
+    // itself passes; the Quote.article gate must still hide the article
+    await atomService.update({
+      table: 'user',
+      where: { id: '1' },
+      data: { state: USER_STATE.frozen },
+    })
+    try {
+      const server = await testClient({
+        connections,
+        context: { viewer: posterUser },
+        isAuth: true,
+      })
+      const { errors } = await server.executeOperation({
+        query: PUT_QUOTE,
+        variables: {
+          input: { articleId: articleGlobalId, content: 'some html string' },
+        },
+      })
+      expect(errors?.[0].extensions.code).toBe('ARTICLE_NOT_FOUND')
+    } finally {
+      await atomService.update({
+        table: 'user',
+        where: { id: '1' },
+        data: { state: USER_STATE.active },
+      })
+    }
+  })
+
   test('no per-article cap: more quotes from the same article still succeed', async () => {
     // quantity limits removed — distinct excerpts from one article all post
     await seedQuote({ content: 'some' })
@@ -481,5 +511,119 @@ describe('quotes query', () => {
     expect(errors).toBeUndefined()
     expect(data.campaign.quotes.totalCount).toBe(2)
     expect(data.campaign.quotes.edges.length).toBe(2)
+  })
+
+  const QUERY_CAMPAIGN_QUOTE_COUNT = /* GraphQL */ `
+    query ($campaignInput: CampaignInput!) {
+      campaign(input: $campaignInput) {
+        ... on WritingChallenge {
+          quoteCount
+        }
+      }
+    }
+  `
+
+  // freezing / banning / archiving a user does not change their articles'
+  // state, so without author-state filtering the wall would leak their content
+  const setAuthorState = async (state: keyof typeof USER_STATE) =>
+    atomService.update({
+      table: 'user',
+      where: { id: '1' },
+      data: { state },
+    })
+
+  test('quotes from restricted authors are hidden from the public wall', async () => {
+    await seedQuote({ content: 'some' })
+    const server = await testClient({ connections })
+    try {
+      for (const state of [
+        USER_STATE.frozen,
+        USER_STATE.banned,
+        USER_STATE.archived,
+      ]) {
+        await setAuthorState(state)
+        const { errors, data } = await server.executeOperation({
+          query: QUERY_CAMPAIGN_QUOTES,
+          variables: {
+            campaignInput: { shortHash: campaign.shortHash },
+            quotesInput: { first: 10 },
+          },
+        })
+        expect(errors).toBeUndefined()
+        expect(data.campaign.quotes.totalCount).toBe(0)
+        expect(data.campaign.quotes.edges).toEqual([])
+
+        const { errors: countErrors, data: countData } =
+          await server.executeOperation({
+            query: QUERY_CAMPAIGN_QUOTE_COUNT,
+            variables: {
+              campaignInput: { shortHash: campaign.shortHash },
+            },
+          })
+        expect(countErrors).toBeUndefined()
+        expect(countData.campaign.quoteCount).toBe(0)
+      }
+    } finally {
+      await setAuthorState(USER_STATE.active)
+    }
+  })
+
+  const QUERY_CAMPAIGN_QUOTES_WITH_ARTICLE = /* GraphQL */ `
+    query ($campaignInput: CampaignInput!, $quotesInput: QuotesInput!) {
+      campaign(input: $campaignInput) {
+        ... on WritingChallenge {
+          quotes(input: $quotesInput) {
+            totalCount
+            edges {
+              node {
+                id
+                content
+                article {
+                  id
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `
+
+  test('restricted-author quotes stay visible to admin (management view)', async () => {
+    await seedQuote({ content: 'some' })
+    await setAuthorState(USER_STATE.frozen)
+    try {
+      const server = await testClient({
+        connections,
+        isAuth: true,
+        isAdmin: true,
+      })
+      const { errors, data } = await server.executeOperation({
+        query: QUERY_CAMPAIGN_QUOTES_WITH_ARTICLE,
+        variables: {
+          campaignInput: { shortHash: campaign.shortHash },
+          quotesInput: { first: 10 },
+        },
+      })
+      expect(errors).toBeUndefined()
+      expect(data.campaign.quotes.totalCount).toBe(1)
+      expect(data.campaign.quotes.edges.length).toBe(1)
+      // admin is also exempt from the Quote.article gate
+      expect(data.campaign.quotes.edges[0].node.article.id).toBe(
+        articleGlobalId
+      )
+
+      const { errors: countErrors, data: countData } =
+        await server.executeOperation({
+          query: QUERY_CAMPAIGN_QUOTE_COUNT,
+          variables: {
+            campaignInput: { shortHash: campaign.shortHash },
+          },
+        })
+      expect(countErrors).toBeUndefined()
+      expect(countData.campaign.quoteCount).toBe(1)
+    } finally {
+      await setAuthorState(USER_STATE.active)
+    }
   })
 })

--- a/src/types/__test__/2/recommendation/articles.test.ts
+++ b/src/types/__test__/2/recommendation/articles.test.ts
@@ -11,6 +11,7 @@ import {
   TRANSACTION_PURPOSE,
   TRANSACTION_STATE,
   DEFAULT_TAKE_PER_PAGE,
+  USER_STATE,
 } from '#common/enums/index.js'
 import {
   AtomService,
@@ -18,6 +19,7 @@ import {
   PublicationService,
   PaymentService,
   CampaignService,
+  RecommendationService,
   SystemService,
   UserService,
 } from '#connectors/index.js'
@@ -130,6 +132,34 @@ describe('hottest articles', () => {
     })
     expect(scorePrev * _.clamp(tagBoostEff, 0.5, 2)).toBe(score)
   })
+  test('banned authors are excluded from the hottest pool', async () => {
+    // hit the pool query directly: the resolver caches ids in redis and the
+    // rest of this suite relies on that cache staying warm
+    const recommendationService = new RecommendationService(connections)
+    const poolArgs = { readersThreshold: 1, commentsThreshold: 1 }
+
+    const before = await recommendationService.findHottestArticles(poolArgs)
+    expect(before.map(({ articleId }) => articleId)).toContain(article.id)
+
+    await atomService.update({
+      table: 'user',
+      where: { id: article.authorId },
+      data: { state: USER_STATE.banned },
+    })
+    try {
+      const excluded = await recommendationService.findHottestArticles(poolArgs)
+      expect(excluded.map(({ articleId }) => articleId)).not.toContain(
+        article.id
+      )
+    } finally {
+      await atomService.update({
+        table: 'user',
+        where: { id: article.authorId },
+        data: { state: USER_STATE.active },
+      })
+    }
+  })
+
   test('campaign_boost works', async () => {
     const [campaign] = await createCampaign(campaignService, article)
     const boost = 10

--- a/src/types/__test__/2/recommendation/authors.test.ts
+++ b/src/types/__test__/2/recommendation/authors.test.ts
@@ -1,8 +1,13 @@
 import type { Connections } from '#definitions/index.js'
 
-import { MATERIALIZED_VIEW, NODE_TYPES } from '#common/enums/index.js'
+import {
+  CACHE_PREFIX,
+  MATERIALIZED_VIEW,
+  NODE_TYPES,
+  USER_STATE,
+} from '#common/enums/index.js'
 import { refreshView } from '#connectors/__test__/utils.js'
-import { ChannelService } from '#connectors/index.js'
+import { AtomService, Cache, ChannelService } from '#connectors/index.js'
 import { toGlobalId } from '#common/utils/index.js'
 
 import { testClient, genConnections, closeConnections } from '../../utils.js'
@@ -99,5 +104,118 @@ describe('authors', () => {
       },
     })
     expect(errors2).toBeUndefined()
+  })
+
+  test('state-restricted authors are excluded at read time even when cached', async () => {
+    const atomService = new AtomService(connections)
+    // two non-viewer authors from seeds, forced to a known baseline state
+    const [activeAuthor, toFreezeAuthor] = await atomService.findMany({
+      table: 'user',
+      whereIn: ['id', ['2', '3']],
+      orderBy: [{ column: 'id', order: 'asc' }],
+    })
+    for (const { id } of [activeAuthor, toFreezeAuthor]) {
+      await atomService.update({
+        table: 'user',
+        where: { id },
+        data: { state: USER_STATE.active },
+      })
+    }
+    const cache = new Cache(
+      CACHE_PREFIX.RECOMMENDATION_AUTHORS,
+      connections.objectCacheRedis
+    )
+    // simulate a pool cached before the freeze happened
+    await cache.storeObject({
+      keys: { type: 'recommendationAuthors', args: { channelId: undefined } },
+      data: [{ authorId: activeAuthor.id }, { authorId: toFreezeAuthor.id }],
+      expire: 60,
+    })
+    await atomService.update({
+      table: 'user',
+      where: { id: toFreezeAuthor.id },
+      data: { state: USER_STATE.frozen },
+    })
+
+    const server = await testClient({ isAuth: true, connections })
+    const { errors, data } = await server.executeOperation({
+      query: GET_AUTHOR_RECOMMENDATION,
+      variables: { input: { first: 5 } },
+    })
+    expect(errors).toBeUndefined()
+    const ids = data.viewer.recommendation.authors.edges.map(
+      ({ node }: { node: { id: string } }) => node.id
+    )
+    expect(ids).toContain(
+      toGlobalId({ type: NODE_TYPES.User, id: activeAuthor.id })
+    )
+    expect(ids).not.toContain(
+      toGlobalId({ type: NODE_TYPES.User, id: toFreezeAuthor.id })
+    )
+
+    await atomService.update({
+      table: 'user',
+      where: { id: toFreezeAuthor.id },
+      data: { state: USER_STATE.active },
+    })
+  })
+
+  test('freezing a user purges the recommended-authors cache', async () => {
+    const atomService = new AtomService(connections)
+    const target = await atomService.findUnique({
+      table: 'user',
+      where: { id: '3' },
+    })
+    await atomService.update({
+      table: 'user',
+      where: { id: target.id },
+      data: { state: USER_STATE.active },
+    })
+    const cache = new Cache(
+      CACHE_PREFIX.RECOMMENDATION_AUTHORS,
+      connections.objectCacheRedis
+    )
+    const sitewideKey = cache.genKey({
+      type: 'recommendationAuthors',
+      args: { channelId: undefined },
+    })
+    await cache.storeObject({
+      keys: { type: 'recommendationAuthors', args: { channelId: undefined } },
+      data: [{ authorId: target.id }],
+      expire: 60,
+    })
+
+    const server = await testClient({
+      isAuth: true,
+      isAdmin: true,
+      connections,
+    })
+    const UPDATE_USER_STATE = /* GraphQL */ `
+      mutation ($input: UpdateUserStateInput!) {
+        updateUserState(input: $input) {
+          id
+          status {
+            state
+          }
+        }
+      }
+    `
+    const { errors } = await server.executeOperation({
+      query: UPDATE_USER_STATE,
+      variables: {
+        input: {
+          id: toGlobalId({ type: NODE_TYPES.User, id: target.id }),
+          state: 'frozen',
+        },
+      },
+    })
+    expect(errors).toBeUndefined()
+    expect(await connections.objectCacheRedis.get(sitewideKey)).toBeNull()
+
+    await atomService.update({
+      table: 'user',
+      where: { id: target.id },
+      data: { state: USER_STATE.active },
+    })
   })
 })

--- a/src/types/__test__/2/recommendation/icymi.test.ts
+++ b/src/types/__test__/2/recommendation/icymi.test.ts
@@ -6,6 +6,7 @@ import {
   NODE_TYPES,
   MATTERS_CHOICE_TOPIC_STATE,
   LANGUAGE,
+  USER_STATE,
 } from '#common/enums/index.js'
 import { RecommendationService, AtomService } from '#connectors/index.js'
 import { toGlobalId } from '#common/utils/index.js'
@@ -70,6 +71,52 @@ describe('icymi', () => {
     })
     expect(errors).toBeUndefined()
     expect(data.viewer.recommendation.icymi.totalCount).toBeGreaterThan(0)
+  })
+  test('articles by state-restricted authors are excluded', async () => {
+    const server = await testClient({ connections })
+    const article = await atomService.findUnique({
+      table: 'article',
+      where: { id: '1' },
+    })
+    await atomService.upsert({
+      table: 'matters_choice',
+      where: { articleId: article.id },
+      create: { articleId: article.id },
+      update: {},
+    })
+
+    await atomService.update({
+      table: 'user',
+      where: { id: article.authorId },
+      data: { state: USER_STATE.frozen },
+    })
+    const { errors, data } = await server.executeOperation({
+      query: GET_VIEWER_RECOMMENDATION_ICYMI,
+      variables: { input: { first: 10 } },
+    })
+    expect(errors).toBeUndefined()
+    const ids = data.viewer.recommendation.icymi.edges.map(
+      ({ node }: { node: { id: string } }) => node.id
+    )
+    expect(ids).not.toContain(
+      toGlobalId({ type: NODE_TYPES.Article, id: article.id })
+    )
+
+    await atomService.update({
+      table: 'user',
+      where: { id: article.authorId },
+      data: { state: USER_STATE.active },
+    })
+    const { data: restoredData } = await server.executeOperation({
+      query: GET_VIEWER_RECOMMENDATION_ICYMI,
+      variables: { input: { first: 10 } },
+    })
+    const restoredIds = restoredData.viewer.recommendation.icymi.edges.map(
+      ({ node }: { node: { id: string } }) => node.id
+    )
+    expect(restoredIds).toContain(
+      toGlobalId({ type: NODE_TYPES.Article, id: article.id })
+    )
   })
 })
 


### PR DESCRIPTION
Promote develop → production.

## Included
- #4920 fix(feed): exclude frozen authors from recommendation surfaces (authors/newest/icymi/channel pinned) + purge cached recommendation pools on freeze/unfreeze; incl. perf follow-up (correlated author-state modifier)
- #4918 fix(quote): hide restricted authors' quotes and articles from the quote wall
- #4921 fix(cloudflare): surface Images API failures instead of swallowing them

## Why
#4920/#4918 close the remaining frozen-account discovery-surface leaks (推薦面/引用牆), following up the 2026-07-04 frozen public-surface series. Frozen accounts (e.g. spam freezes) currently still appear in「值得追蹤」until the daily cache expires.

## Verify after deploy
- `recommendation.authors` / newest / icymi no longer return frozen authors (spot-check with a recently frozen spam account)
- freeze via OSS console → recommendation caches purged (no 1-day residue)
- quote wall spot-check
- image upload failure returns explicit error (not silent success)

🤖 Generated with [Claude Code](https://claude.com/claude-code)