### PR TITLE
fix(feed): exclude restricted authors from campaign feed; add banned to hottest

### DIFF
--- a/src/connectors/__test__/campaignService.test.ts
+++ b/src/connectors/__test__/campaignService.test.ts
@@ -259,6 +259,26 @@ describe('find and count articles', () => {
       data: { state: ARTICLE_STATE.active },
     })
   })
+  test('state-restricted authors are excluded', async () => {
+    const before = await campaignService.findArticles(campaign.id)
+    expect(before.length).toBeGreaterThan(0)
+
+    await atomService.update({
+      table: 'user',
+      where: { id: '1' },
+      data: { state: USER_STATE.frozen },
+    })
+    const excluded = await campaignService.findArticles(campaign.id)
+    expect(excluded.length).toBe(0)
+
+    await atomService.update({
+      table: 'user',
+      where: { id: '1' },
+      data: { state: USER_STATE.active },
+    })
+    const restored = await campaignService.findArticles(campaign.id)
+    expect(restored.length).toBe(before.length)
+  })
   // test('spam are excluded', async () => {
   //   const spamThreshold = 0.5
   //   const _articles1 = await campaignService.findArticles(campaign.id)

--- a/src/connectors/campaignService.ts
+++ b/src/connectors/campaignService.ts
@@ -33,6 +33,7 @@ import {
   toDatetimeRangeString,
   fromDatetimeRangeString,
   fromGlobalId,
+  excludeStateRestrictedAuthors,
   // excludeSpam,
 } from '#common/utils/index.js'
 import { invalidateFQC } from '@matters/apollo-response-cache'
@@ -350,6 +351,11 @@ export class CampaignService {
     if (featured) {
       query.where({ featured })
     }
+
+    // freezing only flips user.state, so without this the public campaign
+    // feed keeps listing frozen authors' articles (applied as a plain call:
+    // knex's loosely-typed `.modify()` would widen the query's row type)
+    excludeStateRestrictedAuthors(query)
 
     return query
   }

--- a/src/connectors/recommendationService.ts
+++ b/src/connectors/recommendationService.ts
@@ -367,7 +367,13 @@ export class RecommendationService {
                   isSpam: false,
                   spamThreshold: spamThreshold ?? 0,
                 },
-                excludeAuthorStates: [USER_STATE.frozen, USER_STATE.archived],
+                // keep in sync with excludeStateRestrictedAuthors: banned
+                // authors' works must not resurface in hottest either
+                excludeAuthorStates: [
+                  USER_STATE.frozen,
+                  USER_STATE.banned,
+                  USER_STATE.archived,
+                ],
                 excludeRestrictedAuthors: USER_RESTRICTION_TYPE.articleHottest,
                 excludeExclusiveCampaignArticles: true,
                 excludeComplaintAreaArticles: true,

--- a/src/types/__test__/2/recommendation/articles.test.ts
+++ b/src/types/__test__/2/recommendation/articles.test.ts
@@ -11,6 +11,7 @@ import {
   TRANSACTION_PURPOSE,
   TRANSACTION_STATE,
   DEFAULT_TAKE_PER_PAGE,
+  USER_STATE,
 } from '#common/enums/index.js'
 import {
   AtomService,
@@ -18,6 +19,7 @@ import {
   PublicationService,
   PaymentService,
   CampaignService,
+  RecommendationService,
   SystemService,
   UserService,
 } from '#connectors/index.js'
@@ -130,6 +132,34 @@ describe('hottest articles', () => {
     })
     expect(scorePrev * _.clamp(tagBoostEff, 0.5, 2)).toBe(score)
   })
+  test('banned authors are excluded from the hottest pool', async () => {
+    // hit the pool query directly: the resolver caches ids in redis and the
+    // rest of this suite relies on that cache staying warm
+    const recommendationService = new RecommendationService(connections)
+    const poolArgs = { readersThreshold: 1, commentsThreshold: 1 }
+
+    const before = await recommendationService.findHottestArticles(poolArgs)
+    expect(before.map(({ articleId }) => articleId)).toContain(article.id)
+
+    await atomService.update({
+      table: 'user',
+      where: { id: article.authorId },
+      data: { state: USER_STATE.banned },
+    })
+    try {
+      const excluded = await recommendationService.findHottestArticles(poolArgs)
+      expect(excluded.map(({ articleId }) => articleId)).not.toContain(
+        article.id
+      )
+    } finally {
+      await atomService.update({
+        table: 'user',
+        where: { id: article.authorId },
+        data: { state: USER_STATE.active },
+      })
+    }
+  })
+
   test('campaign_boost works', async () => {
     const [campaign] = await createCampaign(campaignService, article)
     const boost = 10


### PR DESCRIPTION
Follow-ups from the [PR #4920 security audit](https://github.com/thematters/matters-server/pull/4920#issuecomment-4889976657) (both LOW severity):

## What

1. **Campaign public article list leaked restricted authors.** `campaignService.findArticles` (exposed via `WritingChallenge.articles`) had no author-state filter — frozen/banned/archived authors' articles stayed visible in writing-challenge feeds (#4918 only covered the quote wall). Now applies the shared `excludeStateRestrictedAuthors` (as a plain call — knex's loosely-typed `.modify()` widens the query's row type).
2. **hottest was missing `banned`.** Its pool excluded `[frozen, archived]` while every other surface uses the frozen/banned/archived triple; now consistent.

## Tests

- campaign: freezing the author empties `findArticles`, restoring brings it back (connectors, 15/15 pass)
- hottest: banning the author drops the article from `findHottestArticles` pool, tested at service level because the resolver's redis cache is deliberately kept warm by the rest of the suite (types, 8/8 pass; pre-existing local-only `search_index` teardown error reproduces on clean develop)

No schema changes, no flags — same disposition as #4920 (approved SPEC: frozen accounts out of all public discovery surfaces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)