### PR TITLE
feat(moderation): 小黑屋機制強化 — 永久小黑屋＋凍結/spam-ring 內容自動退出頻道

### DIFF
--- a/db/migrations/20260706000000_archive_unexpired_punish_records.js
+++ b/db/migrations/20260706000000_archive_unexpired_punish_records.js
@@ -1,0 +1,21 @@
+const table = 'punish_record'
+
+// OSS「關小黑屋」改為永久（SPEC-blackhouse-permanent-and-auto §2-A）。
+// 存量一併轉永久：未到期的 banned punish_record 直接 archive，
+// 每日 unbanUsers job 便不再自動解禁這些帳號（解禁改走人工 updateUserState）。
+// 已到期但尚未處理的記錄留給 job 正常放行，不在此轉換。
+export const up = async (knex) => {
+  await knex(table)
+    .where({ state: 'banned', archived: false })
+    .where('expired_at', '>', knex.fn.now())
+    .update({ archived: true, updated_at: knex.fn.now() })
+}
+
+// 反向：把「到期日還在未來」的已 archive 記錄還原成待處理。
+// 只會撈回本 migration 轉換的那批（手動解禁會經 unbanUser 清掉記錄或已到期）。
+export const down = async (knex) => {
+  await knex(table)
+    .where({ state: 'banned', archived: true })
+    .where('expired_at', '>', knex.fn.now())
+    .update({ archived: false, updated_at: knex.fn.now() })
+}

--- a/db/migrations/20260706001000_add_spam_ring_restriction_feature_flag.js
+++ b/db/migrations/20260706001000_add_spam_ring_restriction_feature_flag.js
@@ -1,0 +1,16 @@
+const table = 'feature_flag'
+const name = 'spam_ring_restriction'
+
+// Dark launch: spam-ring 偵測即作者級排除（SPEC-blackhouse-permanent-and-auto §2-D）。
+// flag 預設 off，upsert 不寫 user_restriction，行為與現狀完全相同。
+// 列必須先存在，setFeature（UPDATE）才能當 kill-switch。
+export const up = async (knex) => {
+  await knex(table)
+    .insert({ name, flag: 'off', value: null })
+    .onConflict('name')
+    .ignore()
+}
+
+export const down = async (knex) => {
+  await knex(table).where({ name }).del()
+}

--- a/db/migrations/20260706002000_add_spam_ring_user_restriction_type.js
+++ b/db/migrations/20260706002000_add_spam_ring_user_restriction_type.js
@@ -1,0 +1,30 @@
+const table = 'user_restriction'
+const constraint = 'user_restriction_type_check'
+
+// 新增 user_restriction 類型 'spamRing'：spam-ring 偵測到的成員在人工複查前
+// 先退出頻道/最新/熱門（SPEC-blackhouse-permanent-and-auto §2-D）。
+// t.enu() 產生的 CHECK constraint 需重建才能容納新值。
+const TYPES = ['articleHottest', 'articleNewest', 'spamRing']
+
+const setCheck = async (knex, types) => {
+  const list = types.map((t) => `'${t}'`).join(', ')
+  await knex.raw(
+    `ALTER TABLE "${table}" DROP CONSTRAINT IF EXISTS "${constraint}"`
+  )
+  await knex.raw(
+    `ALTER TABLE "${table}" ADD CONSTRAINT "${constraint}" CHECK (type IN (${list}))`
+  )
+}
+
+export const up = async (knex) => {
+  await setCheck(knex, TYPES)
+}
+
+export const down = async (knex) => {
+  // 先清掉 spamRing 列，否則收窄 constraint 會失敗
+  await knex(table).where({ type: 'spamRing' }).del()
+  await setCheck(
+    knex,
+    TYPES.filter((t) => t !== 'spamRing')
+  )
+}

--- a/db/migrations/20260706003000_backfill_is_spam_for_frozen_users_content.js
+++ b/db/migrations/20260706003000_backfill_is_spam_for_frozen_users_content.js
@@ -1,0 +1,30 @@
+const CONTENT_TABLES = ['article', 'comment', 'moment']
+
+// 凍結帳號內容自動標 Spam 的存量回填（SPEC-blackhouse-permanent-and-auto §2-B5）。
+// 只補 is_spam IS NULL 的列：既有人工判定（true/false）不覆蓋。
+// 誤凍帳號解凍時由 unfreezeUser 把 true 復原為 null（回到分類器評分判定）。
+export const up = async (knex) => {
+  for (const table of CONTENT_TABLES) {
+    await knex(table)
+      .whereNull('is_spam')
+      .whereIn(
+        'author_id',
+        knex('user').select('id').where({ state: 'frozen' })
+      )
+      .update({ is_spam: true })
+  }
+}
+
+// 反向：把仍處於凍結狀態的作者內容 is_spam 還原為 null。
+// （已解凍帳號的內容由 unfreezeUser 復原，不在此範圍。）
+export const down = async (knex) => {
+  for (const table of CONTENT_TABLES) {
+    await knex(table)
+      .where({ is_spam: true })
+      .whereIn(
+        'author_id',
+        knex('user').select('id').where({ state: 'frozen' })
+      )
+      .update({ is_spam: null })
+  }
+}

--- a/db/seeds/31_feature_flag.js
+++ b/db/seeds/31_feature_flag.js
@@ -54,5 +54,9 @@ export const seed = async (knex) => {
       name: 'discovery_probation',
       flag: 'off',
     },
+    {
+      name: 'spam_ring_restriction',
+      flag: 'off',
+    },
   ])
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -3016,6 +3016,7 @@ enum FeatureName {
   article_channel
   hottest_moment_feed
   discovery_probation
+  spam_ring_restriction
 }
 
 enum FeatureFlag {

--- a/src/common/enums/feature.ts
+++ b/src/common/enums/feature.ts
@@ -12,6 +12,7 @@ export const FEATURE_NAME = {
   article_channel: 'article_channel',
   hottest_moment_feed: 'hottest_moment_feed',
   discovery_probation: 'discovery_probation',
+  spam_ring_restriction: 'spam_ring_restriction',
 } as const
 
 export const FEATURE_FLAG = {

--- a/src/common/enums/oss.ts
+++ b/src/common/enums/oss.ts
@@ -1,7 +1,16 @@
 export const USER_RESTRICTION_TYPE = {
   articleHottest: 'articleHottest',
   articleNewest: 'articleNewest',
+  // internal-only: set/removed by spam-ring detection, NOT part of the
+  // GraphQL UserRestrictionType enum nor admin-editable via putRestrictedUsers
+  spamRing: 'spamRing',
 } as const
+
+// the subset admins manage via putRestrictedUsers / OSS restricted-user list
+export const ADMIN_USER_RESTRICTION_TYPES = [
+  USER_RESTRICTION_TYPE.articleHottest,
+  USER_RESTRICTION_TYPE.articleNewest,
+]
 
 export const USER_FEATURE_FLAG_TYPE = {
   bypassSpamDetection: 'bypassSpamDetection',

--- a/src/common/utils/__test__/spamRingResolvers.test.ts
+++ b/src/common/utils/__test__/spamRingResolvers.test.ts
@@ -59,6 +59,7 @@ const makeContext = (viewer: any = { id: '9' }) => {
           updated: 0,
           skipped: 0,
           rings: [],
+          restrictedUserIds: [],
         })),
       },
     },
@@ -239,6 +240,32 @@ describe('spam ring mutation resolvers', () => {
     expect(arg[0].memberUserNames).toBeUndefined()
     expect(arg[0].newAccountRatio).toBeUndefined()
     expect(arg[0].memberEvidence).toEqual({ u1: { a: 1 } })
+    // nothing newly restricted → no cache purge
+    expect(ctx.dataSources.articleService.findByAuthor).not.toHaveBeenCalled()
+  })
+
+  test('upsertSpamRingCandidates purges caches for newly-restricted members', async () => {
+    const ctx = makeContext()
+    ctx.dataSources.spamRingService.upsertCandidates = jest.fn(async () => ({
+      created: 1,
+      updated: 0,
+      skipped: 0,
+      rings: [],
+      restrictedUserIds: ['u1', 'u2'],
+    }))
+    await (upsertSpamRingCandidates as any)(
+      null,
+      {
+        input: { candidates: [{ fingerprint: 'fp1', memberUserIds: ['u1'] }] },
+      },
+      ctx
+    )
+    expect(ctx.dataSources.articleService.findByAuthor).toHaveBeenCalledWith(
+      'u1'
+    )
+    expect(ctx.dataSources.articleService.findByAuthor).toHaveBeenCalledWith(
+      'u2'
+    )
   })
 })
 

--- a/src/common/utils/knex.ts
+++ b/src/common/utils/knex.ts
@@ -47,18 +47,25 @@ export const excludeSpam = (
   }
 }
 
+// `spamRing` is excluded by default alongside `articleNewest`: rows of that
+// type only exist while the spam_ring_restriction flag is on, so default call
+// sites (channels / newest) are zero-diff until the feature launches.
 export const excludeRestrictedAuthors = (
   builder: Knex.QueryBuilder,
   table = 'article',
-  type: ValueOf<
-    typeof USER_RESTRICTION_TYPE
-  > = USER_RESTRICTION_TYPE.articleNewest
+  types:
+    | ValueOf<typeof USER_RESTRICTION_TYPE>
+    | Array<ValueOf<typeof USER_RESTRICTION_TYPE>> = [
+    USER_RESTRICTION_TYPE.articleNewest,
+    USER_RESTRICTION_TYPE.spamRing,
+  ]
 ) => {
+  const typeList = Array.isArray(types) ? types : [types]
   builder.whereNotExists((qb) =>
     qb
       .select(1)
       .from('user_restriction')
-      .where('user_restriction.type', type)
+      .whereIn('user_restriction.type', typeList)
       .where('user_restriction.user_id', qb.client.ref(`${table}.author_id`))
   )
 }

--- a/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
+++ b/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
@@ -422,6 +422,90 @@ describe('findTopicChannelArticles', () => {
 
       await atomService.deleteMany({ table: 'user_restriction' })
     })
+
+    test('pinned articles ARE excluded for spam-ring-detected authors', async () => {
+      // spamRing is a hard exclusion — unlike articleNewest, pinning does not
+      // override it
+      await atomService.create({
+        table: 'user_restriction',
+        data: {
+          userId: articles[0].authorId,
+          type: 'spamRing',
+        },
+      })
+      await atomService.update({
+        table: 'topic_channel',
+        where: { id: channel.id },
+        data: { pinnedArticles: [articles[0].id] },
+      })
+
+      const { query } = await channelService.findTopicChannelArticles(
+        channel.id
+      )
+      const results = await query
+
+      expect(results.map((a) => a.id)).not.toContain(articles[0].id)
+
+      await atomService.deleteMany({ table: 'user_restriction' })
+    })
+  })
+
+  describe('frozen / spam hard exclusions', () => {
+    afterEach(async () => {
+      await atomService.update({
+        table: 'user',
+        where: { id: articles[0].authorId },
+        data: { state: 'active' },
+      })
+      await atomService.update({
+        table: 'article',
+        where: { id: articles[0].id },
+        data: { isSpam: null },
+      })
+      await atomService.update({
+        table: 'topic_channel',
+        where: { id: channel.id },
+        data: { pinnedArticles: [] },
+      })
+    })
+
+    test('excludes pinned article whose author is frozen', async () => {
+      await atomService.update({
+        table: 'user',
+        where: { id: articles[0].authorId },
+        data: { state: 'frozen' },
+      })
+      await atomService.update({
+        table: 'topic_channel',
+        where: { id: channel.id },
+        data: { pinnedArticles: [articles[0].id] },
+      })
+
+      const { query } = await channelService.findTopicChannelArticles(
+        channel.id
+      )
+      const results = await query
+      expect(results.map((a) => a.id)).not.toContain(articles[0].id)
+    })
+
+    test('excludes pinned article marked is_spam=true', async () => {
+      await atomService.update({
+        table: 'article',
+        where: { id: articles[0].id },
+        data: { isSpam: true },
+      })
+      await atomService.update({
+        table: 'topic_channel',
+        where: { id: channel.id },
+        data: { pinnedArticles: [articles[0].id] },
+      })
+
+      const { query } = await channelService.findTopicChannelArticles(
+        channel.id
+      )
+      const results = await query
+      expect(results.map((a) => a.id)).not.toContain(articles[0].id)
+    })
   })
 
   describe('discovery probation', () => {

--- a/src/connectors/__test__/spamRingRestriction.test.ts
+++ b/src/connectors/__test__/spamRingRestriction.test.ts
@@ -1,0 +1,122 @@
+import type { Connections } from '#definitions/index.js'
+
+import { FEATURE_FLAG, FEATURE_NAME } from '#common/enums/index.js'
+import { AtomService } from '../atomService.js'
+import { SpamRingService } from '../spamRingService.js'
+import { SystemService } from '../systemService.js'
+import { UserService } from '../userService.js'
+import { genConnections, closeConnections } from './utils.js'
+
+let connections: Connections
+let spamRingService: SpamRingService
+let systemService: SystemService
+let userService: UserService
+let atomService: AtomService
+
+beforeAll(async () => {
+  connections = await genConnections()
+  spamRingService = new SpamRingService(connections)
+  systemService = new SystemService(connections)
+  userService = new UserService(connections)
+  atomService = new AtomService(connections)
+}, 30000)
+
+afterAll(async () => {
+  await closeConnections(connections)
+})
+
+const setFlag = (flag: keyof typeof FEATURE_FLAG) =>
+  systemService.setFeatureFlag({
+    name: FEATURE_NAME.spam_ring_restriction,
+    flag,
+  })
+
+const spamRingRestrictions = async (userId: string) =>
+  atomService.findMany({
+    table: 'user_restriction',
+    where: { userId, type: 'spamRing' },
+  })
+
+beforeEach(async () => {
+  await atomService.deleteMany({ table: 'spam_ring_event' })
+  await atomService.deleteMany({ table: 'spam_ring_member' })
+  await atomService.deleteMany({ table: 'spam_ring' })
+  await connections.knex('user_restriction').where({ type: 'spamRing' }).del()
+})
+
+describe('spam-ring detection-time restrictions', () => {
+  test('flag off: upsert writes no restrictions (zero diff)', async () => {
+    await setFlag(FEATURE_FLAG.off)
+    await spamRingService.upsertCandidates([
+      { fingerprint: 'fp-off', memberUserIds: ['2', '3'], nAuthors: 2 },
+    ])
+    expect(await spamRingRestrictions('2')).toHaveLength(0)
+    expect(await spamRingRestrictions('3')).toHaveLength(0)
+  })
+
+  test('flag on: upsert restricts each member once (idempotent)', async () => {
+    await setFlag(FEATURE_FLAG.on)
+    await spamRingService.upsertCandidates([
+      { fingerprint: 'fp-on', memberUserIds: ['2', '3'], nAuthors: 2 },
+    ])
+    expect(await spamRingRestrictions('2')).toHaveLength(1)
+    expect(await spamRingRestrictions('3')).toHaveLength(1)
+
+    // re-upsert the same ring must not duplicate the restriction
+    await spamRingService.upsertCandidates([
+      { fingerprint: 'fp-on', memberUserIds: ['2', '3'], nAuthors: 2 },
+    ])
+    expect(await spamRingRestrictions('2')).toHaveLength(1)
+  })
+
+  test('dismiss lifts the members restrictions', async () => {
+    await setFlag(FEATURE_FLAG.on)
+    const { rings } = await spamRingService.upsertCandidates([
+      { fingerprint: 'fp-dismiss', memberUserIds: ['2', '3'], nAuthors: 2 },
+    ])
+    expect(await spamRingRestrictions('2')).toHaveLength(1)
+
+    await spamRingService.dismissRing({ ringId: rings[0].id, actorId: '6' })
+    expect(await spamRingRestrictions('2')).toHaveLength(0)
+    expect(await spamRingRestrictions('3')).toHaveLength(0)
+  })
+
+  test('dismiss keeps restriction for a member still in another pending ring', async () => {
+    await setFlag(FEATURE_FLAG.on)
+    const { rings: ringsA } = await spamRingService.upsertCandidates([
+      { fingerprint: 'fp-a', memberUserIds: ['2', '3'], nAuthors: 2 },
+    ])
+    const { rings: ringsB } = await spamRingService.upsertCandidates([
+      // user 2 is shared across both rings
+      { fingerprint: 'fp-b', memberUserIds: ['2'], nAuthors: 1 },
+    ])
+    expect(ringsA[0].id).not.toBe(ringsB[0].id)
+    expect(await spamRingRestrictions('2')).toHaveLength(1)
+
+    // dismissing ring A must NOT unhide user 2 — ring B still flags them
+    await spamRingService.dismissRing({ ringId: ringsA[0].id, actorId: '6' })
+    expect(await spamRingRestrictions('2')).toHaveLength(1)
+    // user 3 was only in ring A, so their restriction is lifted
+    expect(await spamRingRestrictions('3')).toHaveLength(0)
+  })
+
+  test('restore (unfreeze ring) lifts restrictions of members frozen by it', async () => {
+    await setFlag(FEATURE_FLAG.on)
+    const { rings } = await spamRingService.upsertCandidates([
+      { fingerprint: 'fp-restore', memberUserIds: ['4'], nAuthors: 1 },
+    ])
+    const ringId = rings[0].id
+    await spamRingService.freezeRing({ ringId, actorId: '6', userService })
+    expect(await spamRingRestrictions('4')).toHaveLength(1)
+
+    await spamRingService.unfreezeRing({ ringId, actorId: '6', userService })
+    expect(await spamRingRestrictions('4')).toHaveLength(0)
+    // clean up the state change freeze/unfreeze left on the user
+    await atomService.update({
+      table: 'user',
+      where: { id: '4' },
+      data: { state: 'active' },
+    })
+    await userService.revertUserContentSpamMarks('4')
+  })
+})

--- a/src/connectors/__test__/spamRingRestriction.test.ts
+++ b/src/connectors/__test__/spamRingRestriction.test.ts
@@ -47,26 +47,32 @@ beforeEach(async () => {
 describe('spam-ring detection-time restrictions', () => {
   test('flag off: upsert writes no restrictions (zero diff)', async () => {
     await setFlag(FEATURE_FLAG.off)
-    await spamRingService.upsertCandidates([
+    const result = await spamRingService.upsertCandidates([
       { fingerprint: 'fp-off', memberUserIds: ['2', '3'], nAuthors: 2 },
     ])
     expect(await spamRingRestrictions('2')).toHaveLength(0)
     expect(await spamRingRestrictions('3')).toHaveLength(0)
+    // nothing newly restricted → nothing to purge
+    expect(result.restrictedUserIds).toEqual([])
   })
 
   test('flag on: upsert restricts each member once (idempotent)', async () => {
     await setFlag(FEATURE_FLAG.on)
-    await spamRingService.upsertCandidates([
+    const first = await spamRingService.upsertCandidates([
       { fingerprint: 'fp-on', memberUserIds: ['2', '3'], nAuthors: 2 },
     ])
     expect(await spamRingRestrictions('2')).toHaveLength(1)
     expect(await spamRingRestrictions('3')).toHaveLength(1)
+    // newly-restricted members are reported so the resolver can purge them
+    expect(first.restrictedUserIds.sort()).toEqual(['2', '3'])
 
-    // re-upsert the same ring must not duplicate the restriction
-    await spamRingService.upsertCandidates([
+    // re-upsert the same ring must not duplicate the restriction nor re-report
+    // members as newly restricted (no redundant cache purge)
+    const second = await spamRingService.upsertCandidates([
       { fingerprint: 'fp-on', memberUserIds: ['2', '3'], nAuthors: 2 },
     ])
     expect(await spamRingRestrictions('2')).toHaveLength(1)
+    expect(second.restrictedUserIds).toEqual([])
   })
 
   test('dismiss lifts the members restrictions', async () => {

--- a/src/connectors/__test__/spamRingService.test.ts
+++ b/src/connectors/__test__/spamRingService.test.ts
@@ -30,6 +30,10 @@ const makeConnections = ({
       orderBy: () => b,
       transacting: () => b,
       forUpdate: () => b,
+      select: () => b,
+      whereIn: () => b,
+      whereNot: () => b,
+      del: () => b,
       modify: (fn?: any) => {
         if (fn) fn(b)
         return b
@@ -557,6 +561,8 @@ const makeImportConnections = ({
         rec.whereInCalls.push({ table, column, values })
         return b
       },
+      whereNot: () => b,
+      del: () => b,
       select: () => b,
       orderBy: (...args: any[]) => {
         rec.orderByCalls.push({ table, args })

--- a/src/connectors/__test__/userService.freezeSpam.test.ts
+++ b/src/connectors/__test__/userService.freezeSpam.test.ts
@@ -1,0 +1,147 @@
+import type { Connections } from '#definitions/index.js'
+
+import { USER_STATE } from '#common/enums/index.js'
+import { AtomService } from '../atomService.js'
+import { UserService } from '../userService.js'
+import { genConnections, closeConnections } from './utils.js'
+
+let connections: Connections
+let userService: UserService
+let atomService: AtomService
+
+// a seed user with no spam/frozen entanglement, reused across cases
+const USER_ID = '4'
+
+beforeAll(async () => {
+  connections = await genConnections()
+  userService = new UserService(connections)
+  atomService = new AtomService(connections)
+}, 30000)
+
+afterAll(async () => {
+  await closeConnections(connections)
+})
+
+const seedContent = async () => {
+  const article = await atomService.create({
+    table: 'article',
+    data: {
+      authorId: USER_ID,
+      state: 'active',
+      shortHash: 'freezeSpamArticle01',
+      isSpam: null,
+    },
+  })
+  const comment = await atomService.create({
+    table: 'comment',
+    data: {
+      uuid: '00000000-0000-4000-8000-00000000fa01',
+      authorId: USER_ID,
+      state: 'active',
+      content: 'freeze-spam-comment',
+      type: 'article',
+      targetId: article.id,
+      targetTypeId: '4',
+      isSpam: null,
+    },
+  })
+  const moment = await atomService.create({
+    table: 'moment',
+    data: {
+      shortHash: 'freezeSpamMoment01',
+      authorId: USER_ID,
+      state: 'active',
+      content: 'freeze-spam-moment',
+      isSpam: null,
+    },
+  })
+  return { article, comment, moment }
+}
+
+const readSpam = async () => {
+  const [article, comment, moment] = await Promise.all([
+    atomService.findFirst({
+      table: 'article',
+      where: { authorId: USER_ID, shortHash: 'freezeSpamArticle01' },
+    }),
+    atomService.findFirst({
+      table: 'comment',
+      where: { authorId: USER_ID, content: 'freeze-spam-comment' },
+    }),
+    atomService.findFirst({
+      table: 'moment',
+      where: { authorId: USER_ID, content: 'freeze-spam-moment' },
+    }),
+  ])
+  return {
+    article: article?.isSpam,
+    comment: comment?.isSpam,
+    moment: moment?.isSpam,
+  }
+}
+
+describe('freezeUser / unfreezeUser spam marking', () => {
+  beforeEach(async () => {
+    await atomService.deleteMany({
+      table: 'comment',
+      where: { authorId: USER_ID, content: 'freeze-spam-comment' },
+    })
+    await atomService.deleteMany({
+      table: 'moment',
+      where: { authorId: USER_ID, content: 'freeze-spam-moment' },
+    })
+    await atomService.deleteMany({
+      table: 'article',
+      where: { authorId: USER_ID, shortHash: 'freezeSpamArticle01' },
+    })
+    await atomService.update({
+      table: 'user',
+      where: { id: USER_ID },
+      data: { state: USER_STATE.active },
+    })
+  })
+
+  test('freeze marks all content spam, unfreeze reverts to null', async () => {
+    await seedContent()
+    expect(await readSpam()).toEqual({
+      article: null,
+      comment: null,
+      moment: null,
+    })
+
+    await userService.freezeUser(USER_ID)
+    expect(await readSpam()).toEqual({
+      article: true,
+      comment: true,
+      moment: true,
+    })
+
+    await userService.unfreezeUser(USER_ID, USER_STATE.active)
+    expect(await readSpam()).toEqual({
+      article: null,
+      comment: null,
+      moment: null,
+    })
+  })
+
+  test('freeze does not overwrite an existing is_spam=false verdict', async () => {
+    const { article } = await seedContent()
+    await atomService.update({
+      table: 'article',
+      where: { id: article.id },
+      data: { isSpam: false },
+    })
+
+    await userService.freezeUser(USER_ID)
+
+    const after = await readSpam()
+    // manual "not spam" verdict is preserved; the rest are marked
+    expect(after.article).toBe(false)
+    expect(after.comment).toBe(true)
+    expect(after.moment).toBe(true)
+
+    // unfreeze must not resurrect the false verdict into null
+    await userService.unfreezeUser(USER_ID, USER_STATE.active)
+    expect((await readSpam()).article).toBe(false)
+  })
+})

--- a/src/connectors/article/articleService.ts
+++ b/src/connectors/article/articleService.ts
@@ -107,7 +107,9 @@ export class ArticleService extends BaseService<Article> {
         spamThreshold: number
       }
       excludeAuthorStates?: Array<ValueOf<typeof USER_STATE>>
-      excludeRestrictedAuthors?: ValueOf<typeof USER_RESTRICTION_TYPE>
+      excludeRestrictedAuthors?:
+        | ValueOf<typeof USER_RESTRICTION_TYPE>
+        | Array<ValueOf<typeof USER_RESTRICTION_TYPE>>
       excludeExclusiveCampaignArticles?: boolean
       excludeChannelArticles?: boolean
       excludeComplaintAreaArticles?: boolean
@@ -215,7 +217,10 @@ export class ArticleService extends BaseService<Article> {
             spamThreshold,
           }
         : undefined,
-      excludeRestrictedAuthors: USER_RESTRICTION_TYPE.articleNewest,
+      excludeRestrictedAuthors: [
+        USER_RESTRICTION_TYPE.articleNewest,
+        USER_RESTRICTION_TYPE.spamRing,
+      ],
       excludeChannelArticles,
       excludeExclusiveCampaignArticles,
       excludeProbationAuthors: probationDays,

--- a/src/connectors/channel/channelService.ts
+++ b/src/connectors/channel/channelService.ts
@@ -432,10 +432,6 @@ export class ChannelService {
         'article.channel_enabled': true,
       })
       .whereIn('article.id', pinnedArticleIds)
-    // pinning happens before an author may get frozen; keep parity with the
-    // unpinned query below (applied outside the chain so knex's loosely-typed
-    // `.modify()` does not widen the query's row type)
-    excludeStateRestrictedModifier(pinnedQuery)
 
     // pinning is admin curation, so it overrides the soft `articleNewest`
     // ranking restriction — but a frozen/banned/archived author, a

--- a/src/connectors/channel/channelService.ts
+++ b/src/connectors/channel/channelService.ts
@@ -5,6 +5,7 @@ import type {
   ValueOf,
   TopicChannelFeedback,
 } from '#definitions/index.js'
+import type { Knex } from 'knex'
 
 import {
   ARTICLE_CHANNEL_JOB_STATE,
@@ -23,6 +24,7 @@ import {
   CHANNEL_ANTIFLOOD_LIMIT_PER_WINDOW,
   AUDIT_LOG_ACTION,
   AUDIT_LOG_STATUS,
+  USER_RESTRICTION_TYPE,
 } from '#common/enums/index.js'
 import { environment } from '#common/environment.js'
 import {
@@ -405,6 +407,18 @@ export class ChannelService {
       ])
     const spamThreshold = topicChannelSpamThreshold ?? globalSpamThreshold
 
+    const applySpamFilter = (builder: Knex.QueryBuilder) => {
+      if (spamThreshold) {
+        builder.modify(excludeSpamModifier, spamThreshold)
+      } else {
+        builder.where((qb) => {
+          qb.where('article.is_spam', false).orWhere((b) => {
+            b.whereNull('article.is_spam')
+          })
+        })
+      }
+    }
+
     const pinnedQuery = knexRO
       .select(
         'article.*',
@@ -418,6 +432,20 @@ export class ChannelService {
         'article.channel_enabled': true,
       })
       .whereIn('article.id', pinnedArticleIds)
+
+    // pinning is admin curation, so it overrides the soft `articleNewest`
+    // ranking restriction — but a frozen/banned/archived author, a
+    // spam-marked article, or a spam-ring-detected author is a hard exclusion
+    // that must still drop out of the channel.
+    // statement form (not `.modify`) — knex's `.modify` return type degrades
+    // to `<any, any>` and breaks the callers' result typing
+    applySpamFilter(pinnedQuery)
+    excludeStateRestrictedModifier(pinnedQuery)
+    excludeRestrictedModifier(
+      pinnedQuery,
+      'article',
+      USER_RESTRICTION_TYPE.spamRing
+    )
 
     const unpinnedQuery = knexRO
       .select(
@@ -434,15 +462,7 @@ export class ChannelService {
       })
       .whereIn('topic_channel_article.channel_id', channelIds)
       .modify((builder) => {
-        if (spamThreshold) {
-          builder.modify(excludeSpamModifier, spamThreshold)
-        } else {
-          builder.where((qb) => {
-            qb.where('article.is_spam', false).orWhere((b) => {
-              b.whereNull('article.is_spam')
-            })
-          })
-        }
+        applySpamFilter(builder)
       })
       .modify(excludeRestrictedModifier)
       .modify(excludeStateRestrictedModifier)
@@ -716,6 +736,23 @@ export class ChannelService {
     { addOrderColumn }: { addOrderColumn: boolean } = { addOrderColumn: false }
   ) => {
     const knexRO = this.connections.knexRO
+
+    // curation is hand-picked, so no classifier-threshold filtering here —
+    // but explicitly spam-marked articles and frozen/banned/archived or
+    // spam-ring-detected authors must still drop out of the channel
+    const applyModerationFilter = (builder: Knex.QueryBuilder) => {
+      builder
+        .where((qb) => {
+          qb.where('article.is_spam', false).orWhereNull('article.is_spam')
+        })
+        .modify(excludeStateRestrictedModifier)
+        .modify(
+          excludeRestrictedModifier,
+          'article',
+          USER_RESTRICTION_TYPE.spamRing
+        )
+    }
+
     const pinnedQuery = knexRO('article')
       .select('article.*')
       .join(
@@ -741,6 +778,11 @@ export class ChannelService {
         'curation_channel_article.pinned': false,
         'article.state': ARTICLE_STATE.active,
       })
+
+    // statement form (not `.modify`) — knex's `.modify` return type degrades
+    // to `<any, any>` and breaks the callers' result typing
+    applyModerationFilter(pinnedQuery)
+    applyModerationFilter(unpinnedQuery)
 
     if (addOrderColumn) {
       pinnedQuery.select(

--- a/src/connectors/recommendationService.ts
+++ b/src/connectors/recommendationService.ts
@@ -365,7 +365,10 @@ export class RecommendationService {
                   spamThreshold: spamThreshold ?? 0,
                 },
                 excludeAuthorStates: [USER_STATE.frozen, USER_STATE.archived],
-                excludeRestrictedAuthors: USER_RESTRICTION_TYPE.articleHottest,
+                excludeRestrictedAuthors: [
+                  USER_RESTRICTION_TYPE.articleHottest,
+                  USER_RESTRICTION_TYPE.spamRing,
+                ],
                 excludeExclusiveCampaignArticles: true,
                 excludeComplaintAreaArticles: true,
                 excludeProbationAuthors: probationDays ?? undefined,

--- a/src/connectors/spamRingService.ts
+++ b/src/connectors/spamRingService.ts
@@ -166,11 +166,13 @@ export class SpamRingService extends BaseService<SpamRing> {
     updated: number
     skipped: number
     rings: SpamRing[]
+    restrictedUserIds: string[]
   }> => {
     let created = 0
     let updated = 0
     let skipped = 0
     const rings: SpamRing[] = []
+    const restrictedUserIds = new Set<string>()
     const restrictionEnabled = await this.isRestrictionEnabled()
 
     for (const c of candidates) {
@@ -240,12 +242,19 @@ export class SpamRingService extends BaseService<SpamRing> {
       // pending only: a restored ring re-surfacing must not override the
       // admin's restore decision
       if (restrictionEnabled && ring.status === 'pending') {
-        await this.applyMemberRestrictions(userIds)
+        const restricted = await this.applyMemberRestrictions(userIds)
+        restricted.forEach((id) => restrictedUserIds.add(id))
       }
       rings.push(ring)
     }
 
-    return { created, updated, skipped, rings }
+    return {
+      created,
+      updated,
+      skipped,
+      rings,
+      restrictedUserIds: Array.from(restrictedUserIds),
+    }
   }
 
   // --- 一鍵凍結（永久但可逆的封禁）---
@@ -605,9 +614,12 @@ export class SpamRingService extends BaseService<SpamRing> {
     return !!flag
   }
 
+  // returns the userIds that had a restriction newly written, so the caller
+  // can purge their content caches (an already-restricted member is a no-op)
   private applyMemberRestrictions = async (
     userIds: string[]
-  ): Promise<void> => {
+  ): Promise<string[]> => {
+    const restricted: string[] = []
     for (const userId of userIds) {
       const existing = await this.knexRO('user_restriction')
         .where({ userId, type: USER_RESTRICTION_TYPE.spamRing })
@@ -619,7 +631,9 @@ export class SpamRingService extends BaseService<SpamRing> {
         userId,
         type: USER_RESTRICTION_TYPE.spamRing,
       })
+      restricted.push(userId)
     }
+    return restricted
   }
 
   // lift the spamRing restriction of this ring's members, unless a member

--- a/src/connectors/spamRingService.ts
+++ b/src/connectors/spamRingService.ts
@@ -12,7 +12,13 @@ import type {
 import type { UserService } from './userService.js'
 import type { Knex } from 'knex'
 
-import { USER_STATE, USER_BAN_REMARK } from '#common/enums/index.js'
+import {
+  FEATURE_FLAG,
+  FEATURE_NAME,
+  USER_RESTRICTION_TYPE,
+  USER_STATE,
+  USER_BAN_REMARK,
+} from '#common/enums/index.js'
 import { UserInputError } from '#common/errors.js'
 import { v4 } from 'uuid'
 
@@ -165,6 +171,7 @@ export class SpamRingService extends BaseService<SpamRing> {
     let updated = 0
     let skipped = 0
     const rings: SpamRing[] = []
+    const restrictionEnabled = await this.isRestrictionEnabled()
 
     for (const c of candidates) {
       const existing = await this.findRingByFingerprint(c.fingerprint)
@@ -226,6 +233,15 @@ export class SpamRingService extends BaseService<SpamRing> {
 
       const userIds = await this.resolveMemberIds(c)
       await this.upsertMembers(ring.id, userIds, c.memberEvidence ?? null)
+
+      // detection-time author-level exclusion (dark, flag `spam_ring_restriction`):
+      // members drop out of channels / newest / hottest while pending human
+      // review — covers guardrail-skipped members auto-freeze cannot touch.
+      // pending only: a restored ring re-surfacing must not override the
+      // admin's restore decision
+      if (restrictionEnabled && ring.status === 'pending') {
+        await this.applyMemberRestrictions(userIds)
+      }
       rings.push(ring)
     }
 
@@ -522,6 +538,9 @@ export class SpamRingService extends BaseService<SpamRing> {
         unbanned.push(restored)
       }
 
+      // restore also lifts the detection-time author-level exclusion
+      await this.liftMemberRestrictions(ringId, trx)
+
       const now = new Date()
       const [ring2] = await this.knex('spam_ring')
         .transacting(trx)
@@ -564,10 +583,96 @@ export class SpamRingService extends BaseService<SpamRing> {
       .where({ id: ringId })
       .update({ status: 'dismissed', note: note ?? null, updatedAt: now })
       .returning('*')
+    // dismissal = false positive: lift the detection-time exclusion
+    await this.liftMemberRestrictions(ringId)
     await this.insertEvents([
       { ringId, actorId, action: 'dismissed', detail: { note: note ?? null } },
     ])
     return updatedRing
+  }
+
+  // --- 偵測即作者級排除（SPEC-blackhouse-permanent-and-auto §2-D）---
+
+  // flag read is viewer-independent (detection job runs headless), so query
+  // the row directly instead of systemService.isFeatureEnabled
+  private isRestrictionEnabled = async (): Promise<boolean> => {
+    const flag = await this.knexRO('feature_flag')
+      .where({
+        name: FEATURE_NAME.spam_ring_restriction,
+        flag: FEATURE_FLAG.on,
+      })
+      .first()
+    return !!flag
+  }
+
+  private applyMemberRestrictions = async (
+    userIds: string[]
+  ): Promise<void> => {
+    for (const userId of userIds) {
+      const existing = await this.knexRO('user_restriction')
+        .where({ userId, type: USER_RESTRICTION_TYPE.spamRing })
+        .first()
+      if (existing) {
+        continue
+      }
+      await this.knex('user_restriction').insert({
+        userId,
+        type: USER_RESTRICTION_TYPE.spamRing,
+      })
+    }
+  }
+
+  // lift the spamRing restriction of this ring's members, unless a member
+  // also belongs to another ring that is still detected (pending / frozen) —
+  // dismissing one ring must not unhide a user another ring still flags.
+  // runs regardless of the feature flag so turning the flag off later still
+  // lets dismiss/restore clean up rows written while it was on.
+  private liftMemberRestrictions = async (
+    ringId: string,
+    trx?: Knex.Transaction
+  ): Promise<void> => {
+    const memberQuery = this.knex('spam_ring_member')
+      .where({ ringId })
+      .select('userId')
+    if (trx) {
+      memberQuery.transacting(trx)
+    }
+    const memberRows = await memberQuery
+    const memberIds = Array.from(
+      new Set(memberRows.map((r: { userId: string }) => String(r.userId)))
+    )
+    if (memberIds.length === 0) {
+      return
+    }
+    // members still flagged by another ring that is actively detected
+    // (pending / frozen) — their restriction must stay
+    const activeRingIds = this.knex('spam_ring')
+      .whereIn('status', ['pending', 'frozen'])
+      .select('id')
+    const otherQuery = this.knex('spam_ring_member')
+      .whereIn('userId', memberIds)
+      .whereNot('ringId', ringId)
+      .whereIn('ringId', activeRingIds)
+      .select('userId')
+    if (trx) {
+      otherQuery.transacting(trx)
+    }
+    const otherRows = await otherQuery
+    const stillDetected = new Set(
+      otherRows.map((r: { userId: string }) => String(r.userId))
+    )
+    const toLift = memberIds.filter((id) => !stillDetected.has(id))
+    if (toLift.length === 0) {
+      return
+    }
+    const delQuery = this.knex('user_restriction')
+      .whereIn('userId', toLift)
+      .where({ type: USER_RESTRICTION_TYPE.spamRing })
+      .del()
+    if (trx) {
+      delQuery.transacting(trx)
+    }
+    await delQuery
   }
 
   // --- 私有輔助 ---

--- a/src/connectors/userService.ts
+++ b/src/connectors/userService.ts
@@ -43,6 +43,7 @@ import {
   VERIFICATION_CODE_STATUS,
   VERIFICATION_CODE_TYPE,
   USER_RESTRICTION_TYPE,
+  ADMIN_USER_RESTRICTION_TYPES,
   VIEW,
   CIRCLE_STATE,
   NOTICE_TYPE,
@@ -1875,13 +1876,20 @@ export class UserService extends BaseService<User> {
    *        Restrictions           *
    *                               *
    *********************************/
-  public findRestrictions = async (id: string): Promise<UserRestriction[]> => {
-    const table = 'user_restriction'
-    return this.models.findMany({
-      table,
-      select: ['type', 'createdAt'],
-      where: { userId: id },
-    })
+  // admin-managed types only by default: the internal `spamRing` type is not
+  // part of the GraphQL UserRestrictionType enum and must not leak into the
+  // OSS restrictions field, nor be deleted by updateRestrictions' diff
+  public findRestrictions = async (
+    id: string,
+    { includeInternal = false }: { includeInternal?: boolean } = {}
+  ): Promise<UserRestriction[]> => {
+    const query = this.knexRO('user_restriction')
+      .select('type', 'created_at')
+      .where({ userId: id })
+    if (!includeInternal) {
+      query.whereIn('type', ADMIN_USER_RESTRICTION_TYPES)
+    }
+    return query
   }
 
   public updateRestrictions = async (
@@ -1922,6 +1930,9 @@ export class UserService extends BaseService<User> {
       .select('user.*', this.knexRO.raw('COUNT(1) OVER() ::int AS total_count'))
       .from('user')
       .join('user_restriction', 'user.id', 'user_restriction.user_id')
+      // OSS restricted-user list manages admin-set types only; spam-ring
+      // detected members are reviewed on the rings page instead
+      .whereIn('user_restriction.type', ADMIN_USER_RESTRICTION_TYPES)
       .groupBy('user.id')
       .orderByRaw('MAX(user_restriction.created_at) DESC')
       .modify((builder: Knex.QueryBuilder) => {
@@ -2015,6 +2026,11 @@ export class UserService extends BaseService<User> {
       updatedAt: new Date(),
     }
 
+    // frozen accounts' content is spam by policy: mark it so spam-filtered
+    // surfaces (channels, feeds, classifier training) all pick it up.
+    // Only fills `null` rows — manual is_spam verdicts are kept.
+    await this.markUserContentSpam(userId, trx)
+
     return await this.baseUpdate(
       userId,
       remark ? { ...data, remark } : data,
@@ -2024,11 +2040,45 @@ export class UserService extends BaseService<User> {
   }
 
   // Reverse a freeze by restoring an explicit prior state (e.g. preFreezeState).
+  // Also reverts the freeze-time spam marks so a wrongly frozen user is fully
+  // restored (back to classifier-score-based filtering).
   public unfreezeUser = async (
     userId: string,
     state: ValueOf<typeof USER_STATE>,
     trx?: Knex.Transaction
-  ) => await this.baseUpdate(userId, { state }, undefined, trx)
+  ) => {
+    await this.revertUserContentSpamMarks(userId, trx)
+    return this.baseUpdate(userId, { state }, undefined, trx)
+  }
+
+  private contentSpamTables = ['article', 'comment', 'moment']
+
+  private markUserContentSpam = async (
+    userId: string,
+    trx?: Knex.Transaction
+  ) => {
+    const knexInstance = trx ?? this.knex
+    for (const table of this.contentSpamTables) {
+      await knexInstance(table)
+        .where({ authorId: userId })
+        .whereNull('isSpam')
+        .update({ isSpam: true, updatedAt: new Date() })
+    }
+  }
+
+  // `true` → `null` (not `false`): unfreezing means "no verdict", the spam
+  // classifier score takes over again. Manually set `false` rows are untouched.
+  public revertUserContentSpamMarks = async (
+    userId: string,
+    trx?: Knex.Transaction
+  ) => {
+    const knexInstance = trx ?? this.knex
+    for (const table of this.contentSpamTables) {
+      await knexInstance(table)
+        .where({ authorId: userId, isSpam: true })
+        .update({ isSpam: null, updatedAt: new Date() })
+    }
+  }
 
   public verifyWalletSignature = async ({
     ethAddress,

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -1898,6 +1898,7 @@ export type GQLFeatureName =
   | 'payment'
   | 'payout'
   | 'spam_detection'
+  | 'spam_ring_restriction'
   | 'tag_adoption'
   | 'topic_channel_spam_filter'
   | 'verify_appreciate'

--- a/src/mutations/user/updateUserState.ts
+++ b/src/mutations/user/updateUserState.ts
@@ -71,9 +71,25 @@ const resolver: GQLMutationResolvers['updateUserState'] = async (
   const handleUpdateUserState = async (user: User) => {
     let updatedUser: User
     if (state === USER_STATE.banned) {
+      // leaving frozen for banned: freeze-time spam marks no longer apply
+      if (user.state === USER_STATE.frozen) {
+        await userService.revertUserContentSpamMarks(user.id)
+      }
       updatedUser = await userService.banUser(user.id, { banDays })
+    } else if (state === USER_STATE.frozen) {
+      // clean up punish records so the daily unban job cannot flip a
+      // frozen user back to active
+      if (user.state === USER_STATE.banned) {
+        await userService.archivePunishRecordsByUserId({
+          userId: user.id,
+          state: USER_STATE.banned,
+        })
+      }
+      updatedUser = await userService.freezeUser(user.id)
     } else if (state !== user.state && user.state === USER_STATE.banned) {
       updatedUser = await userService.unbanUser(user.id, state)
+    } else if (state !== user.state && user.state === USER_STATE.frozen) {
+      updatedUser = await userService.unfreezeUser(user.id, state)
     } else {
       updatedUser = await atomService.update({
         table: 'user',

--- a/src/mutations/user/upsertSpamRingCandidates.ts
+++ b/src/mutations/user/upsertSpamRingCandidates.ts
@@ -1,9 +1,17 @@
 import type { GQLMutationResolvers } from '#definitions/index.js'
 
+import { invalidateUserContentCaches } from './utils.js'
+
 const resolver: GQLMutationResolvers['upsertSpamRingCandidates'] = async (
   _,
   { input: { candidates } },
-  { dataSources: { spamRingService } }
+  {
+    dataSources: {
+      spamRingService,
+      articleService,
+      connections: { redis },
+    },
+  }
 ) => {
   const mapped = candidates.map((c) => ({
     fingerprint: c.fingerprint,
@@ -17,11 +25,18 @@ const resolver: GQLMutationResolvers['upsertSpamRingCandidates'] = async (
     severity: c.severity ?? undefined,
     firstSeenAt: c.firstSeenAt ?? undefined,
     lastSeenAt: c.lastSeenAt ?? undefined,
-    memberEvidence: c.memberEvidence
-      ? JSON.parse(c.memberEvidence)
-      : undefined,
+    memberEvidence: c.memberEvidence ? JSON.parse(c.memberEvidence) : undefined,
   }))
-  return spamRingService.upsertCandidates(mapped)
+  const result = await spamRingService.upsertCandidates(mapped)
+
+  // purge content caches of members newly excluded this run, so the
+  // detection-time restriction takes effect immediately instead of waiting
+  // out the PUBLIC_QUERY TTL — mirrors the freeze/unfreeze/ring paths
+  for (const userId of result.restrictedUserIds) {
+    await invalidateUserContentCaches(userId, { articleService, redis })
+  }
+
+  return result
 }
 
 export default resolver

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -688,6 +688,7 @@ export default /* GraphQL */ `
     article_channel
     hottest_moment_feed
     discovery_probation
+    spam_ring_restriction
   }
 
   enum FeatureFlag {


### PR DESCRIPTION
## 概要

小黑屋（把帳號/內容排除在頻道之外）機制強化，依 [SPEC-blackhouse-permanent-and-auto](https://github.com/thematters/matters-agent-sop)（Full tier）。搭配 oss-next PR（永久小黑屋 UI）。

四項需求：
- **A. 永久小黑屋**：里長室關小黑屋由 7 天改永久。server 端 `banUser` 不帶 `banDays` 本就不寫 `punish_record`＝永不自動解禁（零改動），另加 migration 把存量未到期記錄 archive 轉永久。
- **B. 凍結 → 內容自動標 Spam**：`freezeUser` 同交易把作者 article/comment/moment `is_spam` NULL→true；`unfreezeUser` 復原 true→NULL（誤凍可完整還原，不覆蓋人工 false 判定）；`updateUserState` 各 state 轉換走對應路徑；存量回填 migration。
- **C. 頻道過濾補洞**：topic channel **pinned 查詢**與 **curation channel 全部查詢**原本沒有作者狀態/spam 過濾。pinned 對 frozen/spam/spamRing 硬排除，但保留「pinning 覆蓋 articleNewest 軟排序限制」語意。
- **D. 偵測即作者級排除（Dark）**：新增內部 `user_restriction` 類型 `spamRing`（不進 GraphQL enum、不入 OSS 受限清單、不被 putRestrictedUsers diff 誤刪）；`upsertSpamRingCandidates` 對 pending ring 成員寫 restriction（涵蓋 guardrail 跳過送人工複查者）並 purge cache；dismiss/restore 移除且多 ring 共同成員有防護；排除套到 channel/newest/hottest。整包 flag `spam_ring_restriction` 預設 **off**。

## Feature flag / Dark launch

- D 掛 `spam_ring_restriction`（migration 插 off 列）。flag off 時 `user_restriction(type=spamRing)` 無列＝**zero diff**。查詢端排除恆掛（無列即無影響），寫入端受 flag 閘控。
- A/B/C 為與既有凍結語意一致的 moderation 修復，Done（無 flag）；可逆（解凍復原／反向 migration）。

## Migrations（4 支）

1. `punish_record` 未到期 banned 記錄 archive（存量轉永久）
2. `feature_flag` 插入 `spam_ring_restriction`（off）
3. `user_restriction.type` check constraint 加 `spamRing`
4. frozen 帳號內容 `is_spam` NULL→true 回填（只補 null，不覆蓋人工判定）

## Security gate（Full tier — 已跑）

對抗式差異審查（4 lens：授權/業務邏輯/注入/快取），**無 CRITICAL/HIGH**。唯一 actionable MEDIUM（偵測寫 restriction 後未 purge cache）已於本 PR `43f2f3db7` 修復。其餘：unfreeze 復原抹掉人工 spam 判定＝SPEC 已拍板接受的 trade-off；comment/moment is_spam 無過濾面＝標記語意（隱藏另由 state 過濾涵蓋）；tag hottest 未掛 spamRing＝SPEC out-of-scope。報告見稽核輸出。

## 測試

新增 3 個 DB 整合測試檔（freeze round-trip、頻道硬排除、restriction 寫入/idempotent/dismiss/多 ring/restore）＋ resolver 契約測試；相關套件全綠、`tsc` 0 error、lint 0 error。

## 部署

- merge 進 `develop`＝只到 **staging**；**production 需另開 `develop → master` promote PR**。
- D 的 flag 開啟前：staging 驗收＋首批 ring 人工抽查無誤傷後由 owner 開 flag。

🤖 Generated with [Claude Code](https://claude.com/claude-code)