### PR TITLE
feat(moderation): notify and record moderation case on account freeze

### DIFF
--- a/src/connectors/__test__/spamRingService.test.ts
+++ b/src/connectors/__test__/spamRingService.test.ts
@@ -157,7 +157,13 @@ describe('SpamRingService.freezeRing', () => {
     expect(userService.freezeUser).toHaveBeenCalledTimes(1)
     expect(userService.freezeUser).toHaveBeenCalledWith(
       'u1',
-      expect.objectContaining({ remark: USER_BAN_REMARK.spamRing })
+      expect.objectContaining({
+        remark: USER_BAN_REMARK.spamRing,
+        source: 'model_assisted',
+        automationRole: 'assisted',
+        reason: 'spam',
+        actorId: '9',
+      })
     )
     expect(userService.banUser).not.toHaveBeenCalled()
     expect(result.frozen.map((u: any) => u.id)).toEqual(['u1'])
@@ -463,7 +469,8 @@ describe('SpamRingService.unfreezeRing', () => {
     expect(userService.unfreezeUser).toHaveBeenCalledWith(
       'u1',
       USER_STATE.active,
-      expect.anything()
+      expect.anything(),
+      { actorId: '9' }
     )
     expect(result.unbanned.map((u: any) => u.id)).toEqual(['u1'])
     expect(result.skipped.map((s: any) => s.user.id)).toEqual(['u3'])

--- a/src/connectors/__test__/systemServiceAccountRestriction.test.ts
+++ b/src/connectors/__test__/systemServiceAccountRestriction.test.ts
@@ -1,0 +1,189 @@
+import { SystemService } from '#connectors/systemService.js'
+
+// mock knex builder：chainable + thenable，記錄 moderation_case / moderation_event
+// 的寫入以驗證帳號凍結 case 的建立與結案（無 DB）
+const makeConnections = ({
+  existingCase = null,
+}: {
+  existingCase?: any
+} = {}) => {
+  const rec = {
+    caseInserts: [] as any[],
+    caseUpdates: [] as any[],
+    eventInserts: [] as any[],
+  }
+  const builder = (table: string) => {
+    const ctx: any = { table, where: {} }
+    const b: any = {
+      where: (w: any) => {
+        Object.assign(ctx.where, w)
+        return b
+      },
+      whereNull: () => b,
+      orderBy: () => b,
+      first: async () => {
+        if (ctx.table === 'moderation_case') {
+          return existingCase ?? undefined
+        }
+        return undefined
+      },
+      insert: (rows: any) => {
+        const row = Array.isArray(rows) ? rows[0] : rows
+        if (ctx.table === 'moderation_case') {
+          rec.caseInserts.push(row)
+          const res: any = {
+            onConflict: () => ({
+              ignore: () => ({
+                returning: async () =>
+                  existingCase ? [] : [{ id: '1', status: 'received', ...row }],
+              }),
+            }),
+          }
+          return res
+        }
+        if (ctx.table === 'moderation_event') {
+          rec.eventInserts.push(row)
+        }
+        return {
+          then: (resolve: any) => resolve(undefined),
+          returning: async () => [row],
+        }
+      },
+      update: (data: any) => {
+        if (ctx.table === 'moderation_case') {
+          rec.caseUpdates.push({ where: { ...ctx.where }, data })
+        }
+        return {
+          returning: async () => [
+            { id: '1', ...(existingCase ?? {}), ...data },
+          ],
+          then: (resolve: any) => resolve(1),
+        }
+      },
+    }
+    return b
+  }
+  const knex: any = (t: string) => builder(t)
+  knex.fn = { now: () => new Date() }
+  const connections: any = {
+    knex,
+    knexRO: knex,
+    knexSearch: knex,
+    redis: {},
+    objectCacheRedis: {},
+  }
+  return { connections, rec }
+}
+
+describe('SystemService.recordAccountRestrictionCase', () => {
+  test('creates a user case, actions it and marks notice sent', async () => {
+    const { connections, rec } = makeConnections()
+    const service = new SystemService(connections)
+
+    const result = await service.recordAccountRestrictionCase({
+      userId: '42',
+      reason: 'spam',
+      source: 'model_assisted',
+      automationRole: 'assisted',
+      actorId: '9',
+      noticeSent: true,
+    })
+
+    expect(rec.caseInserts[0]).toEqual(
+      expect.objectContaining({
+        source: 'model_assisted',
+        targetType: 'user',
+        targetId: '42',
+        reason: 'spam',
+        automationRole: 'assisted',
+      })
+    )
+    // created + actioned events
+    expect(rec.eventInserts.map((e) => e.eventType)).toEqual([
+      'created',
+      'actioned',
+    ])
+    expect(rec.eventInserts[1]).toEqual(
+      expect.objectContaining({
+        actorType: 'admin',
+        actorId: '9',
+        toStatus: 'action_taken',
+        toOutcome: 'account_limited',
+      })
+    )
+    // case actioned with notice sent
+    expect(rec.caseUpdates[0].data).toEqual(
+      expect.objectContaining({
+        status: 'action_taken',
+        outcome: 'account_limited',
+        noticeState: 'sent',
+      })
+    )
+    expect(result.status).toBe('action_taken')
+  })
+
+  test('reuses the existing case and skips the created event', async () => {
+    const { connections, rec } = makeConnections({
+      existingCase: {
+        id: '7',
+        status: 'action_taken',
+        outcome: 'account_limited',
+        noticeState: 'sent',
+      },
+    })
+    const service = new SystemService(connections)
+
+    await service.recordAccountRestrictionCase({
+      userId: '42',
+      reason: 'spam',
+      source: 'model_assisted',
+    })
+
+    expect(rec.eventInserts.map((e) => e.eventType)).toEqual(['actioned'])
+  })
+})
+
+describe('SystemService.resolveAccountRestrictionCase', () => {
+  test('resolves the open case as restored with a restored event', async () => {
+    const { connections, rec } = makeConnections({
+      existingCase: {
+        id: '7',
+        status: 'action_taken',
+        outcome: 'account_limited',
+      },
+    })
+    const service = new SystemService(connections)
+
+    const result = await service.resolveAccountRestrictionCase({
+      userId: '42',
+      actorId: '9',
+    })
+
+    expect(rec.caseUpdates[0].data).toEqual(
+      expect.objectContaining({ status: 'resolved', outcome: 'restored' })
+    )
+    expect(rec.eventInserts[0]).toEqual(
+      expect.objectContaining({
+        eventType: 'restored',
+        actorType: 'admin',
+        actorId: '9',
+        fromOutcome: 'account_limited',
+        toOutcome: 'restored',
+      })
+    )
+    expect(result?.status).toBe('resolved')
+  })
+
+  test('is a no-op when no open case exists (pre-recording freezes)', async () => {
+    const { connections, rec } = makeConnections()
+    const service = new SystemService(connections)
+
+    const result = await service.resolveAccountRestrictionCase({
+      userId: '42',
+    })
+
+    expect(result).toBeNull()
+    expect(rec.eventInserts).toHaveLength(0)
+    expect(rec.caseUpdates).toHaveLength(0)
+  })
+})

--- a/src/connectors/notification/translations.ts
+++ b/src/connectors/notification/translations.ts
@@ -36,9 +36,9 @@ export default {
         : '因为违反社区规则，您已被禁言，无法发布作品和评论',
     en: ({ banDays }) =>
       banDays
-        ? 'You have been fobidden to publish any contents' +
-          `and comments within ${banDays} days for vilolating the Term of Use`
-        : 'You have been fobidden to publish any contents and comments for vilolating the Term of Use',
+        ? 'You have been forbidden to publish any contents ' +
+          `and comments within ${banDays} days for violating the Terms of Use`
+        : 'You have been forbidden to publish any contents and comments for violating the Terms of Use',
   }),
   user_banned_payment: i18n({
     zh_hant:
@@ -48,14 +48,16 @@ export default {
     en: 'Due to the detection of irregular transactions, your account has been temporarily suspended. If you require further clarification, please contact us at hi@matters.town',
   }),
   user_frozen: i18n({
-    zh_hant: '因為違反社區規則，Matters 決定將您的賬戶凍結，無法在站上進行互動',
-    zh_hans: '因为违反社区规则，Matters 决定将您的账户冻结，无法在站上进行互动',
-    en: 'Your account has been deactivated for vilolating the Term of Use',
+    zh_hant:
+      '因為違反用戶協議與社區規則，Matters 已將您的帳戶凍結，凍結期間無法在站上進行互動。若對此處置有疑問或希望申訴，請來信 hi@matters.town，站方將覆核後回覆',
+    zh_hans:
+      '因为违反用户协议与社区规则，Matters 已将您的账户冻结，冻结期间无法在站上进行互动。若对此处置有疑问或希望申诉，请来信 hi@matters.town，站方将覆核后回复',
+    en: 'Your account has been frozen for violating the Terms of Use and community guidelines, and cannot interact on the site while frozen. If you have questions or wish to appeal, please contact hi@matters.town and our team will review your case.',
   }),
   user_unbanned: i18n({
     zh_hant: '你的評論與創作權限已恢復',
     zh_hans: '你的评论与创作权限已恢复',
-    en: 'Your account has been recover.',
+    en: 'Your account has been recovered.',
   }),
   comment_banned: i18n<{ content: string }>({
     zh_hant: ({ content }) =>
@@ -63,7 +65,7 @@ export default {
     zh_hans: ({ content }) =>
       `因为违反社区规则，您的评论“${makeSummary(content, 21)}”已被隐藏`,
     en: ({ content }) =>
-      `You comment "${makeSummary(
+      `Your comment "${makeSummary(
         content,
         21
       )}" has been archived from Matters for violating the community rules`,

--- a/src/connectors/spamRingService.ts
+++ b/src/connectors/spamRingService.ts
@@ -394,6 +394,10 @@ export class SpamRingService extends BaseService<SpamRing> {
         const frozenUser = (await userService.freezeUser(user.id, {
           remark: USER_BAN_REMARK.spamRing,
           trx,
+          actorId,
+          source: 'model_assisted',
+          automationRole: 'assisted',
+          reason: 'spam',
         })) as User
         await this.updateMember(
           member.id,
@@ -508,7 +512,8 @@ export class SpamRingService extends BaseService<SpamRing> {
         const restored = (await userService.unfreezeUser(
           user.id,
           member.preFreezeState ?? USER_STATE.active,
-          trx
+          trx,
+          { actorId }
         )) as User
         await this.updateMember(
           member.id,

--- a/src/connectors/systemService.ts
+++ b/src/connectors/systemService.ts
@@ -828,6 +828,126 @@ export class SystemService extends BaseService<BaseDBSchema> {
     })
   }
 
+  /**
+   * Record an account-level enforcement (freeze) as a moderation case so it
+   * enters transparency metrics. Re-freezing with the same source/reason
+   * reuses the case (unique on source/targetType/targetId/reason).
+   */
+  public recordAccountRestrictionCase = async ({
+    userId,
+    reason,
+    source,
+    automationRole = 'none',
+    actorId,
+    noticeSent = false,
+    metadata,
+  }: {
+    userId: string
+    reason: string
+    source: ModerationCaseSource
+    automationRole?: ModerationAutomationRole
+    actorId?: string | null
+    noticeSent?: boolean
+    metadata?: Record<string, unknown>
+  }): Promise<ModerationCase> => {
+    const { moderationCase, created } = await this.findOrCreateModerationCase({
+      source,
+      targetType: 'user',
+      targetId: userId,
+      reason,
+      automationRole,
+    })
+
+    if (created) {
+      await this.createModerationEvent({
+        caseId: moderationCase.id,
+        eventType: 'created',
+        actorType: actorId ? 'admin' : 'system',
+        actorId,
+        toStatus: 'received',
+        metadata: metadata ?? null,
+      })
+    }
+
+    const [updatedCase] = await this.knex<ModerationCase>('moderation_case')
+      .where({ id: moderationCase.id })
+      .update({
+        status: 'action_taken',
+        outcome: 'account_limited',
+        ...(noticeSent ? { noticeState: 'sent' } : {}),
+        updatedAt: this.knex.fn.now(),
+      })
+      .returning('*')
+
+    await this.createModerationEvent({
+      caseId: moderationCase.id,
+      eventType: 'actioned',
+      actorType: actorId ? 'admin' : 'system',
+      actorId,
+      publicReason: reason,
+      fromStatus: moderationCase.status,
+      toStatus: 'action_taken',
+      fromOutcome: moderationCase.outcome,
+      toOutcome: 'account_limited',
+      metadata: metadata ?? null,
+    })
+
+    return updatedCase
+  }
+
+  /**
+   * Resolve the open account-restriction case when the account is unfrozen
+   * (appeal accepted or staff reversal). No-op when no open case exists,
+   * e.g. freezes that predate case recording.
+   */
+  public resolveAccountRestrictionCase = async ({
+    userId,
+    actorId,
+    metadata,
+  }: {
+    userId: string
+    actorId?: string | null
+    metadata?: Record<string, unknown>
+  }): Promise<ModerationCase | null> => {
+    const moderationCase = await this.knex<ModerationCase>('moderation_case')
+      .where({
+        targetType: 'user',
+        targetId: userId,
+        outcome: 'account_limited',
+      })
+      .whereNull('resolvedAt')
+      .orderBy('id', 'desc')
+      .first()
+
+    if (!moderationCase) {
+      return null
+    }
+
+    const [updatedCase] = await this.knex<ModerationCase>('moderation_case')
+      .where({ id: moderationCase.id })
+      .update({
+        status: 'resolved',
+        outcome: 'restored',
+        resolvedAt: this.knex.fn.now(),
+        updatedAt: this.knex.fn.now(),
+      })
+      .returning('*')
+
+    await this.createModerationEvent({
+      caseId: moderationCase.id,
+      eventType: 'restored',
+      actorType: actorId ? 'admin' : 'system',
+      actorId,
+      fromStatus: moderationCase.status,
+      toStatus: 'resolved',
+      fromOutcome: moderationCase.outcome,
+      toOutcome: 'restored',
+      metadata: metadata ?? null,
+    })
+
+    return updatedCase
+  }
+
   private toModerationTargetType = (
     targetType: ReportType
   ): ModerationTargetType => {

--- a/src/connectors/userService.ts
+++ b/src/connectors/userService.ts
@@ -15,6 +15,8 @@ import type {
   LANGUAGES,
   UserBoost,
   UserFeatureFlag,
+  ModerationCaseSource,
+  ModerationAutomationRole,
 } from '#definitions/index.js'
 import type { Knex } from 'knex'
 
@@ -116,6 +118,7 @@ import { LikeCoin } from './likecoin/index.js'
 import { NotificationService } from './notification/notificationService.js'
 import { OAuthService } from './oauthService.js'
 import { SearchService } from './searchService.js'
+import { SystemService } from './systemService.js'
 
 const logger = getLogger('service-user')
 
@@ -1999,7 +2002,18 @@ export class UserService extends BaseService<User> {
     {
       remark,
       trx,
-    }: { remark?: ValueOf<typeof USER_BAN_REMARK>; trx?: Knex.Transaction } = {}
+      actorId,
+      source = 'admin',
+      automationRole = 'none',
+      reason = 'tos_violation',
+    }: {
+      remark?: ValueOf<typeof USER_BAN_REMARK>
+      trx?: Knex.Transaction
+      actorId?: string | null
+      source?: ModerationCaseSource
+      automationRole?: ModerationAutomationRole
+      reason?: string
+    } = {}
   ) => {
     // fire-and-forget appeal notice (not awaited, holds no DB lock); safe to keep
     // inside a caller transaction — a rollback only wastes a notice in the rare
@@ -2015,20 +2029,54 @@ export class UserService extends BaseService<User> {
       updatedAt: new Date(),
     }
 
-    return await this.baseUpdate(
+    const updated = await this.baseUpdate(
       userId,
       remark ? { ...data, remark } : data,
       undefined,
       trx
     )
+
+    // best-effort moderation case for NCC transparency metrics; runs outside
+    // the caller transaction (own connection, different tables) and must not
+    // fail the freeze itself.
+    try {
+      const systemService = new SystemService(this.connections)
+      await systemService.recordAccountRestrictionCase({
+        userId,
+        reason,
+        source,
+        automationRole,
+        actorId,
+        noticeSent: true,
+        ...(remark ? { metadata: { remark } } : {}),
+      })
+    } catch (error) {
+      logger.error(error)
+    }
+
+    return updated
   }
 
   // Reverse a freeze by restoring an explicit prior state (e.g. preFreezeState).
   public unfreezeUser = async (
     userId: string,
     state: ValueOf<typeof USER_STATE>,
-    trx?: Knex.Transaction
-  ) => await this.baseUpdate(userId, { state }, undefined, trx)
+    trx?: Knex.Transaction,
+    { actorId }: { actorId?: string | null } = {}
+  ) => {
+    const updated = await this.baseUpdate(userId, { state }, undefined, trx)
+
+    // best-effort: close the open account-restriction case (appeal accepted /
+    // staff reversal); no-op for freezes that predate case recording.
+    try {
+      const systemService = new SystemService(this.connections)
+      await systemService.resolveAccountRestrictionCase({ userId, actorId })
+    } catch (error) {
+      logger.error(error)
+    }
+
+    return updated
+  }
 
   public verifyWalletSignature = async ({
     ethAddress,

--- a/src/connectors/userService.ts
+++ b/src/connectors/userService.ts
@@ -2052,22 +2052,28 @@ export class UserService extends BaseService<User> {
       trx
     )
 
-    // best-effort moderation case for NCC transparency metrics; runs outside
-    // the caller transaction (own connection, different tables) and must not
-    // fail the freeze itself.
-    try {
-      const systemService = new SystemService(this.connections)
-      await systemService.recordAccountRestrictionCase({
-        userId,
-        reason,
-        source,
-        automationRole,
-        actorId,
-        noticeSent: true,
-        ...(remark ? { metadata: { remark } } : {}),
-      })
-    } catch (error) {
-      logger.error(error)
+    // best-effort moderation case for NCC transparency metrics; must not fail
+    // the freeze itself. Runs on its own connection: when inside a caller
+    // transaction, do not await — waiting on a second pool connection while
+    // the transaction holds one can starve small pools (deadlocks the test
+    // pool), same reasoning as the fire-and-forget notice above.
+    const systemService = new SystemService(this.connections)
+    const recordCase = () =>
+      systemService
+        .recordAccountRestrictionCase({
+          userId,
+          reason,
+          source,
+          automationRole,
+          actorId,
+          noticeSent: true,
+          ...(remark ? { metadata: { remark } } : {}),
+        })
+        .catch((error) => logger.error(error))
+    if (trx) {
+      void recordCase()
+    } else {
+      await recordCase()
     }
 
     return updated
@@ -2086,12 +2092,18 @@ export class UserService extends BaseService<User> {
     const updated = await this.baseUpdate(userId, { state }, undefined, trx)
 
     // best-effort: close the open account-restriction case (appeal accepted /
-    // staff reversal); no-op for freezes that predate case recording.
-    try {
-      const systemService = new SystemService(this.connections)
-      await systemService.resolveAccountRestrictionCase({ userId, actorId })
-    } catch (error) {
-      logger.error(error)
+    // staff reversal); no-op for freezes that predate case recording. Same
+    // pool-starvation rule as freezeUser: never await while inside a caller
+    // transaction.
+    const systemService = new SystemService(this.connections)
+    const resolveCase = () =>
+      systemService
+        .resolveAccountRestrictionCase({ userId, actorId })
+        .catch((error) => logger.error(error))
+    if (trx) {
+      void resolveCase()
+    } else {
+      await resolveCase()
     }
 
     return updated

--- a/src/mutations/user/updateUserState.ts
+++ b/src/mutations/user/updateUserState.ts
@@ -82,6 +82,21 @@ const resolver: GQLMutationResolvers['updateUserState'] = async (
       updatedUser = await userService.banUser(user.id, { banDays })
     } else if (state !== user.state && user.state === USER_STATE.banned) {
       updatedUser = await userService.unbanUser(user.id, state)
+    } else if (
+      state === USER_STATE.frozen &&
+      user.state !== USER_STATE.frozen
+    ) {
+      // route through freezeUser so admin/batch freezes send the user_frozen
+      // appeal notice and record a moderation case, same as spam-ring freezes
+      updatedUser = (await userService.freezeUser(user.id, {
+        actorId: viewer.id,
+        source: 'admin',
+      })) as User
+    } else if (user.state === USER_STATE.frozen && state !== user.state) {
+      // unfreeze resolves the open account-restriction case (appeal accepted)
+      updatedUser = (await userService.unfreezeUser(user.id, state, undefined, {
+        actorId: viewer.id,
+      })) as User
     } else {
       updatedUser = await atomService.update({
         table: 'user',


### PR DESCRIPTION
## What

Closes the two biggest gaps in the account-freeze appeal flow (found while handling the @eqsasia appeal):

1. **Admin/batch console freezes sent no notice at all.** `updateUserState` with `state=frozen` was a plain state update — only spam-ring freezes (via `freezeUser`) sent the `user_frozen` appeal notice. Now `updateUserState` routes freeze/unfreeze through `freezeUser`/`unfreezeUser`.
2. **No account freeze wrote a moderation case**, so account-level enforcement and appeals never entered NCC transparency metrics. `freezeUser` now records a `moderation_case` (target_type=user, outcome=account_limited, notice_state=sent) with created/actioned events; `unfreezeUser` resolves the open case as `restored` with a restored event. Both best-effort — a case failure never fails the freeze.
3. **Notice copy** now cites the ToS/community rules and gives the appeal channel (hi@matters.town) in all three languages; fixed EN typos (`vilolating`, `fobidden`, `You comment`, `has been recover`).

Case tagging: spam-ring freezes → `source=model_assisted, automation_role=assisted, reason=spam`; admin console freezes → `source=admin, reason=tos_violation, actor=viewer`.

## Not changed

- banned→frozen still goes through `unbanUser` (punish-record cleanup preserved, prior no-notice semantics kept — rare admin edge case).
- No email channel (deliberately out of scope per owner).
- Pre-existing frozen accounts have no case; resolveAccountRestrictionCase is a safe no-op for them. Historical backfill (e.g. @eqsasia) stays manual.

## Tests

- `systemServiceAccountRestriction.test.ts` (new, mock): case create/action/notice-sent, case reuse on re-freeze, resolve-as-restored, no-op without open case — 4/4.
- `spamRingService.test.ts`: updated for the new freeze/unfreeze call contracts — 14/14.
- `tsc` clean; eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)