### PR TITLE
hotfix: remove slow state filters from public feeds

### DIFF
--- a/src/connectors/__test__/articleService/articleService.test.ts
+++ b/src/connectors/__test__/articleService/articleService.test.ts
@@ -424,28 +424,6 @@ describe('latestArticles', () => {
     expect(articles[0].authorId).toBeDefined()
     expect(articles[0].state).toBeDefined()
   })
-  test('state-restricted authors are excluded', async () => {
-    const articles = await articleService.findNewestArticles()
-    const targetAuthorId = articles[0].authorId
-
-    await atomService.update({
-      table: 'user',
-      where: { id: targetAuthorId },
-      data: { state: USER_STATE.frozen },
-    })
-    const excluded = await articleService.findNewestArticles()
-    expect(excluded.map(({ authorId }) => authorId)).not.toContain(
-      targetAuthorId
-    )
-
-    await atomService.update({
-      table: 'user',
-      where: { id: targetAuthorId },
-      data: { state: USER_STATE.active },
-    })
-    const restored = await articleService.findNewestArticles()
-    expect(restored.map(({ authorId }) => authorId)).toContain(targetAuthorId)
-  })
   test('spam are excluded', async () => {
     const articles = await articleService.findNewestArticles({
       spamThreshold: 0.5,

--- a/src/connectors/article/articleService.ts
+++ b/src/connectors/article/articleService.ts
@@ -39,7 +39,6 @@ import {
 import {
   excludeSpam as excludeSpamModifier,
   excludeRestrictedAuthors as excludeRestrictedModifier,
-  excludeStateRestrictedAuthors as excludeStateRestrictedModifier,
   excludeExclusiveCampaignArticles as excludeExclusiveCampaignArticlesModifier,
   excludeProbationAuthors as excludeProbationModifier,
 } from '#common/utils/index.js'
@@ -221,11 +220,6 @@ export class ArticleService extends BaseService<Article> {
       excludeExclusiveCampaignArticles,
       excludeProbationAuthors: probationDays,
     })
-    // freezing only flips user.state, not user_restriction, so the
-    // restricted-authors filter alone still surfaces frozen accounts in
-    // newest / recommended-authors / recommended-tags pools; the correlated
-    // modifier probes user pkey per row instead of scanning the user table
-    excludeStateRestrictedModifier(query)
     return query.orderBy('id', 'desc')
   }
 

--- a/src/connectors/recommendationService.ts
+++ b/src/connectors/recommendationService.ts
@@ -25,10 +25,7 @@ import {
   ActionFailedError,
 } from '#common/errors.js'
 import { getLogger } from '#common/logger.js'
-import {
-  excludeProbationAuthors as excludeProbationModifier,
-  excludeStateRestrictedAuthors as excludeStateRestrictedModifier,
-} from '#common/utils/index.js'
+import { excludeProbationAuthors as excludeProbationModifier } from '#common/utils/index.js'
 import { daysToDatetimeRange } from '#common/utils/time.js'
 import { quantile, median } from 'd3-array'
 import keyBy from 'lodash/keyBy.js'
@@ -921,9 +918,6 @@ export class RecommendationService {
       )
       .leftJoin('article', 'choice.article_id', 'article.id')
       .where({ state: ARTICLE_STATE.active })
-      // matters_choice is curated before an author may get frozen, so the
-      // author state must be re-checked at read time
-      .modify(excludeStateRestrictedModifier)
       .modify((builder) => {
         if (probationDays) {
           builder.modify(excludeProbationModifier, probationDays)

--- a/src/types/__test__/2/recommendation/icymi.test.ts
+++ b/src/types/__test__/2/recommendation/icymi.test.ts
@@ -6,7 +6,6 @@ import {
   NODE_TYPES,
   MATTERS_CHOICE_TOPIC_STATE,
   LANGUAGE,
-  USER_STATE,
 } from '#common/enums/index.js'
 import { RecommendationService, AtomService } from '#connectors/index.js'
 import { toGlobalId } from '#common/utils/index.js'
@@ -71,52 +70,6 @@ describe('icymi', () => {
     })
     expect(errors).toBeUndefined()
     expect(data.viewer.recommendation.icymi.totalCount).toBeGreaterThan(0)
-  })
-  test('articles by state-restricted authors are excluded', async () => {
-    const server = await testClient({ connections })
-    const article = await atomService.findUnique({
-      table: 'article',
-      where: { id: '1' },
-    })
-    await atomService.upsert({
-      table: 'matters_choice',
-      where: { articleId: article.id },
-      create: { articleId: article.id },
-      update: {},
-    })
-
-    await atomService.update({
-      table: 'user',
-      where: { id: article.authorId },
-      data: { state: USER_STATE.frozen },
-    })
-    const { errors, data } = await server.executeOperation({
-      query: GET_VIEWER_RECOMMENDATION_ICYMI,
-      variables: { input: { first: 10 } },
-    })
-    expect(errors).toBeUndefined()
-    const ids = data.viewer.recommendation.icymi.edges.map(
-      ({ node }: { node: { id: string } }) => node.id
-    )
-    expect(ids).not.toContain(
-      toGlobalId({ type: NODE_TYPES.Article, id: article.id })
-    )
-
-    await atomService.update({
-      table: 'user',
-      where: { id: article.authorId },
-      data: { state: USER_STATE.active },
-    })
-    const { data: restoredData } = await server.executeOperation({
-      query: GET_VIEWER_RECOMMENDATION_ICYMI,
-      variables: { input: { first: 10 } },
-    })
-    const restoredIds = restoredData.viewer.recommendation.icymi.edges.map(
-      ({ node }: { node: { id: string } }) => node.id
-    )
-    expect(restoredIds).toContain(
-      toGlobalId({ type: NODE_TYPES.Article, id: article.id })
-    )
   })
 })
 


### PR DESCRIPTION
## Summary
- remove request-time state-restricted author filters from newest and icymi public feed queries
- keep existing user_restriction, spam, campaign, channel, and probation filters in place
- remove tests that asserted the temporarily rolled-back request-time behavior

## Incident context
- Cloudflare returned 502/504 for `matters.town` and `web-next.matters.town` around 2026-07-06 14:21 UTC
- EB health showed `matters-client-prod` Red/Severe and `matters-client-prod-webnext` Red/Degraded while `matters-server-prod-new` stayed Green/Ok
- production GraphQL probes for `viewer.recommendation.newest` and `viewer.recommendation.icymi` intermittently timed out or returned `canceling statement due to conflict with recovery` with SQL containing the state-restricted author filter introduced in the promoted release

## Verification
- `npm run build`
- `npm run testcmd -- build/connectors/__test__/articleService/articleService.test.js build/types/__test__/2/recommendation/icymi.test.js --runInBand --forceExit`

## Follow-up
- Reintroduce state-based discovery exclusion only after query plan/index validation against production-sized data or via a precomputed/cache-safe path.
