### PR TITLE
hotfix: avoid recommendation cache stampedes

### DIFF
--- a/src/common/enums/cache.ts
+++ b/src/common/enums/cache.ts
@@ -39,6 +39,7 @@ export const CACHE_PREFIX = {
   ARTICLE_CHANNEL_THRESHOLD: 'cache-article-channel-threshold',
   RECOMMENDATION_TAGS: 'cache-recommendation-tags',
   RECOMMENDATION_AUTHORS: 'cache-recommendation-authors',
+  RECOMMENDATION_ICYMI: 'cache-recommendation-icymi',
   RECOMMENDATION_HOTTEST: 'cache-recommendation-hottest',
   RECOMMENDATION_HOTTEST_MOMENTS: 'cache-recommendation-hottest-moments',
   CHANNEL_FLOOD: 'cache-channel-flood',

--- a/src/queries/user/recommendation/authors.ts
+++ b/src/queries/user/recommendation/authors.ts
@@ -15,7 +15,6 @@ export const authors: GQLRecommendationResolvers['authors'] = async (
   {
     dataSources: {
       userService,
-      recommendationService,
       atomService,
       connections: { objectCacheRedis },
     },
@@ -60,17 +59,17 @@ export const authors: GQLRecommendationResolvers['authors'] = async (
     channelId = channel?.id
   }
 
-  const authorIds = await cache.getObject({
+  const authorIds = await cache.getObject<Array<{ authorId: string }>>({
     keys: {
       type: 'recommendationAuthors',
       args: {
         channelId,
       },
     },
-    getter: async () => {
-      const { query } = await recommendationService.recommendAuthors(channelId)
-      return query
-    },
+    // The recommendation pool is expensive to rebuild on public reads. Cache
+    // misses are filled by the cache-ahead Lambda instead of tying up web DB
+    // connections during deploys or cold starts.
+    getter: async () => [],
     expire: CACHE_TTL.LONG,
   })
   const filtered = authorIds.filter(({ authorId }) => !notIn.includes(authorId))

--- a/src/queries/user/recommendation/icymi.ts
+++ b/src/queries/user/recommendation/icymi.ts
@@ -1,16 +1,56 @@
-import type { GQLRecommendationResolvers } from '#definitions/index.js'
+import type { Article, GQLRecommendationResolvers } from '#definitions/index.js'
 
+import { CACHE_PREFIX, CACHE_TTL } from '#common/enums/index.js'
 import { connectionFromArray, fromConnectionArgs } from '#common/utils/index.js'
+import { Cache } from '#connectors/index.js'
 
 export const icymi: GQLRecommendationResolvers['icymi'] = async (
   _,
   { input },
-  { dataSources: { recommendationService } }
+  {
+    dataSources: {
+      recommendationService,
+      connections: { objectCacheRedis },
+    },
+  }
 ) => {
   const { take, skip } = fromConnectionArgs(input)
-  const [articles, totalCount] = await recommendationService.findIcymiArticles({
-    take,
-    skip,
-  })
+  const cache = new Cache(CACHE_PREFIX.RECOMMENDATION_ICYMI, objectCacheRedis)
+  const keys = { type: 'recommendationIcymi', args: { take, skip } }
+  const cacheKey = cache.genKey(keys)
+  const raw = await objectCacheRedis.get(cacheKey)
+  let cached = raw
+    ? (JSON.parse(raw) as { articles: Article[]; totalCount: number })
+    : undefined
+
+  if (!cached) {
+    const lockKey = `${cacheKey}:lock`
+    const acquired = await objectCacheRedis.set(lockKey, '1', 'EX', 60, 'NX')
+    if (acquired) {
+      try {
+        try {
+          const [queryArticles, queryTotalCount] =
+            await recommendationService.findIcymiArticles({
+              take,
+              skip,
+            })
+          cached = { articles: queryArticles, totalCount: queryTotalCount }
+        } catch {
+          cached = { articles: [], totalCount: 0 }
+        }
+        await cache.storeObject({
+          keys,
+          data: cached,
+          expire: CACHE_TTL.PUBLIC_FEED_ARTICLE,
+        })
+      } finally {
+        await objectCacheRedis.del(lockKey)
+      }
+    } else {
+      cached = { articles: [], totalCount: 0 }
+    }
+  }
+
+  const { articles, totalCount } = cached
   return connectionFromArray(articles, input, totalCount)
 }


### PR DESCRIPTION
## Summary\n- avoid rebuilding recommendation author pools synchronously on public reads\n- add short ICYMI cache with a Redis lock so cache misses do not stampede DB connections\n\n## Verification\n- npm run build\n- npm run testcmd -- build/types/__test__/2/recommendation/authors.test.js build/types/__test__/2/recommendation/icymi.test.js --runInBand --forceExit