### PR TITLE
chore: back-merge master into develop (hotfix #4927 slow-feed-filter removal)

### DIFF
--- a/src/connectors/__test__/articleService/articleService.test.ts
+++ b/src/connectors/__test__/articleService/articleService.test.ts
@@ -424,28 +424,6 @@ describe('latestArticles', () => {
     expect(articles[0].authorId).toBeDefined()
     expect(articles[0].state).toBeDefined()
   })
-  test('state-restricted authors are excluded', async () => {
-    const articles = await articleService.findNewestArticles()
-    const targetAuthorId = articles[0].authorId
-
-    await atomService.update({
-      table: 'user',
-      where: { id: targetAuthorId },
-      data: { state: USER_STATE.frozen },
-    })
-    const excluded = await articleService.findNewestArticles()
-    expect(excluded.map(({ authorId }) => authorId)).not.toContain(
-      targetAuthorId
-    )
-
-    await atomService.update({
-      table: 'user',
-      where: { id: targetAuthorId },
-      data: { state: USER_STATE.active },
-    })
-    const restored = await articleService.findNewestArticles()
-    expect(restored.map(({ authorId }) => authorId)).toContain(targetAuthorId)
-  })
   test('spam are excluded', async () => {
     const articles = await articleService.findNewestArticles({
       spamThreshold: 0.5,

--- a/src/connectors/article/articleService.ts
+++ b/src/connectors/article/articleService.ts
@@ -39,7 +39,6 @@ import {
 import {
   excludeSpam as excludeSpamModifier,
   excludeRestrictedAuthors as excludeRestrictedModifier,
-  excludeStateRestrictedAuthors as excludeStateRestrictedModifier,
   excludeExclusiveCampaignArticles as excludeExclusiveCampaignArticlesModifier,
   excludeProbationAuthors as excludeProbationModifier,
 } from '#common/utils/index.js'
@@ -221,11 +220,6 @@ export class ArticleService extends BaseService<Article> {
       excludeExclusiveCampaignArticles,
       excludeProbationAuthors: probationDays,
     })
-    // freezing only flips user.state, not user_restriction, so the
-    // restricted-authors filter alone still surfaces frozen accounts in
-    // newest / recommended-authors / recommended-tags pools; the correlated
-    // modifier probes user pkey per row instead of scanning the user table
-    excludeStateRestrictedModifier(query)
     return query.orderBy('id', 'desc')
   }
 

--- a/src/connectors/recommendationService.ts
+++ b/src/connectors/recommendationService.ts
@@ -25,10 +25,7 @@ import {
   ActionFailedError,
 } from '#common/errors.js'
 import { getLogger } from '#common/logger.js'
-import {
-  excludeProbationAuthors as excludeProbationModifier,
-  excludeStateRestrictedAuthors as excludeStateRestrictedModifier,
-} from '#common/utils/index.js'
+import { excludeProbationAuthors as excludeProbationModifier } from '#common/utils/index.js'
 import { daysToDatetimeRange } from '#common/utils/time.js'
 import { quantile, median } from 'd3-array'
 import keyBy from 'lodash/keyBy.js'
@@ -921,9 +918,6 @@ export class RecommendationService {
       )
       .leftJoin('article', 'choice.article_id', 'article.id')
       .where({ state: ARTICLE_STATE.active })
-      // matters_choice is curated before an author may get frozen, so the
-      // author state must be re-checked at read time
-      .modify(excludeStateRestrictedModifier)
       .modify((builder) => {
         if (probationDays) {
           builder.modify(excludeProbationModifier, probationDays)

--- a/src/types/__test__/2/recommendation/icymi.test.ts
+++ b/src/types/__test__/2/recommendation/icymi.test.ts
@@ -6,7 +6,6 @@ import {
   NODE_TYPES,
   MATTERS_CHOICE_TOPIC_STATE,
   LANGUAGE,
-  USER_STATE,
 } from '#common/enums/index.js'
 import { RecommendationService, AtomService } from '#connectors/index.js'
 import { toGlobalId } from '#common/utils/index.js'
@@ -71,52 +70,6 @@ describe('icymi', () => {
     })
     expect(errors).toBeUndefined()
     expect(data.viewer.recommendation.icymi.totalCount).toBeGreaterThan(0)
-  })
-  test('articles by state-restricted authors are excluded', async () => {
-    const server = await testClient({ connections })
-    const article = await atomService.findUnique({
-      table: 'article',
-      where: { id: '1' },
-    })
-    await atomService.upsert({
-      table: 'matters_choice',
-      where: { articleId: article.id },
-      create: { articleId: article.id },
-      update: {},
-    })
-
-    await atomService.update({
-      table: 'user',
-      where: { id: article.authorId },
-      data: { state: USER_STATE.frozen },
-    })
-    const { errors, data } = await server.executeOperation({
-      query: GET_VIEWER_RECOMMENDATION_ICYMI,
-      variables: { input: { first: 10 } },
-    })
-    expect(errors).toBeUndefined()
-    const ids = data.viewer.recommendation.icymi.edges.map(
-      ({ node }: { node: { id: string } }) => node.id
-    )
-    expect(ids).not.toContain(
-      toGlobalId({ type: NODE_TYPES.Article, id: article.id })
-    )
-
-    await atomService.update({
-      table: 'user',
-      where: { id: article.authorId },
-      data: { state: USER_STATE.active },
-    })
-    const { data: restoredData } = await server.executeOperation({
-      query: GET_VIEWER_RECOMMENDATION_ICYMI,
-      variables: { input: { first: 10 } },
-    })
-    const restoredIds = restoredData.viewer.recommendation.icymi.edges.map(
-      ({ node }: { node: { id: string } }) => node.id
-    )
-    expect(restoredIds).toContain(
-      toGlobalId({ type: NODE_TYPES.Article, id: article.id })
-    )
   })
 })
 


### PR DESCRIPTION
## 為什麼

prod hotfix [#4927](https://github.com/thematters/matters-server/pull/4927) `cdb73f87d`「remove slow state filters from public feeds」打在 **master**、沒進 develop。develop 這兩處慢查詢還在——若直接 `develop → master` promote 會**靜默回退該 hotfix**、prod feed 恐再度 timeout。本 PR 先把 hotfix 併回 develop，讓後續 promote 不會誤刪它。

## 內容

merge `origin/master` 進 develop，淨效果＝套用 hotfix 對這兩處的移除：
- `articleService.findArticles` 尾端 `excludeStateRestrictedModifier(query)`（newest / recommended-authors / recommended-tags 共用）
- `recommendationService` `matters_choice`（icymi）的 `.modify(excludeStateRestrictedModifier)`
- 連同對應 import 與被移除的測試斷言（icymi / articleService test）

**保留** develop 上的 blackhouse 改動（#4925）：`excludeRestrictedAuthors` 陣列化＋`spamRing`、hottest 的 `excludeAuthorStates:[frozen,banned,archived]`——與 hotfix 移除的（那兩處 state 過濾）不同機制、不衝突。

## 效能 vs 正確性取捨（已與 owner 確認走此方向）

保留 hotfix 的移除＝newest/icymi/recommended pools 的凍結作者 state 過濾維持關閉（快）。頻道/精選/搜尋等其他面的凍結隱藏不受影響（走各自的過濾）。日後若要在這些 pool 補回過濾，需用效能可接受的實作（indexed / 改寫）另案處理。

## 驗證

tsc 0 error、lint 0 error、prettier clean；recommendation/article/spamRing/channel 相關套件本機 132 tests 全綠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)