### PR TITLE
test: guard public feed query shape

### DIFF
--- a/src/connectors/__test__/articleService/articleService.test.ts
+++ b/src/connectors/__test__/articleService/articleService.test.ts
@@ -424,6 +424,12 @@ describe('latestArticles', () => {
     expect(articles[0].authorId).toBeDefined()
     expect(articles[0].state).toBeDefined()
   })
+  test('does not filter author state at request time', () => {
+    const sql = articleService.findNewestArticles().toSQL().sql
+
+    expect(sql).not.toContain('from "user"')
+    expect(sql).not.toContain('"user"."state"')
+  })
   test('spam are excluded', async () => {
     const articles = await articleService.findNewestArticles({
       spamThreshold: 0.5,

--- a/src/connectors/__test__/recommendationService/recommendationService.test.ts
+++ b/src/connectors/__test__/recommendationService/recommendationService.test.ts
@@ -237,6 +237,20 @@ describe('find icymi articles', () => {
     expect(articles).toHaveLength(0)
     expect(totalCount).toBe(0)
   })
+  test('does not filter author state at request time', async () => {
+    const queries: string[] = []
+    const onQuery = ({ sql }: { sql: string }) => {
+      queries.push(sql)
+    }
+    connections.knexRO.on('query', onQuery)
+    try {
+      await recommendationService.findIcymiArticles({})
+    } finally {
+      connections.knexRO.off('query', onQuery)
+    }
+
+    expect(queries.join('\n')).not.toContain('"user"."state"')
+  })
   test('find articles', async () => {
     const topic = await recommendationService.createIcymiTopic({
       title,

--- a/src/connectors/article/articleService.ts
+++ b/src/connectors/article/articleService.ts
@@ -207,6 +207,9 @@ export class ArticleService extends BaseService<Article> {
     excludeExclusiveCampaignArticles?: boolean
     probationDays?: number
   } = {}): Knex.QueryBuilder<Article, Article[]> => {
+    // Keep user state checks out of this request-time public feed query.
+    // Frozen/archived author suppression for discovery surfaces must be
+    // handled by precomputed/cached data, not by joining user state here.
     const query = this.findArticles({
       state: ARTICLE_STATE.active,
       spam: spamThreshold

--- a/src/connectors/recommendationService.ts
+++ b/src/connectors/recommendationService.ts
@@ -894,6 +894,9 @@ export class RecommendationService {
     skip?: number
   }) => {
     const MAX_ITEM_COUNT = DEFAULT_TAKE_PER_PAGE * 50
+    // Keep user state checks out of this request-time public feed query.
+    // Frozen/archived author suppression for ICYMI must be handled before
+    // articles enter matters_choice or by a cache-ahead path.
     // dark-launched discovery probation: `null` while flag is off (zero diff)
     const probationDays = await this.systemService.getDiscoveryProbationDays()
     const records = await this.knexRO


### PR DESCRIPTION
## Summary
- document that public request-time feed queries must not join user state filters
- add regression coverage for newest and ICYMI query shape
- keep runtime behavior unchanged after the production timeout hotfix

## Verification
- npm run build
- npm run testcmd -- build/connectors/__test__/articleService/articleService.test.js build/connectors/__test__/recommendationService/recommendationService.test.js --runInBand --forceExit