### PR TITLE
hotfix: dedupe spam ring digest sends

### DIFF
--- a/.github/workflows/lambda-deploy.yml
+++ b/.github/workflows/lambda-deploy.yml
@@ -575,6 +575,7 @@ jobs:
             cronExpression="cron(0 1 * * ? *)"
 
   deploy-spam-ring-digest:
+    if: inputs.environment == 'production'
     needs: build-lambda-image
     runs-on: ubuntu-latest
     steps:

--- a/src/handlers/__test__/spamRingDigest.test.ts
+++ b/src/handlers/__test__/spamRingDigest.test.ts
@@ -17,9 +17,33 @@ const makeBuilder = (result: unknown) => {
   return qb
 }
 const knexRO = jest.fn((_table: unknown) => makeBuilder(queuedResults.shift()))
+const redisStore = new Map<string, string>()
+const redis = {
+  get: jest.fn(async (key: unknown) => redisStore.get(key as string) ?? null),
+  set: jest.fn(
+    async (
+      key: unknown,
+      value: unknown,
+      _ex?: unknown,
+      _ttl?: unknown,
+      nx?: unknown
+    ) => {
+      const normalizedKey = key as string
+      if (nx === 'NX' && redisStore.has(normalizedKey)) {
+        return null
+      }
+      redisStore.set(normalizedKey, value as string)
+      return 'OK'
+    }
+  ),
+  del: jest.fn(async (key: unknown) => {
+    redisStore.delete(key as string)
+    return 1
+  }),
+}
 
 jest.unstable_mockModule('../../connections.js', () => ({
-  connections: { knexRO },
+  connections: { knexRO, redis },
 }))
 
 // Mock axios BEFORE importing the SUT (ESM rule); the shared telegram
@@ -117,6 +141,7 @@ describe('formatDigest', () => {
 })
 
 describe('handler', () => {
+  const originalEnv = environment.env
   const originalTelegramBotToken = environment.telegramBotToken
   const originalTelegramAlertChatId = environment.telegramAlertChatId
   const originalTelegramAlertThreadId = environment.telegramAlertThreadId
@@ -124,7 +149,12 @@ describe('handler', () => {
   beforeEach(() => {
     axios.post.mockReset()
     knexRO.mockClear()
+    redis.get.mockClear()
+    redis.set.mockClear()
+    redis.del.mockClear()
+    redisStore.clear()
     queuedResults.length = 0
+    ;(environment as { env: string }).env = 'production'
     ;(environment as { telegramBotToken: string }).telegramBotToken = 'tkn'
     ;(environment as { telegramAlertChatId: string }).telegramAlertChatId =
       '-100'
@@ -133,6 +163,8 @@ describe('handler', () => {
   })
 
   afterEach(() => {
+    jest.useRealTimers()
+    ;(environment as { env: string | undefined }).env = originalEnv
     ;(environment as { telegramBotToken: string }).telegramBotToken =
       originalTelegramBotToken
     ;(environment as { telegramAlertChatId: string }).telegramAlertChatId =
@@ -150,7 +182,38 @@ describe('handler', () => {
     expect(axios.post).not.toHaveBeenCalled()
   })
 
+  it('skips in non-production environments', async () => {
+    ;(environment as { env: string }).env = 'development'
+
+    await handler()
+
+    expect(knexRO).not.toHaveBeenCalled()
+    expect(redis.get).not.toHaveBeenCalled()
+    expect(axios.post).not.toHaveBeenCalled()
+  })
+
+  it('skips when the daily digest was already sent', async () => {
+    redisStore.set('spam-ring-digest:sent:2026-07-07', '1')
+    jest.useFakeTimers().setSystemTime(new Date('2026-07-07T01:00:00Z'))
+
+    await handler()
+
+    expect(knexRO).not.toHaveBeenCalled()
+    expect(axios.post).not.toHaveBeenCalled()
+  })
+
+  it('skips when another digest send is in progress', async () => {
+    redisStore.set('spam-ring-digest:lock:2026-07-07', '1')
+    jest.useFakeTimers().setSystemTime(new Date('2026-07-07T01:00:00Z'))
+
+    await handler()
+
+    expect(knexRO).not.toHaveBeenCalled()
+    expect(axios.post).not.toHaveBeenCalled()
+  })
+
   it('collects stats and posts the digest with thread id', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-07-07T01:00:00Z'))
     // query order in collectStats: pending / detected / frozen / top rows
     queuedResults.push({ count: '3' }, { count: '2' }, { count: '1' }, [
       {
@@ -184,5 +247,7 @@ describe('handler', () => {
     expect(text).toContain('<code>abcdef01</code>')
     // pg numeric string is normalized before formatting
     expect(text).toContain('新帳號比 92%')
+    expect(redisStore.get('spam-ring-digest:sent:2026-07-07')).toBe('1')
+    expect(redisStore.has('spam-ring-digest:lock:2026-07-07')).toBe(false)
   })
 })

--- a/src/handlers/spamRingDigest.ts
+++ b/src/handlers/spamRingDigest.ts
@@ -12,6 +12,8 @@ const OSS_RINGS_URL = 'https://oss.matters.town/next/rings'
 const LOOKBACK_MS = 24 * 60 * 60 * 1000
 const TOP_PENDING_LIMIT = 5
 const FINGERPRINT_DISPLAY_LENGTH = 8
+const DEDUPE_TTL_SECONDS = 30 * 60 * 60
+const LOCK_TTL_SECONDS = 10 * 60
 
 export type SpamRingDigestTopRing = {
   fingerprint: string
@@ -86,6 +88,15 @@ export const formatDigest = (stats: SpamRingDigestStats): string => {
 const toCount = (row: unknown): number =>
   Number((row as { count?: string | number } | undefined)?.count ?? 0)
 
+const digestDateKey = (date = new Date()): string =>
+  date.toISOString().slice(0, 10)
+
+const sentKey = (date = new Date()): string =>
+  `spam-ring-digest:sent:${digestDateKey(date)}`
+
+const lockKey = (date = new Date()): string =>
+  `spam-ring-digest:lock:${digestDateKey(date)}`
+
 /** Read-only aggregation over the spam_ring table (replica connection). */
 export const collectStats = async (): Promise<SpamRingDigestStats> => {
   const knexRO = connections.knexRO
@@ -130,6 +141,11 @@ export const collectStats = async (): Promise<SpamRingDigestStats> => {
  * the infra side and is NOT part of this repo.
  */
 export const handler = async (): Promise<void> => {
+  if (environment.env !== 'production') {
+    logger.info('spam-ring-digest: non-production environment; skipped')
+    return
+  }
+
   const botToken = environment.telegramBotToken
   const chatId = environment.telegramAlertChatId
   const threadId = environment.telegramAlertThreadId
@@ -140,16 +156,40 @@ export const handler = async (): Promise<void> => {
     return
   }
 
-  const stats = await collectStats()
-  await sendTelegramMessage({
-    botToken,
-    chatId,
-    threadId,
-    text: formatDigest(stats),
-  })
-  logger.info('spam-ring-digest sent: %j', {
-    pendingTotal: stats.pendingTotal,
-    detectedLast24h: stats.detectedLast24h,
-    frozenLast24h: stats.frozenLast24h,
-  })
+  const redis = connections.redis
+  const now = new Date()
+  const dedupeKey = sentKey(now)
+  const inFlightKey = lockKey(now)
+
+  if (await redis.get(dedupeKey)) {
+    logger.info('spam-ring-digest: already sent for %s; skipped', dedupeKey)
+    return
+  }
+
+  const lock = await redis.set(inFlightKey, '1', 'EX', LOCK_TTL_SECONDS, 'NX')
+  if (lock !== 'OK') {
+    logger.info('spam-ring-digest: send already in progress; skipped')
+    return
+  }
+
+  try {
+    const stats = await collectStats()
+    await sendTelegramMessage({
+      botToken,
+      chatId,
+      threadId,
+      text: formatDigest(stats),
+    })
+    await redis.set(dedupeKey, '1', 'EX', DEDUPE_TTL_SECONDS)
+    logger.info('spam-ring-digest sent: %j', {
+      pendingTotal: stats.pendingTotal,
+      detectedLast24h: stats.detectedLast24h,
+      frozenLast24h: stats.frozenLast24h,
+    })
+  } catch (error) {
+    await redis.del(inFlightKey)
+    throw error
+  }
+
+  await redis.del(inFlightKey)
 }


### PR DESCRIPTION
## Summary

Fix duplicate and inconsistent spam-ring daily Telegram digests observed on 2026-07-07 09:00 Asia/Taipei.

## Root cause

CloudWatch evidence for the 09:00 run:

- production Lambda invoked twice at 01:00 UTC and sent the same stats twice: `pendingTotal=241`, `detectedLast24h=53`, `frozenLast24h=27`
- develop Lambda was also scheduled at the same cron and used the same Telegram alert config, but its DB had no rings, so it sent the all-clear content
- the develop first Telegram request timed out after 5s, then Lambda async retry sent the all-clear at 09:01 Asia/Taipei

Immediate mitigation already applied in AWS:

```bash
aws events disable-rule --region ap-southeast-1 --name spam-ring-digest-develop-CronEvent-4YElRJQIr2Df
# State: DISABLED
```

## Changes

- Skip `spamRingDigest.handler` unless `MATTERS_ENV=production`
- Add Redis daily sent key and in-flight lock so duplicate EventBridge deliveries do not send duplicate Telegram messages
- Deploy `deploy-spam-ring-digest` only for production in `lambda-deploy.yml`
- Add handler tests for non-production skip, already-sent skip, in-flight skip, and successful sent-key cleanup

## Verification

```bash
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/lambda-deploy.yml"); puts "lambda-deploy yaml ok"'
# lambda-deploy yaml ok

MATTERS_ENV=test node --experimental-vm-modules --no-experimental-fetch node_modules/.bin/jest build/handlers/__test__/spamRingDigest.test.js --runInBand
# PASS build/handlers/__test__/spamRingDigest.test.js
# Tests: 9 passed, 9 total
```

Commit hook also completed eslint, tsc, schema generation, codegen, and prettier checks before creating commit `19599e54b`.

Note: an earlier broad `npm test -- --runTestsByPath ...` invocation hit the repo's full test pipeline and failed in unrelated connector DB migrations with Postgres `out of shared memory`. It was stopped and replaced with the targeted handler test above.
