### PR TITLE
fix(feed): keep frozen authors out of newest/icymi via restriction rows

### DIFF
--- a/db/migrations/20260707100000_add_frozen_user_restriction_type.js
+++ b/db/migrations/20260707100000_add_frozen_user_restriction_type.js
@@ -1,0 +1,39 @@
+const table = 'user_restriction'
+const constraint = 'user_restriction_type_check'
+
+// 新增 user_restriction 類型 'frozen':凍結帳號退出 newest/icymi/channels
+// (SPEC-frozen-newest-icymi-recovery)。查詢端沿用已部署的
+// excludeRestrictedAuthors 過濾,不動熱路徑查詢形狀——#4920 的逐 row user
+// 表探測曾在 prod 造成 newest timeout(#4927 回退),本機制是其替代。
+// t.enu() 產生的 CHECK constraint 需重建才能容納新值。
+const TYPES = ['articleHottest', 'articleNewest', 'spamRing', 'frozen']
+
+const setCheck = async (knex, types) => {
+  const list = types.map((t) => `'${t}'`).join(', ')
+  await knex.raw(
+    `ALTER TABLE "${table}" DROP CONSTRAINT IF EXISTS "${constraint}"`
+  )
+  await knex.raw(
+    `ALTER TABLE "${table}" ADD CONSTRAINT "${constraint}" CHECK (type IN (${list}))`
+  )
+}
+
+export const up = async (knex) => {
+  await setCheck(knex, TYPES)
+  // 歷史回填:現存 frozen 用戶各補一筆(一戶一 row,冪等)。
+  // #4926 之後的凍結由 freezeUser 即時寫入,這裡只補存量。
+  await knex.raw(`
+    INSERT INTO "${table}" (user_id, type)
+    SELECT id, 'frozen' FROM "user" WHERE state = 'frozen'
+    ON CONFLICT (user_id, type) DO NOTHING
+  `)
+}
+
+export const down = async (knex) => {
+  // 先清掉 frozen 列,否則收窄 constraint 會失敗
+  await knex(table).where({ type: 'frozen' }).del()
+  await setCheck(
+    knex,
+    TYPES.filter((t) => t !== 'frozen')
+  )
+}

--- a/src/common/enums/oss.ts
+++ b/src/common/enums/oss.ts
@@ -4,6 +4,11 @@ export const USER_RESTRICTION_TYPE = {
   // internal-only: set/removed by spam-ring detection, NOT part of the
   // GraphQL UserRestrictionType enum nor admin-editable via putRestrictedUsers
   spamRing: 'spamRing',
+  // internal-only: written by freezeUser / removed by unfreezeUser, so the
+  // already-deployed user_restriction filters keep frozen authors out of
+  // newest / icymi / channels without touching hot-path query shapes
+  // (SPEC-frozen-newest-icymi-recovery)
+  frozen: 'frozen',
 } as const
 
 // the subset admins manage via putRestrictedUsers / OSS restricted-user list

--- a/src/common/utils/knex.ts
+++ b/src/common/utils/knex.ts
@@ -50,6 +50,9 @@ export const excludeSpam = (
 // `spamRing` is excluded by default alongside `articleNewest`: rows of that
 // type only exist while the spam_ring_restriction flag is on, so default call
 // sites (channels / newest) are zero-diff until the feature launches.
+// `frozen` rows are written by freezeUser / removed by unfreezeUser — this
+// data-path keeps frozen authors out of default call sites without adding
+// any per-row user-table probe (the #4920 approach that timed out on prod).
 export const excludeRestrictedAuthors = (
   builder: Knex.QueryBuilder,
   table = 'article',
@@ -58,6 +61,7 @@ export const excludeRestrictedAuthors = (
     | Array<ValueOf<typeof USER_RESTRICTION_TYPE>> = [
     USER_RESTRICTION_TYPE.articleNewest,
     USER_RESTRICTION_TYPE.spamRing,
+    USER_RESTRICTION_TYPE.frozen,
   ]
 ) => {
   const typeList = Array.isArray(types) ? types : [types]

--- a/src/connectors/__test__/userService.freezeSpam.test.ts
+++ b/src/connectors/__test__/userService.freezeSpam.test.ts
@@ -1,6 +1,11 @@
 import type { Connections } from '#definitions/index.js'
 
-import { USER_STATE } from '#common/enums/index.js'
+import {
+  USER_STATE,
+  USER_RESTRICTION_TYPE,
+  USER_FEATURE_FLAG_TYPE,
+} from '#common/enums/index.js'
+import { ArticleService } from '../article/articleService.js'
 import { AtomService } from '../atomService.js'
 import { UserService } from '../userService.js'
 import { genConnections, closeConnections } from './utils.js'
@@ -143,5 +148,110 @@ describe('freezeUser / unfreezeUser spam marking', () => {
     // unfreeze must not resurrect the false verdict into null
     await userService.unfreezeUser(USER_ID, USER_STATE.active)
     expect((await readSpam()).article).toBe(false)
+  })
+})
+
+describe('freezeUser / unfreezeUser visibility restriction rows', () => {
+  const readRestrictions = async () =>
+    (
+      await atomService.findMany({
+        table: 'user_restriction',
+        where: { userId: USER_ID },
+      })
+    )
+      .map(({ type }) => type)
+      .sort()
+
+  beforeEach(async () => {
+    await atomService.deleteMany({
+      table: 'user_restriction',
+      where: { userId: USER_ID },
+    })
+    await atomService.deleteMany({
+      table: 'user_feature_flag',
+      where: { userId: USER_ID },
+    })
+    await atomService.update({
+      table: 'user',
+      where: { id: USER_ID },
+      data: { state: USER_STATE.active },
+    })
+  })
+
+  test('freeze writes a frozen restriction; unfreeze removes only that type', async () => {
+    // an admin-set restriction must survive the freeze/unfreeze cycle
+    await atomService.create({
+      table: 'user_restriction',
+      data: { userId: USER_ID, type: USER_RESTRICTION_TYPE.articleHottest },
+    })
+
+    await userService.freezeUser(USER_ID)
+    expect(await readRestrictions()).toEqual(
+      [
+        USER_RESTRICTION_TYPE.articleHottest,
+        USER_RESTRICTION_TYPE.frozen,
+      ].sort()
+    )
+
+    // idempotent on re-freeze
+    await userService.freezeUser(USER_ID)
+    expect(await readRestrictions()).toEqual(
+      [
+        USER_RESTRICTION_TYPE.articleHottest,
+        USER_RESTRICTION_TYPE.frozen,
+      ].sort()
+    )
+
+    await userService.unfreezeUser(USER_ID, USER_STATE.active)
+    expect(await readRestrictions()).toEqual([
+      USER_RESTRICTION_TYPE.articleHottest,
+    ])
+  })
+
+  test('freeze drops the bypassSpamDetection whitelist flag', async () => {
+    await atomService.create({
+      table: 'user_feature_flag',
+      data: {
+        userId: USER_ID,
+        type: USER_FEATURE_FLAG_TYPE.bypassSpamDetection,
+      },
+    })
+
+    await userService.freezeUser(USER_ID)
+
+    const flags = await atomService.findMany({
+      table: 'user_feature_flag',
+      where: { userId: USER_ID },
+    })
+    expect(flags).toHaveLength(0)
+  })
+
+  test('frozen author drops out of findNewestArticles and returns on unfreeze', async () => {
+    const articleService = new ArticleService(connections)
+    const article = await atomService.create({
+      table: 'article',
+      data: {
+        authorId: USER_ID,
+        state: 'active',
+        shortHash: 'freezeNewest01',
+        isSpam: false,
+      },
+    })
+
+    const before = await articleService.findNewestArticles()
+    expect(before.map(({ id }) => id)).toContain(article.id)
+
+    await userService.freezeUser(USER_ID)
+    const excluded = await articleService.findNewestArticles()
+    expect(excluded.map(({ id }) => id)).not.toContain(article.id)
+
+    await userService.unfreezeUser(USER_ID, USER_STATE.active)
+    const restored = await articleService.findNewestArticles()
+    expect(restored.map(({ id }) => id)).toContain(article.id)
+
+    await atomService.deleteMany({
+      table: 'article',
+      where: { id: article.id },
+    })
   })
 })

--- a/src/connectors/article/articleService.ts
+++ b/src/connectors/article/articleService.ts
@@ -220,6 +220,7 @@ export class ArticleService extends BaseService<Article> {
       excludeRestrictedAuthors: [
         USER_RESTRICTION_TYPE.articleNewest,
         USER_RESTRICTION_TYPE.spamRing,
+        USER_RESTRICTION_TYPE.frozen,
       ],
       excludeChannelArticles,
       excludeExclusiveCampaignArticles,

--- a/src/connectors/recommendationService.ts
+++ b/src/connectors/recommendationService.ts
@@ -25,7 +25,10 @@ import {
   ActionFailedError,
 } from '#common/errors.js'
 import { getLogger } from '#common/logger.js'
-import { excludeProbationAuthors as excludeProbationModifier } from '#common/utils/index.js'
+import {
+  excludeProbationAuthors as excludeProbationModifier,
+  excludeRestrictedAuthors as excludeRestrictedModifier,
+} from '#common/utils/index.js'
 import { daysToDatetimeRange } from '#common/utils/time.js'
 import { quantile, median } from 'd3-array'
 import keyBy from 'lodash/keyBy.js'
@@ -374,6 +377,7 @@ export class RecommendationService {
                 excludeRestrictedAuthors: [
                   USER_RESTRICTION_TYPE.articleHottest,
                   USER_RESTRICTION_TYPE.spamRing,
+                  USER_RESTRICTION_TYPE.frozen,
                 ],
                 excludeExclusiveCampaignArticles: true,
                 excludeComplaintAreaArticles: true,
@@ -921,6 +925,10 @@ export class RecommendationService {
       )
       .leftJoin('article', 'choice.article_id', 'article.id')
       .where({ state: ARTICLE_STATE.active })
+      // curation happens before an author may get frozen; the restriction-row
+      // anti-join is bounded by the curated window (≤ MAX_ITEM_COUNT rows) —
+      // unlike the per-row user-state probe #4927 had to revert
+      .modify((builder) => excludeRestrictedModifier(builder))
       .modify((builder) => {
         if (probationDays) {
           builder.modify(excludeProbationModifier, probationDays)

--- a/src/connectors/userService.ts
+++ b/src/connectors/userService.ts
@@ -2045,6 +2045,21 @@ export class UserService extends BaseService<User> {
     // Only fills `null` rows — manual is_spam verdicts are kept.
     await this.markUserContentSpam(userId, trx)
 
+    // visibility restriction row: the already-deployed excludeRestrictedAuthors
+    // filter (newest / icymi / channels) picks it up without any hot-path query
+    // change (SPEC-frozen-newest-icymi-recovery). Same connection as the freeze.
+    await (trx ?? this.knex)('user_restriction')
+      .insert({ userId, type: USER_RESTRICTION_TYPE.frozen })
+      .onConflict(['userId', 'type'])
+      .ignore()
+
+    // a frozen account must not keep a spam-detection bypass: the whitelist
+    // overrides is_spam marks in excludeSpam and would leak its content back
+    // into spam-filtered surfaces.
+    await (trx ?? this.knex)('user_feature_flag')
+      .where({ userId, type: USER_FEATURE_FLAG_TYPE.bypassSpamDetection })
+      .del()
+
     const updated = await this.baseUpdate(
       userId,
       remark ? { ...data, remark } : data,
@@ -2089,6 +2104,14 @@ export class UserService extends BaseService<User> {
     { actorId }: { actorId?: string | null } = {}
   ) => {
     await this.revertUserContentSpamMarks(userId, trx)
+
+    // lift the freeze-time visibility restriction (only the `frozen` type —
+    // admin-set articleNewest/articleHottest rows and ring-managed spamRing
+    // rows are intentionally untouched)
+    await (trx ?? this.knex)('user_restriction')
+      .where({ userId, type: USER_RESTRICTION_TYPE.frozen })
+      .del()
+
     const updated = await this.baseUpdate(userId, { state }, undefined, trx)
 
     // best-effort: close the open account-restriction case (appeal accepted /

--- a/src/types/__test__/2/recommendation/icymi.test.ts
+++ b/src/types/__test__/2/recommendation/icymi.test.ts
@@ -6,6 +6,7 @@ import {
   NODE_TYPES,
   MATTERS_CHOICE_TOPIC_STATE,
   LANGUAGE,
+  USER_RESTRICTION_TYPE,
 } from '#common/enums/index.js'
 import { RecommendationService, AtomService } from '#connectors/index.js'
 import { toGlobalId } from '#common/utils/index.js'
@@ -70,6 +71,55 @@ describe('icymi', () => {
     })
     expect(errors).toBeUndefined()
     expect(data.viewer.recommendation.icymi.totalCount).toBeGreaterThan(0)
+  })
+
+  test('articles by restricted (frozen) authors are excluded', async () => {
+    const server = await testClient({ connections })
+    const article = await atomService.findUnique({
+      table: 'article',
+      where: { id: '1' },
+    })
+    await atomService.upsert({
+      table: 'matters_choice',
+      where: { articleId: article.id },
+      create: { articleId: article.id },
+      update: {},
+    })
+
+    // the freeze-time restriction row is what icymi filters on — the
+    // data-path replacement for the reverted per-row user-state probe
+    await atomService.create({
+      table: 'user_restriction',
+      data: { userId: article.authorId, type: USER_RESTRICTION_TYPE.frozen },
+    })
+
+    const { errors, data } = await server.executeOperation({
+      query: GET_VIEWER_RECOMMENDATION_ICYMI,
+      variables: { input: { first: 10 } },
+    })
+    expect(errors).toBeUndefined()
+    const ids = data.viewer.recommendation.icymi.edges.map(
+      ({ node }: { node: { id: string } }) => node.id
+    )
+    expect(ids).not.toContain(
+      toGlobalId({ type: NODE_TYPES.Article, id: article.id })
+    )
+
+    // lifting the restriction restores the curated pick
+    await atomService.deleteMany({
+      table: 'user_restriction',
+      where: { userId: article.authorId, type: USER_RESTRICTION_TYPE.frozen },
+    })
+    const { data: restoredData } = await server.executeOperation({
+      query: GET_VIEWER_RECOMMENDATION_ICYMI,
+      variables: { input: { first: 10 } },
+    })
+    const restoredIds = restoredData.viewer.recommendation.icymi.edges.map(
+      ({ node }: { node: { id: string } }) => node.id
+    )
+    expect(restoredIds).toContain(
+      toGlobalId({ type: NODE_TYPES.Article, id: article.id })
+    )
   })
 })
 


### PR DESCRIPTION
## What

Data-path replacement for the state filters #4927 had to revert (newest timeout on prod). Implements the approved [SPEC-frozen-newest-icymi-recovery](https://github.com/thematters/matters-agent-sop/blob/spec/frozen-newest-icymi-recovery/specs/SPEC-frozen-newest-icymi-recovery.md).

**Principle: no hot-path query-shape changes.** Freezing now writes data the already-deployed filters consume:

- New internal `user_restriction` type **`frozen`** (like `spamRing`: not in the GraphQL enum, not admin-editable). `freezeUser` inserts it, `unfreezeUser` deletes it (admin-set `articleNewest`/`articleHottest` and ring-managed `spamRing` rows untouched). Same connection/transaction as the freeze itself.
- `excludeRestrictedAuthors` (already live on newest/channels — near-empty table, zero-cost anti-join) gains `frozen` in its type lists. The newest query keeps its exact shape; the anti-join IN-list just has one more value.
- **icymi** now applies the same filter — its anti-join is bounded by the curated window (≤ `MAX_ITEM_COUNT` = 500 rows), unlike the per-row `user`-table probe that timed out.
- Hottest MV query also gains `frozen` in its explicit list (offline refresh, belt-and-suspenders on top of #4924's author-state exclusion).
- Migration rebuilds the type CHECK constraint (same pattern as the `spamRing` migration) and **backfills one row per currently-frozen user** — idempotent (`ON CONFLICT DO NOTHING`), exactly reversible (`DELETE WHERE type='frozen'`).
- `freezeUser` also drops the user's `bypassSpamDetection` whitelist flag: the whitelist overrides `is_spam` marks in `excludeSpam` and would leak frozen content back into spam-filtered surfaces.

## Perf gate (per spec §6)

- newest: zero query-shape change — the filter was already running in prod with the restriction table near-empty; this PR only adds rows (hundreds, one per frozen user).
- icymi: bounded anti-join, EXPLAIN available on staging before promote.
- Please watch newest/icymi p95 + slow-query log for 24h after prod deploy; rollback = revert + `DELETE FROM user_restriction WHERE type='frozen'`.

## Tests (all against local real DB, 97 passed across touched suites)

- `userService.freezeSpam.test.ts`: restriction row write/remove (admin rows survive, re-freeze idempotent), whitelist flag dropped, **newest round-trip restored** (the coverage #4927 removed, now asserting the new mechanism)
- `icymi.test.ts`: restored exclusion test via restriction row, plus restore-on-lift
- No regressions: `spamRingRestriction` (shared table), `articleService`, `spamRingService`, `systemServiceAccountRestriction`

🤖 Generated with [Claude Code](https://claude.com/claude-code)