### PR TITLE
fix: purge recommendation tag caches on user state changes

### DIFF
--- a/src/connectors/__test__/articleService/articleService.test.ts
+++ b/src/connectors/__test__/articleService/articleService.test.ts
@@ -424,6 +424,12 @@ describe('latestArticles', () => {
     expect(articles[0].authorId).toBeDefined()
     expect(articles[0].state).toBeDefined()
   })
+  test('does not filter author state at request time', () => {
+    const sql = articleService.findNewestArticles().toSQL().sql
+
+    expect(sql).not.toContain('from "user"')
+    expect(sql).not.toContain('"user"."state"')
+  })
   test('spam are excluded', async () => {
     const articles = await articleService.findNewestArticles({
       spamThreshold: 0.5,

--- a/src/connectors/__test__/recommendationService/recommendationService.test.ts
+++ b/src/connectors/__test__/recommendationService/recommendationService.test.ts
@@ -237,6 +237,20 @@ describe('find icymi articles', () => {
     expect(articles).toHaveLength(0)
     expect(totalCount).toBe(0)
   })
+  test('does not filter author state at request time', async () => {
+    const queries: string[] = []
+    const onQuery = ({ sql }: { sql: string }) => {
+      queries.push(sql)
+    }
+    connections.knexRO.on('query', onQuery)
+    try {
+      await recommendationService.findIcymiArticles({})
+    } finally {
+      connections.knexRO.off('query', onQuery)
+    }
+
+    expect(queries.join('\n')).not.toContain('"user"."state"')
+  })
   test('find articles', async () => {
     const topic = await recommendationService.createIcymiTopic({
       title,

--- a/src/connectors/article/articleService.ts
+++ b/src/connectors/article/articleService.ts
@@ -209,6 +209,9 @@ export class ArticleService extends BaseService<Article> {
     excludeExclusiveCampaignArticles?: boolean
     probationDays?: number
   } = {}): Knex.QueryBuilder<Article, Article[]> => {
+    // Keep user state checks out of this request-time public feed query.
+    // Frozen/archived author suppression for discovery surfaces must be
+    // handled by precomputed/cached data, not by joining user state here.
     const query = this.findArticles({
       state: ARTICLE_STATE.active,
       spam: spamThreshold

--- a/src/connectors/recommendationService.ts
+++ b/src/connectors/recommendationService.ts
@@ -901,6 +901,9 @@ export class RecommendationService {
     skip?: number
   }) => {
     const MAX_ITEM_COUNT = DEFAULT_TAKE_PER_PAGE * 50
+    // Keep user state checks out of this request-time public feed query.
+    // Frozen/archived author suppression for ICYMI must be handled before
+    // articles enter matters_choice or by a cache-ahead path.
     // dark-launched discovery probation: `null` while flag is off (zero diff)
     const probationDays = await this.systemService.getDiscoveryProbationDays()
     const records = await this.knexRO

--- a/src/mutations/user/freezeSpamRing.ts
+++ b/src/mutations/user/freezeSpamRing.ts
@@ -4,7 +4,7 @@ import { ForbiddenError } from '#common/errors.js'
 import { fromGlobalId } from '#common/utils/index.js'
 
 import {
-  invalidateRecommendationAuthorsCache,
+  invalidateRecommendationCaches,
   invalidateUserContentCaches,
 } from './utils.js'
 
@@ -41,7 +41,7 @@ const resolver: GQLMutationResolvers['freezeSpamRing'] = async (
     await invalidateUserContentCaches(user.id, { articleService, redis })
   }
   if (result.frozen.length > 0) {
-    await invalidateRecommendationAuthorsCache({
+    await invalidateRecommendationCaches({
       atomService,
       objectCacheRedis,
     })

--- a/src/mutations/user/unfreezeSpamRing.ts
+++ b/src/mutations/user/unfreezeSpamRing.ts
@@ -4,7 +4,7 @@ import { ForbiddenError } from '#common/errors.js'
 import { fromGlobalId } from '#common/utils/index.js'
 
 import {
-  invalidateRecommendationAuthorsCache,
+  invalidateRecommendationCaches,
   invalidateUserContentCaches,
 } from './utils.js'
 
@@ -38,7 +38,7 @@ const resolver: GQLMutationResolvers['unfreezeSpamRing'] = async (
     await invalidateUserContentCaches(user.id, { articleService, redis })
   }
   if (result.unbanned.length > 0) {
-    await invalidateRecommendationAuthorsCache({
+    await invalidateRecommendationCaches({
       atomService,
       objectCacheRedis,
     })

--- a/src/mutations/user/updateUserState.ts
+++ b/src/mutations/user/updateUserState.ts
@@ -5,7 +5,7 @@ import { ActionFailedError, UserInputError } from '#common/errors.js'
 import { fromGlobalId } from '#common/utils/index.js'
 
 import {
-  invalidateRecommendationAuthorsCache,
+  invalidateRecommendationCaches,
   invalidateUserContentCaches,
 } from './utils.js'
 
@@ -28,7 +28,7 @@ const resolver: GQLMutationResolvers['updateUserState'] = async (
 
   const invalidateUserCaches = async (userId: string) => {
     await invalidateUserContentCaches(userId, { articleService, redis })
-    await invalidateRecommendationAuthorsCache({
+    await invalidateRecommendationCaches({
       atomService,
       objectCacheRedis,
     })

--- a/src/mutations/user/utils.ts
+++ b/src/mutations/user/utils.ts
@@ -27,18 +27,16 @@ export const invalidateUserContentCaches = async (
   }
 }
 
-// the recommended-authors pool (值得追蹤) is cached outside FQC with
-// CACHE_TTL.LONG, one key per channel plus a sitewide one; drop all of them
-// after a state change so a frozen author leaves (or an unfrozen one
-// re-enters) the pool without waiting out the TTL
-export const invalidateRecommendationAuthorsCache = async ({
+// recommendation pools are cached outside FQC with CACHE_TTL.LONG, one key per
+// channel plus a sitewide one; drop all of them after a state change so
+// frozen/restored authors are reflected without waiting out the TTL
+export const invalidateRecommendationCaches = async ({
   atomService,
   objectCacheRedis,
 }: {
   atomService: AtomService
   objectCacheRedis: Redis
 }) => {
-  const cache = new Cache(CACHE_PREFIX.RECOMMENDATION_AUTHORS, objectCacheRedis)
   const channels = await atomService.findMany({
     table: 'topic_channel',
     select: ['id'],
@@ -47,9 +45,21 @@ export const invalidateRecommendationAuthorsCache = async ({
     undefined, // sitewide key
     ...channels.map(({ id }) => id),
   ]
+  const caches = [
+    {
+      cache: new Cache(CACHE_PREFIX.RECOMMENDATION_AUTHORS, objectCacheRedis),
+      type: 'recommendationAuthors',
+    },
+    {
+      cache: new Cache(CACHE_PREFIX.RECOMMENDATION_TAGS, objectCacheRedis),
+      type: 'recommendationTags',
+    },
+  ]
   for (const channelId of channelIds) {
-    await cache.removeObject({
-      keys: { type: 'recommendationAuthors', args: { channelId } },
-    })
+    for (const { cache, type } of caches) {
+      await cache.removeObject({
+        keys: { type, args: { channelId } },
+      })
+    }
   }
 }

--- a/src/types/__test__/2/recommendation/authors.test.ts
+++ b/src/types/__test__/2/recommendation/authors.test.ts
@@ -160,7 +160,7 @@ describe('authors', () => {
     })
   })
 
-  test('freezing a user purges the recommended-authors cache', async () => {
+  test('freezing a user purges recommendation authors and tags caches', async () => {
     const atomService = new AtomService(connections)
     const target = await atomService.findUnique({
       table: 'user',
@@ -171,17 +171,30 @@ describe('authors', () => {
       where: { id: target.id },
       data: { state: USER_STATE.active },
     })
-    const cache = new Cache(
+    const authorsCache = new Cache(
       CACHE_PREFIX.RECOMMENDATION_AUTHORS,
       connections.objectCacheRedis
     )
-    const sitewideKey = cache.genKey({
+    const tagsCache = new Cache(
+      CACHE_PREFIX.RECOMMENDATION_TAGS,
+      connections.objectCacheRedis
+    )
+    const authorsSitewideKey = authorsCache.genKey({
       type: 'recommendationAuthors',
       args: { channelId: undefined },
     })
-    await cache.storeObject({
+    const tagsSitewideKey = tagsCache.genKey({
+      type: 'recommendationTags',
+      args: { channelId: undefined },
+    })
+    await authorsCache.storeObject({
       keys: { type: 'recommendationAuthors', args: { channelId: undefined } },
       data: [{ authorId: target.id }],
+      expire: 60,
+    })
+    await tagsCache.storeObject({
+      keys: { type: 'recommendationTags', args: { channelId: undefined } },
+      data: [{ tagId: '1' }],
       expire: 60,
     })
 
@@ -210,7 +223,10 @@ describe('authors', () => {
       },
     })
     expect(errors).toBeUndefined()
-    expect(await connections.objectCacheRedis.get(sitewideKey)).toBeNull()
+    expect(
+      await connections.objectCacheRedis.get(authorsSitewideKey)
+    ).toBeNull()
+    expect(await connections.objectCacheRedis.get(tagsSitewideKey)).toBeNull()
 
     await atomService.update({
       table: 'user',


### PR DESCRIPTION
## Summary
- #4935 already shipped the core newest/icymi fix via frozen restriction rows, so this PR does not redo that runtime behavior
- backport the public-feed query-shape guard from #4930 into develop to prevent a future develop -> master release from silently dropping it
- clear both recommendation authors and recommendation tags Redis pools after user state changes, including spam-ring freeze/unfreeze paths

## SOP notes
- Branch path: feature branch -> develop
- Service placement: matters-server, because this is core moderation visibility and cache invalidation behavior
- Risk surface: moderation visibility; requires Codecov/CI and security review before production promotion
- Production approval: not requested in this PR

## Verification
- npm run build
- npm run testcmd -- build/types/__test__/2/recommendation/authors.test.js build/connectors/__test__/articleService/articleService.test.js build/connectors/__test__/recommendationService/recommendationService.test.js build/types/__test__/2/recommendation/icymi.test.js build/connectors/__test__/userService.freezeSpam.test.js --runInBand --forceExit

## Related
- #4935 release: frozen authors out of newest/icymi via restriction rows
- #4930 guard: public feed query shape