### PR TITLE
fix(channel): make classification pipeline resilient to backlog and API failure

### DIFF
--- a/deployment/lambda/channeljob.yml
+++ b/deployment/lambda/channeljob.yml
@@ -30,8 +30,13 @@ Resources:
           MATTERS_ENV: !Ref mattersEnv
       Architectures:
         - x86_64
-      MemorySize: 512
-      Timeout: 180
+      # Sized up from 512/180 after the 2026-07 channel-pipeline outage: syncing
+      # a large processing/error backlog parses a big classifier response and
+      # loops per-job, which OOM'd at 512MB and timed out at 180s. The batch cap
+      # (JOB_BATCH_SIZE in channelJobService) bounds each tick; the extra memory
+      # and timeout give headroom while a backlog drains.
+      MemorySize: 1536
+      Timeout: 300
       Role: !GetAtt LambdaRole.Arn
       VpcConfig:
         SecurityGroupIds:

--- a/src/connectors/__test__/channelService/topicChannel.test.ts
+++ b/src/connectors/__test__/channelService/topicChannel.test.ts
@@ -5,6 +5,7 @@ import { AtomService } from '../../atomService.js'
 import { ChannelService } from '../../channel/channelService.js'
 import { genConnections, closeConnections } from '../utils.js'
 import { ARTICLE_CHANNEL_JOB_STATE } from '#common/enums/index.js'
+import { environment } from '#common/environment.js'
 
 import { jest } from '@jest/globals'
 
@@ -396,22 +397,29 @@ describe('channel classifier', () => {
     const articleId = '1'
     await atomService.deleteMany({ table: 'article_channel_job' })
 
-    // classify returns null when the API is unreachable/failed
-    const mockClassifier = { classify: jest.fn(() => null) }
-    // @ts-ignore
-    await channelService._classifyArticlesChannels(
-      [{ id: articleId, title: 'test', content: 'test' }],
-      mockClassifier as any
-    )
+    // simulate a configured API that then fails (classify returns null); error
+    // jobs are only recorded when the API is configured, not when it is unset
+    const originalApiUrl = environment.channelClassificationApiUrl
+    environment.channelClassificationApiUrl = 'http://test-classifier'
+    try {
+      const mockClassifier = { classify: jest.fn(() => null) }
+      // @ts-ignore
+      await channelService._classifyArticlesChannels(
+        [{ id: articleId, title: 'test', content: 'test' }],
+        mockClassifier as any
+      )
 
-    // the article must not be silently dropped: an error job is recorded so
-    // retry-error-jobs can pick it up once the API recovers
-    const jobs = await atomService.findMany({
-      table: 'article_channel_job',
-      where: { articleId },
-    })
-    expect(jobs).toHaveLength(1)
-    expect(jobs[0].state).toBe(ARTICLE_CHANNEL_JOB_STATE.error)
+      // the article must not be silently dropped: an error job is recorded so
+      // retry-error-jobs can pick it up once the API recovers
+      const jobs = await atomService.findMany({
+        table: 'article_channel_job',
+        where: { articleId },
+      })
+      expect(jobs).toHaveLength(1)
+      expect(jobs[0].state).toBe(ARTICLE_CHANNEL_JOB_STATE.error)
+    } finally {
+      environment.channelClassificationApiUrl = originalApiUrl
+    }
   })
 })
 

--- a/src/connectors/__test__/channelService/topicChannel.test.ts
+++ b/src/connectors/__test__/channelService/topicChannel.test.ts
@@ -384,6 +384,28 @@ describe('channel classifier', () => {
     expect(result).toBeDefined()
     expect(result?.[0].state).toBe(ARTICLE_CHANNEL_JOB_STATE.finished)
   })
+
+  test('records a retryable error job when the classification API fails', async () => {
+    const articleId = '1'
+    await atomService.deleteMany({ table: 'article_channel_job' })
+
+    // classify returns null when the API is unreachable/failed
+    const mockClassifier = { classify: jest.fn(() => null) }
+    // @ts-ignore
+    await channelService._classifyArticlesChannels(
+      [{ id: articleId, title: 'test', content: 'test' }],
+      mockClassifier as any
+    )
+
+    // the article must not be silently dropped: an error job is recorded so
+    // retry-error-jobs can pick it up once the API recovers
+    const jobs = await atomService.findMany({
+      table: 'article_channel_job',
+      where: { articleId },
+    })
+    expect(jobs).toHaveLength(1)
+    expect(jobs[0].state).toBe(ARTICLE_CHANNEL_JOB_STATE.error)
+  })
 })
 
 describe('togglePinChannelArticles', () => {

--- a/src/connectors/__test__/channelService/topicChannel.test.ts
+++ b/src/connectors/__test__/channelService/topicChannel.test.ts
@@ -363,6 +363,13 @@ describe('setArticleChannels', () => {
 })
 
 describe('channel classifier', () => {
+  // These tests create article_channel_job rows; clean them up so the FK from
+  // article_channel_job -> article does not block `delete from article` in
+  // other test suites that share the same database.
+  afterEach(async () => {
+    await atomService.deleteMany({ table: 'article_channel_job' })
+  })
+
   test('classify article channels', async () => {
     const articleId = '1'
 

--- a/src/connectors/channel/channelJobService.ts
+++ b/src/connectors/channel/channelJobService.ts
@@ -9,6 +9,13 @@ import { ChannelService } from './channelService.js'
 
 const logger = getLogger('service-channel-job')
 
+// Cap how many jobs a single sync/retry tick pulls and forwards to the
+// classification API. Without a cap a large backlog is sent in one oversized
+// batch that never finishes within the Lambda timeout, so the same backlog is
+// re-sent every tick and never drains (a self-sustaining failure loop). A cap
+// lets each tick chip away at the backlog instead.
+const JOB_BATCH_SIZE = 100
+
 export type JobState =
   (typeof ARTICLE_CHANNEL_JOB_STATE)[keyof typeof ARTICLE_CHANNEL_JOB_STATE]
 
@@ -164,6 +171,8 @@ export class ChannelJobService {
           .as('jobs')
       )
       .where('state', 'processing')
+      .orderBy('created_at', 'asc')
+      .limit(JOB_BATCH_SIZE)
   }
 
   // get latest error job for each article
@@ -182,27 +191,33 @@ export class ChannelJobService {
           .as('jobs')
       )
       .where('state', 'error')
+      .orderBy('created_at', 'asc')
+      .limit(JOB_BATCH_SIZE)
   }
 
   public getRecentJobs = async (
     hours: number
   ): Promise<ArticleChannelJob[]> => {
-    return this.knexRO.select('*').from(
-      this.knexRO
-        .select('*')
-        .distinctOn('article_id')
-        .from('article_channel_job')
-        .where(
-          'created_at',
-          '>',
-          this.knexRO.raw(`CURRENT_TIMESTAMP - interval '${hours} hours'`)
-        )
-        .orderBy([
-          { column: 'article_id', order: 'asc' },
-          { column: 'created_at', order: 'desc' },
-        ])
-        .as('jobs')
-    )
+    return this.knexRO
+      .select('*')
+      .from(
+        this.knexRO
+          .select('*')
+          .distinctOn('article_id')
+          .from('article_channel_job')
+          .where(
+            'created_at',
+            '>',
+            this.knexRO.raw(`CURRENT_TIMESTAMP - interval '${hours} hours'`)
+          )
+          .orderBy([
+            { column: 'article_id', order: 'asc' },
+            { column: 'created_at', order: 'desc' },
+          ])
+          .as('jobs')
+      )
+      .orderBy('created_at', 'asc')
+      .limit(JOB_BATCH_SIZE)
   }
 
   private updateJobState = async (

--- a/src/connectors/channel/channelService.ts
+++ b/src/connectors/channel/channelService.ts
@@ -676,6 +676,12 @@ export class ChannelService {
     const result = await classifier.classify(texts)
 
     if (!result) {
+      // classify() returns null both when the API is unconfigured and when it
+      // fails. If the API isn't configured there was nothing to attempt, so keep
+      // the original quiet no-op (also avoids spurious jobs in tests/dev).
+      if (!environment.channelClassificationApiUrl) {
+        return
+      }
       // The classification API failed for the whole batch. Do NOT drop
       // silently: without a job row these articles are never classified and
       // never retried. Record an error job per article so retry-error-jobs can

--- a/src/connectors/channel/channelService.ts
+++ b/src/connectors/channel/channelService.ts
@@ -55,6 +55,11 @@ import { ChannelClassifier } from './channelClassifier.js'
 
 const logger = getLogger('service-channel')
 
+// Sentinel job_id used when the classification API fails before returning a
+// real job id. Lets us record a retryable error job (article_channel_job
+// requires a non-null job_id and is unique on [article_id, job_id]).
+const CLASSIFICATION_FAILED_JOB_ID = 'classification-failed'
+
 export class ChannelService {
   private connections: Connections
   private models: AtomService
@@ -671,6 +676,26 @@ export class ChannelService {
     const result = await classifier.classify(texts)
 
     if (!result) {
+      // The classification API failed for the whole batch. Do NOT drop
+      // silently: without a job row these articles are never classified and
+      // never retried. Record an error job per article so retry-error-jobs can
+      // pick them up once the API recovers.
+      logger.error(
+        `Channel classification API failed for ${articles.length} article(s); recording error jobs for retry`
+      )
+      await Promise.all(
+        articles.map((article) =>
+          this.models.upsertOnConflict({
+            table: 'article_channel_job',
+            create: {
+              articleId: article.id,
+              jobId: CLASSIFICATION_FAILED_JOB_ID,
+              state: ARTICLE_CHANNEL_JOB_STATE.error,
+            },
+            onConflict: ['articleId', 'jobId'],
+          })
+        )
+      )
       return
     }
 

--- a/src/connectors/userService.ts
+++ b/src/connectors/userService.ts
@@ -1857,11 +1857,19 @@ export class UserService extends BaseService<User> {
       })
       if (articles.length > 0) {
         const publicationService = new PublicationService(this.connections)
-        await Promise.all(
-          articles.map((article) =>
-            publicationService.runPostProcessing(article, false)
+        // Re-run post-processing (which re-classifies channels) in bounded
+        // batches. A prolific author can have thousands of articles; firing
+        // them all at once floods the classification API and can take the
+        // whole pipeline down. Process chunks sequentially to cap concurrency.
+        const reclassifyBatchSize = 20
+        const batches = _.chunk(articles, reclassifyBatchSize)
+        for (const batch of batches) {
+          await Promise.all(
+            batch.map((article) =>
+              publicationService.runPostProcessing(article, false)
+            )
           )
-        )
+        }
       }
     }
   }


### PR DESCRIPTION
## 背景

2026-07 事故：整條「文章 → 主題頻道」AI 分類管線停擺數日（7/2 起各頻道出現文章缺口，調查當下仍在燒）。經 AWS/CloudWatch + 程式追查，這**不是單一 bug**，而是三個結構弱點串成的正回饋死循環。

**觸發**：管理端授予某高產作者 `bypassSpamDetection` 旗標 → `addFeatureFlag` 對其「全部文章」`Promise.all` 同時重跑分類 → 2,383 個並發請求瞬間壓垮分類 API（inferchannel Function URL + FIFO 佇列 + ECS worker）。

**放大成持久故障**：
- 分類 API 過載後每個請求 180s timeout。
- sync Lambda 每分鐘把**全部**卡在 `processing` 的殭屍 job 一次丟給前端查結果，批次太大永遠處理不完 → job 狀態更新不掉 → 每分鐘重來，與新流量無關的自我維持死循環。
- 期間 `classify()` 失敗回 null 被靜默丟棄，連 job record 都沒有 → 那批文章永久漏分類、retry 也碰不到。

## 這個 PR 修什麼

1. **批次上限**（`channelJobService`）：`getProcessingJobs` / `getErrorJobs` / `getRecentJobs` 一律 `orderBy(created_at asc) + limit(JOB_BATCH_SIZE=100)`。每輪只啃一段，backlog 逐步排乾，杜絕大批次死循環。
2. **修 silent-drop**（`channelService._classifyArticlesChannels`）：`classify()` 回 null 時，對每篇文章寫入一筆 `error` job（sentinel `job_id`），讓 `retry-error-jobs` 在 API 恢復後補跑，不再靜默漏掉。
3. **授旗限併發**（`userService.addFeatureFlag`）：授 `bypassSpamDetection` 時的全量 `Promise.all` 改成 `lodash.chunk`（每批 20）循序處理，根除觸發點。
4. **sync Lambda 資源**（`deployment/lambda/channeljob.yml`）：`512→1536MB`、`180→300s`。同步大批結果會解析大 JSON 並逐 job 寫 DB，512MB 實測 OOM；批次上限生效後仍保留餘裕。

## 線上止血（已於 prod 手動套用，本 PR 讓其中可版控的部分固化）

- inferchannel 前端 Lambda `128→1769MB`、`180→300s`（屬 **ModelApiStack**，另一 repo，需另開 PR 固化，否則 CDK 重部署會打回 128MB）。
- sync Lambda `512→1536MB`、`180→300s`（本 PR 的 channeljob.yml 已對齊）。
- 暫時停用 `retry-error` 排程以防殭屍 job 轉 error 後重演過載；**本 PR 部署後可重新啟用**——屆時批次上限已在同一份 image，retry-error 只會每輪拉 100 筆，安全。

**恢復觀察**：套用止血後前端 timeout（180s）→ 22s→5s、錯誤歸零；sync 由持續 timeout → 一次過渡超時 → 160s → 43s、錯誤歸零，backlog 快速收斂。

## 待辦（不在本 PR）

- **ModelApiStack** repo：把 inferchannel 前端記憶體/timeout 固化。
- **回填 7/2–7/4 漏分類文章**：這批文章無 job record，retry 排程碰不到，需用 admin mutation `classifyArticlesChannels(ids)` 控量重跑（需列出該窗口內 `classification.channels IS NULL` 的 articleId）。
- 加 CloudWatch 告警：分類 Lambda 連續失敗要通知（本次壞 5 天無人察覺）。

## 測試

- 新增 silent-drop 測試：`classify()` 回 null 時應寫入 `error` job（`topicChannel.test.ts`）。
- `tsc --noEmit` 0 錯誤、eslint 0、prettier 已套用。
- ⚠️ DB-backed 測試本機無 test DB 未執行，請 CI 驗證。

🤖 Generated with [Claude Code](https://claude.com/claude-code)