### PR TITLE
fix: default spam rings to actionable newest

### DIFF
--- a/docs/specs/spam-ring-oss-defaults-and-merge.md
+++ b/docs/specs/spam-ring-oss-defaults-and-merge.md
@@ -1,0 +1,54 @@
+# Spam Ring OSS Defaults and Merge Refinement
+
+## Problem
+
+Operators use the OSS `集團偵測` page as the default review queue. The queue
+currently surfaces high-score older rings first, keeps rings whose members were
+already handled by other moderation actions, and can split one campaign into
+many small five-member rings when templates differ but the same strong entity is
+shared.
+
+## Users
+
+- OSS operators handling spam-ring review and freeze actions.
+- Trust and safety maintainers monitoring daily digest counts.
+
+## Scope
+
+- `matters-server`: add an actionable filter for `oss.spamRings` and make the
+  unspecified sort default newest first.
+- `matters-oss-next`: make the rings page default to newest pending actionable
+  rings, with a fallback when the server schema has not deployed yet.
+- `spam-detection-scaffold`: merge ring candidates that share conservative
+  strong entities across templates.
+
+## Out of Scope
+
+- No production moderation mutations.
+- No automatic freeze rollout change.
+- No backfill or mutation of existing `spam_ring` rows.
+- No broad redesign of the OSS console.
+
+## Acceptance
+
+- Opening `/next/rings` defaults to pending rings sorted by `detectedAt` desc.
+- The default pending queue excludes rings with no members still eligible for
+  handling.
+- Operators can still disable the local hide-handled toggle to inspect raw
+  pending data.
+- Candidate merge still groups by normalized fingerprint, and additionally
+  groups by invite code, contact id, or external domain.
+- Brand-only matches do not merge across templates.
+
+## Risk
+
+Moderation/admin surface. Security review is required before production
+promotion. The server and OSS changes are read-only query/UI behavior. The
+scaffold change affects future candidate writeback shape, but does not freeze
+accounts by itself.
+
+## Rollback
+
+- Revert the three PRs.
+- If only the server PR rolls back, OSS falls back to local hide-handled filtering
+  because it probes the GraphQL input schema before sending `actionable`.

--- a/schema.graphql
+++ b/schema.graphql
@@ -2751,11 +2751,13 @@ enum SpamRingsSort {
 input OSSSpamRingsInput {
   after: String
   first: Int
-  sort: SpamRingsSort = score
+  sort: SpamRingsSort = detectedAt
   filter: OSSSpamRingsFilter
 }
 
 input OSSSpamRingsFilter {
+  """Only include rings that still have at least one member eligible for handling."""
+  actionable: Boolean
   status: SpamRingStatus
 }
 

--- a/src/common/utils/__test__/spamRingResolvers.test.ts
+++ b/src/common/utils/__test__/spamRingResolvers.test.ts
@@ -286,13 +286,14 @@ describe('spam ring query resolvers', () => {
     const input = {
       first: 20,
       sort: 'nAuthors',
-      filter: { status: 'pending' },
+      filter: { status: 'pending', actionable: true },
     }
 
     await (spamRings as any)(null, { input }, ctx)
 
     expect(ctx.dataSources.spamRingService.findRings).toHaveBeenCalledWith({
       status: 'pending',
+      actionable: true,
     })
     expect(connectionFromQuery).toHaveBeenCalledWith({
       query,
@@ -301,7 +302,7 @@ describe('spam ring query resolvers', () => {
     })
   })
 
-  test('oss.spamRings defaults to score sorting and no status filter', async () => {
+  test('oss.spamRings defaults to detectedAt sorting and no status filter', async () => {
     const query = { __query: 'score-query' }
     const ctx = {
       dataSources: {
@@ -315,11 +316,12 @@ describe('spam ring query resolvers', () => {
 
     expect(ctx.dataSources.spamRingService.findRings).toHaveBeenCalledWith({
       status: undefined,
+      actionable: undefined,
     })
     expect(connectionFromQuery).toHaveBeenCalledWith({
       query,
       args: { first: 10 },
-      orderBy: { column: 'score', order: 'desc' },
+      orderBy: { column: 'detectedAt', order: 'desc' },
     })
   })
 

--- a/src/connectors/__test__/spamRingService.test.ts
+++ b/src/connectors/__test__/spamRingService.test.ts
@@ -528,6 +528,10 @@ const makeImportConnections = ({
     offsets: [] as number[],
     limits: [] as number[],
     orderByCalls: [] as any[],
+    whereExistsCalls: [] as any[],
+    joinCalls: [] as any[],
+    whereRawCalls: [] as any[],
+    whereNotInCalls: [] as any[],
     ringInserts: [] as any[],
     ringUpdates: [] as any[],
     memberInserts: [] as any[],
@@ -569,6 +573,27 @@ const makeImportConnections = ({
         return b
       },
       whereNot: () => b,
+      whereNotIn: (column: string, values: any[]) => {
+        rec.whereNotInCalls.push({ table, column, values })
+        return b
+      },
+      whereExists: (fn: any) => {
+        rec.whereExistsCalls.push({ table })
+        fn.call(b)
+        return b
+      },
+      from: (fromTable: string) => {
+        ctx.table = fromTable
+        return b
+      },
+      join: (...args: any[]) => {
+        rec.joinCalls.push({ table: ctx.table, args })
+        return b
+      },
+      whereRaw: (...args: any[]) => {
+        rec.whereRawCalls.push({ table: ctx.table, args })
+        return b
+      },
       del: () => b,
       select: () => b,
       orderBy: (...args: any[]) => {
@@ -689,6 +714,57 @@ describe('SpamRingService query helpers', () => {
       expect.arrayContaining([
         { table: 'spam_ring_member', args: ['id', 'asc'] },
         { table: 'spam_ring_event', args: ['createdAt', 'desc'] },
+      ])
+    )
+  })
+
+  test('findRings can filter to actionable pending rings', async () => {
+    const { connections, rec } = makeImportConnections({
+      rings: [{ id: 'r1', status: 'pending' }],
+    })
+    const service = new SpamRingService(connections)
+
+    await (service.findRings({
+      status: 'pending',
+      actionable: true,
+    }) as any)
+
+    expect(rec.whereCalls).toEqual(
+      expect.arrayContaining([
+        { table: 'spam_ring', where: { status: 'pending' } },
+      ])
+    )
+    expect(rec.whereExistsCalls).toEqual([{ table: 'spam_ring' }])
+    expect(rec.joinCalls).toEqual(
+      expect.arrayContaining([
+        {
+          table: 'spam_ring_member',
+          args: ['user', 'user.id', 'spam_ring_member.userId'],
+        },
+      ])
+    )
+    expect(rec.whereRawCalls).toEqual(
+      expect.arrayContaining([
+        {
+          table: 'spam_ring_member',
+          args: ['"spam_ring_member"."ring_id" = "spam_ring"."id"'],
+        },
+      ])
+    )
+    expect(rec.whereInCalls).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          column: 'spam_ring_member.status',
+          values: ['pending', 'restored'],
+        }),
+      ])
+    )
+    expect(rec.whereNotInCalls).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          column: 'user.state',
+          values: [USER_STATE.banned, USER_STATE.frozen, USER_STATE.archived],
+        }),
       ])
     )
   })

--- a/src/connectors/spamRingService.ts
+++ b/src/connectors/spamRingService.ts
@@ -99,12 +99,28 @@ export class SpamRingService extends BaseService<SpamRing> {
   // --- 查詢 ---
   public findRings = ({
     status,
+    actionable,
   }: {
     status?: SpamRingStatus
+    actionable?: boolean | null
   }): Knex.QueryBuilder => {
     const query = this.knexRO('spam_ring')
     if (status) {
       query.where({ status })
+    }
+    if (actionable) {
+      query.whereExists(function (this: Knex.QueryBuilder) {
+        this.select(1)
+          .from('spam_ring_member')
+          .join('user', 'user.id', 'spam_ring_member.userId')
+          .whereRaw('"spam_ring_member"."ring_id" = "spam_ring"."id"')
+          .whereIn('spam_ring_member.status', ['pending', 'restored'])
+          .whereNotIn('user.state', [
+            USER_STATE.banned,
+            USER_STATE.frozen,
+            USER_STATE.archived,
+          ])
+      })
     }
     return query
   }

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -3359,6 +3359,8 @@ export type GQLOssSpamDatetimeFilterInput = {
 }
 
 export type GQLOssSpamRingsFilter = {
+  /** Only include rings that still have at least one member eligible for handling. */
+  actionable?: InputMaybe<Scalars['Boolean']['input']>
   status?: InputMaybe<GQLSpamRingStatus>
 }
 

--- a/src/queries/system/oss/spamRings.ts
+++ b/src/queries/system/oss/spamRings.ts
@@ -10,6 +10,7 @@ export const spamRings: GQLOssResolvers['spamRings'] = async (
 ) => {
   const query: Knex.QueryBuilder = spamRingService.findRings({
     status: input?.filter?.status ?? undefined,
+    actionable: input?.filter?.actionable ?? undefined,
   })
 
   let orderBy: { column: string; order: 'asc' | 'desc' }
@@ -24,8 +25,10 @@ export const spamRings: GQLOssResolvers['spamRings'] = async (
       orderBy = { column: 'nAuthors', order: 'desc' }
       break
     case 'score':
-    default:
       orderBy = { column: 'score', order: 'desc' }
+      break
+    default:
+      orderBy = { column: 'detectedAt', order: 'desc' }
       break
   }
 

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -414,12 +414,14 @@ export default /* GraphQL */ `
   input OSSSpamRingsInput {
     after: String
     first: Int @constraint(min: 0)
-    sort: SpamRingsSort = score
+    sort: SpamRingsSort = detectedAt
     filter: OSSSpamRingsFilter
   }
 
   input OSSSpamRingsFilter {
     status: SpamRingStatus
+    "Only include rings that still have at least one member eligible for handling."
+    actionable: Boolean
   }
 
   input UpdateModerationCaseInput {


### PR DESCRIPTION
## Summary
- add SPEC for OSS spam-ring default queue and merge refinement
- add `OSSSpamRingsFilter.actionable` to return only rings with at least one still-handleable member
- default `oss.spamRings` sorting to `detectedAt desc` when sort is omitted

## Verification
- `npm run build`
- `MATTERS_ENV=test node --experimental-vm-modules --no-experimental-fetch node_modules/.bin/jest build/common/utils/__test__/spamRingResolvers.test.js build/connectors/__test__/spamRingService.test.js --runInBand`

## Risk / SOP
- Moderation/admin surface, so security review remains a production promotion gate.
- Read-only GraphQL query behavior; no production mutation and no data backfill.
