### PR TITLE
fix(spam-ring): process new members on frozen rings

### DIFF
--- a/src/connectors/__test__/spamRingService.test.ts
+++ b/src/connectors/__test__/spamRingService.test.ts
@@ -278,12 +278,12 @@ describe('SpamRingService.freezeRing', () => {
     expect(result.skipped.map((s: any) => s.reason)).toEqual(['already frozen'])
   })
 
-  test('idempotent no-op when the ring is already frozen under the lock', async () => {
+  test('idempotent no-op when a frozen ring has no new pending member', async () => {
     // concurrency guard (audit F4): a second freeze that finds the ring already
     // frozen inside the transaction must not re-process members.
     const ring = { id: '1', status: 'frozen', signals: { nearDupRingSize: 1 } }
     const members = [
-      { id: 'm1', userId: 'u1', status: 'pending', bannedByThisRing: false },
+      { id: 'm1', userId: 'u1', status: 'frozen', bannedByThisRing: true },
     ]
     const users: Record<string, any> = {
       u1: {
@@ -305,6 +305,61 @@ describe('SpamRingService.freezeRing', () => {
     expect(userService.freezeUser).not.toHaveBeenCalled()
     expect(result.frozen).toEqual([])
     expect(result.ring.status).toBe('frozen')
+  })
+
+  test('a frozen ring processes only newly appended pending members', async () => {
+    const frozenAt = new Date(Date.now() - DAY)
+    const ring = {
+      id: '1',
+      status: 'frozen',
+      frozenAt,
+      frozenBy: 'original-admin',
+      signals: { nearDupRingSize: 3 },
+    }
+    const members = [
+      { id: 'm1', userId: 'u1', status: 'frozen', bannedByThisRing: true },
+      { id: 'm2', userId: 'u2', status: 'pending', bannedByThisRing: false },
+      { id: 'm3', userId: 'u3', status: 'pending', bannedByThisRing: false },
+    ]
+    const users: Record<string, any> = {
+      u1: {
+        id: 'u1',
+        state: USER_STATE.frozen,
+        createdAt: new Date(Date.now() - DAY),
+      },
+      u2: {
+        id: 'u2',
+        state: USER_STATE.active,
+        createdAt: new Date(Date.now() - DAY),
+      },
+      u3: {
+        id: 'u3',
+        state: USER_STATE.active,
+        createdAt: new Date(Date.now() - DAY),
+      },
+    }
+    const { connections, rec } = makeConnections({ ring, members, users })
+    const service = makeService(connections, users)
+    const userService = makeUserService(users)
+
+    const result = await service.freezeRing({
+      ringId: '1',
+      actorId: 'refresh-job',
+      memberUserIds: ['u2'],
+      userService: userService as any,
+    })
+
+    expect(userService.freezeUser).toHaveBeenCalledTimes(1)
+    expect(userService.freezeUser).toHaveBeenCalledWith(
+      'u2',
+      expect.objectContaining({ actorId: 'refresh-job' })
+    )
+    expect(result.frozen.map((user: any) => user.id)).toEqual(['u2'])
+    expect(rec.memberUpdates.map((update) => update.where.id)).toEqual(['m2'])
+    expect(rec.ringUpdates.at(-1)).not.toHaveProperty('frozenAt')
+    expect(rec.ringUpdates.at(-1)).not.toHaveProperty('frozenBy')
+    const event = rec.eventInserts.find((item) => item.action === 'frozen')
+    expect(JSON.parse(event.detail)).toMatchObject({ refresh: true, frozen: 1 })
   })
 
   test('memberUserIds restricts the freeze to verified members; others are skipped untouched', async () => {

--- a/src/connectors/spamRingService.ts
+++ b/src/connectors/spamRingService.ts
@@ -322,21 +322,41 @@ export class SpamRingService extends BaseService<SpamRing> {
       if (ring.status === 'dismissed') {
         throw new UserInputError('cannot freeze a dismissed ring')
       }
-      if (ring.status === 'frozen') {
-        // 已在鎖內確認凍結 → idempotent no-op（成員早已處理）
-        return ring
-      }
 
       const members = (await this.knex('spam_ring_member')
         .transacting(trx)
         .where({ ringId })
         .orderBy('id', 'asc')) as SpamRingMember[]
+      if (
+        ring.status === 'frozen' &&
+        !members.some(
+          (member) =>
+            member.status === 'pending' &&
+            (!memberScope || memberScope.has(String(member.userId)))
+        )
+      ) {
+        // 已凍結 ring 沒有本輪可處理的新成員，維持完全冪等。
+        return ring
+      }
       // informational only: a high-confidence ring no longer bypasses the
       // old-account / high-karma guard — established accounts always go to
       // human review even in high-confidence rings.
       const highConfidence = isHighConfidenceFreezeRing(ring)
 
       for (const member of members) {
+        if (ring.status === 'frozen' && member.status !== 'pending') {
+          // refresh 只處理 upsert 後新增的 pending 成員，既有 frozen/skipped/restored
+          // 成員不重跑，也不重複寫事件。
+          continue
+        }
+        if (
+          ring.status === 'frozen' &&
+          memberScope &&
+          !memberScope.has(String(member.userId))
+        ) {
+          // 可能是另一層偵測剛加入的成員，留給持有該層驗證名單的 run 處理。
+          continue
+        }
         const user = (await this.knex('user')
           .transacting(trx)
           .forUpdate()
@@ -458,15 +478,19 @@ export class SpamRingService extends BaseService<SpamRing> {
       }
 
       const now = new Date()
+      const ringPatch =
+        ring.status === 'frozen'
+          ? { updatedAt: now }
+          : {
+              status: 'frozen',
+              frozenAt: now,
+              frozenBy: actorId,
+              updatedAt: now,
+            }
       const [ring2] = await this.knex('spam_ring')
         .transacting(trx)
         .where({ id: ringId })
-        .update({
-          status: 'frozen',
-          frozenAt: now,
-          frozenBy: actorId,
-          updatedAt: now,
-        })
+        .update(ringPatch)
         .returning('*')
       await this.insertEvents(
         [
@@ -479,6 +503,7 @@ export class SpamRingService extends BaseService<SpamRing> {
               frozen: frozen.length,
               skipped: skipped.length,
               highConfidence,
+              refresh: ring.status === 'frozen',
             },
           },
         ],


### PR DESCRIPTION
## Summary

- let an already frozen spam ring process members appended by a later detection run
- only process pending members that are inside the current verified member scope
- keep existing frozen, skipped, and restored members untouched
- preserve the original frozenAt and frozenBy values during a refresh
- keep no-new-member retries fully idempotent

## Why

Article and moment detection share normalized fingerprints. One content layer can freeze a ring before the other layer appends its verified members. The old early return left those later members pending forever.

## Verification

- `npm run build`
- `npm run testcmd -- build/connectors/__test__/spamRingService.test.js --runInBand` (16/16)
- ESLint on the two changed TypeScript files
- `git diff --check`

## Release order

Deploy this server change before merging and deploying spam-detection-scaffold PR #30. `AUTO_FREEZE` remains off until the v2 shadow list is manually accepted.