### PR TITLE
Expose spam detector metadata for OSS triage

### DIFF
--- a/docs/specs/topic-channel-spam-visibility.md
+++ b/docs/specs/topic-channel-spam-visibility.md
@@ -1,0 +1,106 @@
+# SPEC: Topic Channel Spam Visibility Controls
+
+| Field | Value |
+| --- | --- |
+| Feature / change name | Topic channel spam visibility controls |
+| Owner | Matters moderation / OSS owner |
+| Drafted by | agent |
+| Risk tier | Full |
+| Date | 2026-07-13 |
+| Status | Approved by thread context |
+
+## 1. Problem & User
+
+Moderators and operators need to explain why spam-like articles remain visible in topic channels such as `性別／愛` and `生活事`. Current production evidence shows the channel threshold is active, but many suspicious articles have spam scores below the topic-channel threshold and therefore remain visible. OSS can see only the score and manual spam label, not the detector's raw decision metadata.
+
+## 2. Goal & Non-Goals
+
+- In scope:
+  - Expose stored spam detector metadata to admin-only `Article.oss.spamStatus`.
+  - Preserve existing public and read-spam-status permissions.
+  - Document the production-only hotfix path for lowering `topic_channel_spam_filter`.
+  - Prepare the data surface needed for pseudo positive and pseudo negative review.
+- Out of scope:
+  - Changing the global `spam_detection` threshold.
+  - Freezing, restricting, or terminating users from this signal.
+  - Replacing the spam model in this PR.
+  - Adding a new OSS page in this PR.
+
+## 3. Success Criteria
+
+| # | Acceptance condition | How verified |
+| --- | --- | --- |
+| 1 | Admin can query `decision`, `reason`, `pSpam`, and `pHam` under `Article.oss.spamStatus`. | GraphQL type test |
+| 2 | Visitors and ordinary users without `readSpamStatus` still cannot read `Article.oss.spamStatus`. | Existing auth tests |
+| 3 | Topic channel visibility behavior is unchanged by this PR. | No change to channel filtering logic |
+| 4 | Production threshold changes remain explicit human-approved operations. | Release notes and runbook |
+
+## 4. Repos & Service Placement
+
+| Work area | Repo | Core / Non-core | Reason |
+| --- | --- | --- | --- |
+| GraphQL admin data surface | `thematters/matters-server` | Core | Article OSS fields and auth live here |
+| Future OSS list UI | `thematters/matters-oss-next` | Core admin UI | Not part of this PR |
+| Future model/dataset feedback | spam dataset / detector repos | Non-core | Model retraining and labels should stay outside `matters-server` |
+
+## 5. Data & Schema
+
+- New tables or columns: none in this PR. `article.decision`, `article.reason`, `article.p_spam`, and `article.p_ham` already exist.
+- New GraphQL fields: `SpamStatus.decision`, `SpamStatus.reason`, `SpamStatus.pSpam`, `SpamStatus.pHam`.
+- Migration or backfill: none.
+
+## 6. Permissions
+
+| Actor | May do | Must NOT do | Enforced by |
+| --- | --- | --- | --- |
+| Admin | Read raw detector metadata through `Article.oss.spamStatus` | Mutate detector metadata through this query | Existing `ArticleOSS.spamStatus` resolver auth plus field `@auth(admin)` |
+| User with `readSpamStatus` | Read existing score and manual spam state | Read raw detector metadata | Field-level `@auth(admin)` on detector metadata |
+| Visitor / ordinary user | No access to `Article.oss.spamStatus` | Read score or detector metadata | Existing resolver `ForbiddenError` |
+
+## 7. Risk Class
+
+| Risk surface | Touched? | Boundary |
+| --- | --- | --- |
+| Payments / payout / wallet | no | None |
+| Moderation / spam / blocklist | yes | Read-only admin metadata exposure |
+| Federation / ActivityPub | no | None |
+| Auth / OAuth / session | no | Existing auth guard preserved |
+| File upload | no | None |
+| Public domain routing | no | None |
+| Account state / permissions | no | No state mutation |
+| Email / notifications | no | None |
+
+Security review is required before production because this touches moderation data.
+
+## 8. Feature-Flag Plan
+
+| Field | Value |
+| --- | --- |
+| State while in progress | Done |
+| Flag name | None for metadata fields |
+| Default state | Existing admin-only GraphQL auth |
+| Back-end guard | Existing `Article.oss.spamStatus` auth plus field `@auth(admin)` |
+| Front-end gating | Not mounted in this PR |
+| Launch trigger | Merge to `develop`, verify on staging, promote with release |
+| Kill-switch | Revert PR or stop selecting fields in OSS |
+
+Production hotfix, if separately approved by the owner: call `setFeature(input: { name: topic_channel_spam_filter, flag: on, value: 0.65 })`. Rollback is `setFeature(input: { name: topic_channel_spam_filter, flag: on, value: 0.8 })`.
+
+## 9. Design Surface
+
+| Field | Value |
+| --- | --- |
+| Any UI? | no |
+| Design handoff spec | not applicable |
+| Design-system conformance | not applicable |
+
+## 10. Rollout & Rollback
+
+- Rollout: merge to `develop`, verify admin GraphQL on staging, then include in the next `develop` to `master` promotion.
+- Rollback: revert PR or avoid selecting the new fields from clients.
+- Monitoring: check GraphQL auth errors, OSS article spam-status queries, and topic-channel pseudo negative samples.
+
+## 11. Open Questions
+
+- Whether to lower production `topic_channel_spam_filter` from `0.8` to `0.65` now requires explicit production mutation approval.
+- The OSS pseudo negative list needs a separate UI/API spec.

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -11868,11 +11868,7 @@ export type GQLSpamStatusResolvers<
   >
   pHam?: Resolver<Maybe<GQLResolversTypes['Float']>, ParentType, ContextType>
   pSpam?: Resolver<Maybe<GQLResolversTypes['Float']>, ParentType, ContextType>
-  reason?: Resolver<
-    Maybe<GQLResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >
+  reason?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>
   score?: Resolver<Maybe<GQLResolversTypes['Float']>, ParentType, ContextType>
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }>

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -4461,8 +4461,16 @@ export type GQLSpamRingsSort = 'detectedAt' | 'frozenAt' | 'nAuthors' | 'score'
 
 export type GQLSpamStatus = {
   __typename?: 'SpamStatus'
+  /** Raw detector decision, if returned by the spam detector. */
+  decision?: Maybe<Scalars['String']['output']>
   /** Whether this work is labeled as spam by human, null for not labeled yet.  */
   isSpam?: Maybe<Scalars['Boolean']['output']>
+  /** Raw detector ham probability, if returned by the spam detector. */
+  pHam?: Maybe<Scalars['Float']['output']>
+  /** Raw detector spam probability, if returned by the spam detector. */
+  pSpam?: Maybe<Scalars['Float']['output']>
+  /** Raw detector reason, if returned by the spam detector. */
+  reason?: Maybe<Scalars['String']['output']>
   /** Spam confident score by machine, null for not checked yet.  */
   score?: Maybe<Scalars['Float']['output']>
 }
@@ -11848,8 +11856,20 @@ export type GQLSpamStatusResolvers<
   ContextType = Context,
   ParentType extends GQLResolversParentTypes['SpamStatus'] = GQLResolversParentTypes['SpamStatus']
 > = ResolversObject<{
+  decision?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
   isSpam?: Resolver<
     Maybe<GQLResolversTypes['Boolean']>,
+    ParentType,
+    ContextType
+  >
+  pHam?: Resolver<Maybe<GQLResolversTypes['Float']>, ParentType, ContextType>
+  pSpam?: Resolver<Maybe<GQLResolversTypes['Float']>, ParentType, ContextType>
+  reason?: Resolver<
+    Maybe<GQLResolversTypes['String']>,
     ParentType,
     ContextType
   >

--- a/src/queries/article/oss.ts
+++ b/src/queries/article/oss.ts
@@ -87,7 +87,7 @@ export const inSearch: GQLArticleOssResolvers['inSearch'] = async (
 }
 
 export const spamStatus: GQLArticleOssResolvers['spamStatus'] = async (
-  { id, spamScore, isSpam },
+  { id, spamScore, isSpam, decision, reason, pSpam, pHam },
   _,
   { viewer, dataSources: { publicationService, userService } }
 ) => {
@@ -112,7 +112,7 @@ export const spamStatus: GQLArticleOssResolvers['spamStatus'] = async (
     publicationService.detectSpam(id)
   }
 
-  return { score: spamScore, isSpam }
+  return { score: spamScore, isSpam, decision, reason, pSpam, pHam }
 }
 
 export const adStatus: GQLArticleOssResolvers['adStatus'] = async ({

--- a/src/types/__test__/1/article/oss.test.ts
+++ b/src/types/__test__/1/article/oss.test.ts
@@ -290,6 +290,10 @@ describe('query article oss', () => {
           spamStatus {
             score
             isSpam
+            decision
+            reason
+            pSpam
+            pHam
           }
         }
       }
@@ -312,6 +316,16 @@ describe('query article oss', () => {
     const article = await atomService.findUnique({
       table: 'article',
       where: { id: '1' },
+    })
+    await atomService.update({
+      table: 'article',
+      where: { id: article.id },
+      data: {
+        decision: 'review',
+        reason: 'commercial solicitation',
+        pSpam: 0.7,
+        pHam: 0.02,
+      },
     })
     const anonymousServer = await testClient({ connections })
     const { errors } = await anonymousServer.executeOperation({
@@ -343,6 +357,10 @@ describe('query article oss', () => {
     expect(data.article.oss.spamStatus).toBeDefined()
     expect(data.article.oss.spamStatus.score).toBeDefined()
     expect(data.article.oss.spamStatus.isSpam).toBeDefined()
+    expect(data.article.oss.spamStatus.decision).toBe('review')
+    expect(data.article.oss.spamStatus.reason).toBe('commercial solicitation')
+    expect(data.article.oss.spamStatus.pSpam).toBe(0.7)
+    expect(data.article.oss.spamStatus.pHam).toBe(0.02)
   })
 
   test('users with readSpamStatus flag can view spam status', async () => {

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -389,6 +389,18 @@ export default /* GraphQL */ `
 
     "Whether this work is labeled as spam by human, null for not labeled yet. "
     isSpam: Boolean
+
+    "Raw detector decision, if returned by the spam detector."
+    decision: String @auth(mode: "${AUTH_MODE.admin}")
+
+    "Raw detector reason, if returned by the spam detector."
+    reason: String @auth(mode: "${AUTH_MODE.admin}")
+
+    "Raw detector spam probability, if returned by the spam detector."
+    pSpam: Float @auth(mode: "${AUTH_MODE.admin}")
+
+    "Raw detector ham probability, if returned by the spam detector."
+    pHam: Float @auth(mode: "${AUTH_MODE.admin}")
   }
 
   type AdStatus {


### PR DESCRIPTION
## Summary

- Expose stored spam detector metadata on `Article.oss.spamStatus` for admin-only OSS triage.
- Keep existing `score` and `isSpam` access for `readSpamStatus` users unchanged.
- Document the approved spec and the separate production-only threshold hotfix path.

## Why

Current production samples from `性別／愛` and `生活事` show the topic-channel threshold is active, but many spam-like articles remain visible because their stored spam detector scores are below the channel threshold. OSS needs the raw detector decision metadata to build pseudo positive and pseudo negative review lists.

## Security

- New raw detector metadata fields use `@auth(admin)`.
- No new mutation or moderation action path is added.
- No change to global spam detection, topic-channel filtering logic, freezing, restriction, reports, or account termination.
- Scoped security review output is saved at `/Users/mashbean/Developer/output/security-audit/matters-server-topic-channel-spam-visibility/run-1/`.

## Validation

- `npm run build`
- `npm run testcmd -- build/types/__test__/1/article/oss.test.js --runInBand --forceExit --no-coverage -t 'query article oss'`
- `git diff --check`
- `node /Users/mashbean/Developer/repos/matters-agent-sop/skills/security-audit/validate-findings.cjs /Users/mashbean/Developer/output/security-audit/matters-server-topic-channel-spam-visibility/run-1/findings.json`

## Production note

This PR does not change production feature flags. Lowering `topic_channel_spam_filter` below `0.8` should be executed as a separate owner-approved production operation.
