### PR TITLE
Fix transparency appeal outcome semantics

### DIFF
--- a/src/connectors/__test__/transparencyService.test.ts
+++ b/src/connectors/__test__/transparencyService.test.ts
@@ -216,6 +216,99 @@ test('exports aggregated transparency metrics without sensitive fields', async (
   expect(receivedCase.id).toBeDefined()
 })
 
+test('excludes proactive reviews from appeal outcomes', async () => {
+  const actionStates = [
+    ['restored', 'none', 'reversed'],
+    ['restored', 'resolved', 'reversed'],
+    ['active', 'none', 'upheld'],
+    ['active', 'resolved', 'upheld'],
+  ] as const
+  const actions = await connections
+    .knex('community_watch_action')
+    .insert(
+      actionStates.map(([actionState, appealState, reviewState], index) => ({
+        uuid: v4(),
+        commentId: String(index + 1),
+        commentType: 'article',
+        targetType: 'article',
+        targetId: '1',
+        reason: 'spam_ad',
+        actorId: '1',
+        commentAuthorId: '2',
+        originalState: 'active',
+        actionState,
+        appealState,
+        reviewState,
+        reviewerId: '1',
+        reviewedAt: new Date(`2026-01-${10 + index}T12:00:00.000+08:00`),
+        createdAt: new Date(`2026-01-${10 + index}T00:00:00.000+08:00`),
+        updatedAt: new Date(`2026-01-${10 + index}T12:00:00.000+08:00`),
+      }))
+    )
+    .returning('*')
+
+  await connections.knex('community_watch_review_event').insert([
+    {
+      uuid: v4(),
+      actionId: actions[0].id,
+      eventType: 'comment_restored',
+      actorId: '1',
+      createdAt: new Date('2026-01-10T12:00:00.000+08:00'),
+    },
+    {
+      uuid: v4(),
+      actionId: actions[1].id,
+      eventType: 'appeal_received',
+      actorId: '2',
+      createdAt: new Date('2026-01-11T06:00:00.000+08:00'),
+    },
+    {
+      uuid: v4(),
+      actionId: actions[1].id,
+      eventType: 'comment_restored',
+      actorId: '1',
+      createdAt: new Date('2026-01-11T12:00:00.000+08:00'),
+    },
+    {
+      uuid: v4(),
+      actionId: actions[2].id,
+      eventType: 'review_upheld',
+      actorId: '1',
+      createdAt: new Date('2026-01-12T12:00:00.000+08:00'),
+    },
+    {
+      uuid: v4(),
+      actionId: actions[3].id,
+      eventType: 'appeal_received',
+      actorId: '2',
+      createdAt: new Date('2026-01-13T06:00:00.000+08:00'),
+    },
+    {
+      uuid: v4(),
+      actionId: actions[3].id,
+      eventType: 'review_upheld',
+      actorId: '1',
+      createdAt: new Date('2026-01-13T12:00:00.000+08:00'),
+    },
+  ])
+
+  const metrics = await service.exportMetrics({
+    start: '2026-01-01',
+    end: '2026-06-30',
+    timezone: 'Asia/Taipei',
+  })
+
+  expect(metrics.appeals).toEqual({
+    total: 2,
+    upheld: 1,
+    reversed: 1,
+    partially_reversed: 0,
+    pending: 0,
+    restored_content: 1,
+  })
+  expect(metrics.community_watch.restored).toBe(2)
+})
+
 test('serializes stable CSV rows with not recorded gaps', async () => {
   const metrics = await service.exportMetrics({
     start: '2026-01-01',

--- a/src/connectors/transparencyService.ts
+++ b/src/connectors/transparencyService.ts
@@ -994,6 +994,31 @@ export class TransparencyService {
   private getAppeals = async (
     period: Period
   ): Promise<TransparencyMetrics['appeals']> => {
+    const moderationCaseOutcomeAfterAppeal = (outcome: string) =>
+      this.periodQuery('moderation_case', period)
+        .where({ outcome })
+        .whereExists(
+          this.knexRO('moderation_event as appeal_event')
+            .select(this.knexRO.raw('1'))
+            .whereRaw('appeal_event.case_id = moderation_case.id')
+            .whereRaw('appeal_event.event_type = ?', ['appealed'])
+        )
+
+    const communityWatchOutcomeAfterAppeal = (eventType: string) =>
+      this.periodQuery('community_watch_review_event', period)
+        .where({ eventType })
+        .whereExists(
+          this.knexRO('community_watch_review_event as appeal_event')
+            .select(this.knexRO.raw('1'))
+            .whereRaw(
+              'appeal_event.action_id = community_watch_review_event.action_id'
+            )
+            .whereRaw('appeal_event.event_type = ?', ['appeal_received'])
+            .whereRaw(
+              'appeal_event.created_at <= community_watch_review_event.created_at'
+            )
+        )
+
     const [
       moderationAppeals,
       communityAppeals,
@@ -1015,29 +1040,11 @@ export class TransparencyService {
           eventType: 'appeal_received',
         })
       ),
-      countRows(
-        this.periodQuery('moderation_case', period).where({ outcome: 'upheld' })
-      ),
-      countRows(
-        this.periodQuery('community_watch_review_event', period).where({
-          eventType: 'review_upheld',
-        })
-      ),
-      countRows(
-        this.periodQuery('moderation_case', period).where({
-          outcome: 'restored',
-        })
-      ),
-      countRows(
-        this.periodQuery('community_watch_review_event', period).where({
-          eventType: 'comment_restored',
-        })
-      ),
-      countRows(
-        this.periodQuery('moderation_case', period).where({
-          outcome: 'partially_restored',
-        })
-      ),
+      countRows(moderationCaseOutcomeAfterAppeal('upheld')),
+      countRows(communityWatchOutcomeAfterAppeal('review_upheld')),
+      countRows(moderationCaseOutcomeAfterAppeal('restored')),
+      countRows(communityWatchOutcomeAfterAppeal('comment_restored')),
+      countRows(moderationCaseOutcomeAfterAppeal('partially_restored')),
       countRows(
         this.periodQuery('moderation_case', period).where({
           status: 'appealed',


### PR DESCRIPTION
## Summary

- count Community Watch upheld and restored outcomes as appeal outcomes only when an appeal was received first
- apply the same appeal-presence requirement to moderation case outcomes
- keep proactive staff restorations in Community Watch restoration metrics without mislabeling them as successful appeals

## Why

The first production H1 export reported zero appeals but three reversed and restored appeal outcomes. Review of the event stream showed those three restorations had no preceding appeal_received event, so they were proactive staff reviews. Publishing them as appeal reversals would misstate the data.

## Verification

- npm run build
- focused transparencyService Jest suite, 5 tests passed
- Prettier check for both changed files
- ESLint check for both changed files

## Scope

No schema, migration, moderation workflow, source event, or public API changes. This only corrects aggregate export classification.