### PR TITLE
release: promote discovery spam filter to production

### DIFF
--- a/db/migrations/20260714000000_add_discovery_spam_filter_feature_flag.js
+++ b/db/migrations/20260714000000_add_discovery_spam_filter_feature_flag.js
@@ -1,0 +1,13 @@
+const table = 'feature_flag'
+const name = 'discovery_spam_filter'
+
+export const up = async (knex) => {
+  await knex(table)
+    .insert({ name, flag: 'on', value: 0.6 })
+    .onConflict('name')
+    .ignore()
+}
+
+export const down = async (knex) => {
+  await knex(table).where({ name }).del()
+}

--- a/db/seeds/31_feature_flag.js
+++ b/db/seeds/31_feature_flag.js
@@ -37,6 +37,11 @@ export const seed = async (knex) => {
       value: 0.5,
     },
     {
+      name: 'discovery_spam_filter',
+      flag: 'on',
+      value: 0.6,
+    },
+    {
       name: 'topic_channel_spam_filter',
       flag: 'on',
       value: 0.8,

--- a/docs/specs/discovery-spam-filter.md
+++ b/docs/specs/discovery-spam-filter.md
@@ -1,0 +1,75 @@
+# Discovery Spam Filter
+
+## Context
+
+Production topic channels and `/newest` can show detector-blocked articles while
+the global `spam_detection` threshold stays at `0.94`. This global threshold is
+also used by moderation and account-safety flows, so lowering it directly would
+change freeze, report, restriction, and account-deletion behavior.
+
+## Decision
+
+Add `discovery_spam_filter` as a discovery-only threshold. The default rollout
+value is `0.6`.
+
+Discovery surfaces include:
+
+- `/newest`
+- topic channel article lists, through the existing `topic_channel_spam_filter`
+- recommendation services that build public discovery modules from newest or
+  hottest article pools
+- tag article and moment feeds
+- related article recommendations
+
+Moderation and account-safety surfaces continue to use `spam_detection`.
+
+## Detector Metadata Gate
+
+For public discovery filtering, non-bypassed and unlabeled articles must pass all
+of these gates:
+
+- `spam_score` is below the active discovery threshold, or `spam_score` is null
+- `decision` is not `block`, or `decision` is null
+- `p_ham` is greater than `0.02`, or `p_ham` is null
+
+Existing overrides stay intact:
+
+- `bypassSpamDetection` authors are allowed through discovery filters
+- manual `is_spam = false` labels are allowed through discovery filters
+- manual `is_spam = true` labels are excluded
+
+## Backfill Query
+
+Use this query to list currently public articles that detector metadata would now
+hide from discovery surfaces, excluding bypassed authors:
+
+```sql
+select
+  a.id,
+  a.short_hash,
+  avn.title,
+  a.author_id,
+  u.user_name,
+  a.spam_score,
+  a.decision,
+  a.p_spam,
+  a.p_ham,
+  a.created_at
+from article a
+join article_version_newest avn on avn.article_id = a.id
+join "user" u on u.id = a.author_id
+where a.state = 'active'
+  and a.is_spam is null
+  and not exists (
+    select 1
+    from user_feature_flag uff
+    where uff.user_id = a.author_id
+      and uff.type = 'bypassSpamDetection'
+  )
+  and (
+    a.decision = 'block'
+    or a.p_ham <= 0.02
+    or a.spam_score >= 0.6
+  )
+order by a.created_at desc;
+```

--- a/docs/specs/topic-channel-spam-threshold-and-detector-audit.md
+++ b/docs/specs/topic-channel-spam-threshold-and-detector-audit.md
@@ -13,6 +13,8 @@
 
 Moderators and readers are seeing a recent surge of spam in `https://matters.town/newest` and topic channels such as `生活事` and `性別／愛`. The current production `spam_detection` threshold is `0.94`, so articles with `spam_score < 0.94` can remain visible or be collected into topic channels even when the content is clearly spam.
 
+Update: `/newest` and other public discovery surfaces are now covered by `docs/specs/discovery-spam-filter.md`; this older spec remains the topic-channel threshold audit record.
+
 The user-visible goal is to reduce spam collected by topic channels with a more aggressive channel-only threshold while keeping account-state and global visibility decisions conservative.
 
 ## 2. Goal & Non-Goals

--- a/schema.graphql
+++ b/schema.graphql
@@ -3022,6 +3022,7 @@ enum FeatureName {
   circle_management
   circle_interact
   spam_detection
+  discovery_spam_filter
   topic_channel_spam_filter
   article_channel
   hottest_moment_feed

--- a/src/common/enums/cache.ts
+++ b/src/common/enums/cache.ts
@@ -34,6 +34,7 @@ export const CACHE_PREFIX = {
   EMAIL_DOMAIL_WHITELIST: 'cache-email-domain-whitelist',
   TAG_COVERS: 'cache-tag-covers',
   SPAM_THRESHOLD: 'cache-spam-threshold',
+  DISCOVERY_SPAM_THRESHOLD: 'cache-discovery-spam-threshold',
   TOPIC_CHANNEL_SPAM_THRESHOLD: 'cache-topic-channel-spam-threshold',
   DISCOVERY_PROBATION_DAYS: 'cache-discovery-probation-days',
   ARTICLE_CHANNEL_THRESHOLD: 'cache-article-channel-threshold',

--- a/src/common/enums/feature.ts
+++ b/src/common/enums/feature.ts
@@ -8,6 +8,7 @@ export const FEATURE_NAME = {
   circle_management: 'circle_management',
   circle_interact: 'circle_interact',
   spam_detection: 'spam_detection',
+  discovery_spam_filter: 'discovery_spam_filter',
   topic_channel_spam_filter: 'topic_channel_spam_filter',
   article_channel: 'article_channel',
   hottest_moment_feed: 'hottest_moment_feed',

--- a/src/common/utils/knex.ts
+++ b/src/common/utils/knex.ts
@@ -7,8 +7,11 @@ import {
   USER_STATE,
 } from '#common/enums/index.js'
 
+const DETECTOR_BLOCK_DECISION = 'block'
+const DETECTOR_HAM_CONFIDENCE_FLOOR = 0.02
+
 /**
- * Exclude spam articles
+ * Exclude spam articles from public discovery surfaces.
  */
 export const excludeSpam = (
   builder: Knex.QueryBuilder,
@@ -28,12 +31,30 @@ export const excludeSpam = (
         .orWhere((qb) => {
           qb.whereNotIn(`${table}.author_id`, whitelistedAuthors).andWhere(
             (whereBuilder) => {
-              // if (`is_spam` is false) or (`is_spam` is null and (`spam_score` is less than the threshold or `spam_score` is null))
+              // Manual non-spam labels stay visible. Unlabeled articles must
+              // pass score, detector decision, and ham-confidence gates.
               whereBuilder
                 .andWhere(`${table}.is_spam`, false)
                 .orWhere((orWhereBuilder) => {
                   orWhereBuilder
                     .whereNull(`${table}.is_spam`)
+                    .andWhere((decisionWhereBuilder) => {
+                      decisionWhereBuilder
+                        .whereNull(`${table}.decision`)
+                        .orWhereNot(
+                          `${table}.decision`,
+                          DETECTOR_BLOCK_DECISION
+                        )
+                    })
+                    .andWhere((pHamWhereBuilder) => {
+                      pHamWhereBuilder
+                        .whereNull(`${table}.p_ham`)
+                        .orWhere(
+                          `${table}.p_ham`,
+                          '>',
+                          DETECTOR_HAM_CONFIDENCE_FLOOR
+                        )
+                    })
                     .andWhere((spamScoreWhereBuilder) => {
                       spamScoreWhereBuilder
                         .where(`${table}.spam_score`, '<', spamThreshold)

--- a/src/common/utils/knex.ts
+++ b/src/common/utils/knex.ts
@@ -19,6 +19,7 @@ export const excludeSpam = (
   table = 'article'
 ) => {
   if (spamThreshold) {
+    const hasDetectorMetadata = table === 'article'
     const knex = builder.client.queryBuilder()
     const whitelistedAuthors = knex
       .select('user_id')
@@ -36,30 +37,34 @@ export const excludeSpam = (
               whereBuilder
                 .andWhere(`${table}.is_spam`, false)
                 .orWhere((orWhereBuilder) => {
-                  orWhereBuilder
-                    .whereNull(`${table}.is_spam`)
-                    .andWhere((decisionWhereBuilder) => {
-                      decisionWhereBuilder
-                        .whereNull(`${table}.decision`)
-                        .orWhereNot(
-                          `${table}.decision`,
-                          DETECTOR_BLOCK_DECISION
-                        )
-                    })
-                    .andWhere((pHamWhereBuilder) => {
-                      pHamWhereBuilder
-                        .whereNull(`${table}.p_ham`)
-                        .orWhere(
-                          `${table}.p_ham`,
-                          '>',
-                          DETECTOR_HAM_CONFIDENCE_FLOOR
-                        )
-                    })
-                    .andWhere((spamScoreWhereBuilder) => {
-                      spamScoreWhereBuilder
-                        .where(`${table}.spam_score`, '<', spamThreshold)
-                        .orWhereNull(`${table}.spam_score`)
-                    })
+                  orWhereBuilder.whereNull(`${table}.is_spam`)
+
+                  if (hasDetectorMetadata) {
+                    orWhereBuilder
+                      .andWhere((decisionWhereBuilder) => {
+                        decisionWhereBuilder
+                          .whereNull(`${table}.decision`)
+                          .orWhereNot(
+                            `${table}.decision`,
+                            DETECTOR_BLOCK_DECISION
+                          )
+                      })
+                      .andWhere((pHamWhereBuilder) => {
+                        pHamWhereBuilder
+                          .whereNull(`${table}.p_ham`)
+                          .orWhere(
+                            `${table}.p_ham`,
+                            '>',
+                            DETECTOR_HAM_CONFIDENCE_FLOOR
+                          )
+                      })
+                  }
+
+                  orWhereBuilder.andWhere((spamScoreWhereBuilder) => {
+                    spamScoreWhereBuilder
+                      .where(`${table}.spam_score`, '<', spamThreshold)
+                      .orWhereNull(`${table}.spam_score`)
+                  })
                 })
             }
           )

--- a/src/connectors/__test__/articleService/articleService.test.ts
+++ b/src/connectors/__test__/articleService/articleService.test.ts
@@ -13,6 +13,7 @@ import {
   PUBLISH_STATE,
   USER_STATE,
   USER_RESTRICTION_TYPE,
+  USER_FEATURE_FLAG_TYPE,
 } from '#common/enums/index.js'
 import { ArticleService } from '../../article/articleService.js'
 import { PublicationService } from '../../article/publicationService.js'
@@ -431,15 +432,26 @@ describe('latestArticles', () => {
     expect(sql).not.toContain('"user"."state"')
   })
   test('spam are excluded', async () => {
-    const articles = await articleService.findNewestArticles({
-      spamThreshold: 0.5,
-    })
     const spamThreshold = 0.5
+    const createdArticles = await Promise.all(
+      ['1', '1', '1', '1', '2'].map((authorId, index) =>
+        publicationService.createArticle({
+          title: `spam filter test ${index}`,
+          content: `spam filter test content ${index}`,
+          authorId,
+        })
+      )
+    )
+    const articles = createdArticles.map(([article]) => article)
+
     // spam flag is on but no detected articles
     const articles1 = await articleService.findNewestArticles({
-      spamThreshold: 0.5,
+      spamThreshold,
     })
-    expect(articles1).toEqual(articles)
+    const articleIds1 = articles1.map(({ id }) => id)
+    for (const article of articles) {
+      expect(articleIds1).toContain(article.id)
+    }
 
     // spam detected
     await atomService.update({
@@ -448,7 +460,7 @@ describe('latestArticles', () => {
       data: { spamScore: spamThreshold + 0.1 },
     })
     const articles2 = await articleService.findNewestArticles({
-      spamThreshold: 0.5,
+      spamThreshold,
     })
     expect(articles2.map(({ id }) => id)).not.toContain(articles[0].id)
 
@@ -459,7 +471,7 @@ describe('latestArticles', () => {
       data: { isSpam: false },
     })
     const articles3 = await articleService.findNewestArticles({
-      spamThreshold: 0.5,
+      spamThreshold,
     })
     expect(articles3.map(({ id }) => id)).toContain(articles[0].id)
 
@@ -470,7 +482,7 @@ describe('latestArticles', () => {
       data: { spamScore: spamThreshold - 0.1 },
     })
     const articles4 = await articleService.findNewestArticles({
-      spamThreshold: 0.5,
+      spamThreshold,
     })
     expect(articles4.map(({ id }) => id)).toContain(articles[1].id)
 
@@ -481,9 +493,78 @@ describe('latestArticles', () => {
       data: { isSpam: true },
     })
     const articles5 = await articleService.findNewestArticles({
-      spamThreshold: 0.5,
+      spamThreshold,
     })
     expect(articles5.map(({ id }) => id)).not.toContain(articles[1].id)
+
+    // detector block decision is excluded even when score is below threshold
+    await atomService.update({
+      table: 'article',
+      where: { id: articles[2].id },
+      data: {
+        isSpam: null,
+        spamScore: spamThreshold - 0.1,
+        decision: 'block',
+        pHam: 0.5,
+      },
+    })
+    const articles6 = await articleService.findNewestArticles({
+      spamThreshold,
+    })
+    expect(articles6.map(({ id }) => id)).not.toContain(articles[2].id)
+
+    // very low ham confidence is excluded even without a block decision
+    await atomService.update({
+      table: 'article',
+      where: { id: articles[3].id },
+      data: {
+        isSpam: null,
+        spamScore: spamThreshold - 0.1,
+        decision: 'review',
+        pHam: 0.02,
+      },
+    })
+    const articles7 = await articleService.findNewestArticles({
+      spamThreshold,
+    })
+    expect(articles7.map(({ id }) => id)).not.toContain(articles[3].id)
+
+    // manual non-spam label still rescues detector false positives
+    await atomService.update({
+      table: 'article',
+      where: { id: articles[2].id },
+      data: { isSpam: false },
+    })
+    const articles8 = await articleService.findNewestArticles({
+      spamThreshold,
+    })
+    expect(articles8.map(({ id }) => id)).toContain(articles[2].id)
+
+    // bypassSpamDetection remains an explicit discovery allowlist
+    await atomService.update({
+      table: 'article',
+      where: { id: articles[4].id },
+      data: {
+        isSpam: null,
+        spamScore: spamThreshold + 0.1,
+        decision: 'block',
+        pHam: 0.01,
+      },
+    })
+    await userService.updateFeatureFlags(articles[4].authorId, [
+      USER_FEATURE_FLAG_TYPE.bypassSpamDetection,
+    ])
+    const articles9 = await articleService.findNewestArticles({
+      spamThreshold,
+    })
+    expect(articles9.map(({ id }) => id)).toContain(articles[4].id)
+    await atomService.deleteMany({
+      table: 'user_feature_flag',
+      where: {
+        userId: articles[4].authorId,
+        type: USER_FEATURE_FLAG_TYPE.bypassSpamDetection,
+      },
+    })
   })
 
   test('channel articles are excluded', async () => {

--- a/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
+++ b/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
@@ -1,6 +1,10 @@
 import type { Connections, Article, TopicChannel } from '#definitions/index.js'
 
-import { FEATURE_FLAG, FEATURE_NAME, USER_STATE } from '#common/enums/index.js'
+import {
+  FEATURE_FLAG,
+  FEATURE_NAME,
+  USER_STATE,
+} from '#common/enums/index.js'
 import { AtomService } from '../../atomService.js'
 import { CampaignService } from '../../campaignService.js'
 import { ChannelService } from '../../channel/channelService.js'
@@ -296,6 +300,38 @@ describe('findTopicChannelArticles', () => {
 
     expect(resultIds).not.toContain(articles[0].id)
     expect(resultIds).toContain(articles[1].id)
+  })
+
+  test('excludes detector block decisions and very low ham confidence', async () => {
+    await systemService.setFeatureFlag({
+      name: FEATURE_NAME.topic_channel_spam_filter,
+      flag: FEATURE_FLAG.on,
+      value: 0.6,
+    })
+
+    await atomService.update({
+      table: 'article',
+      where: { id: articles[0].id },
+      data: { isSpam: null, spamScore: 0.2, decision: 'block', pHam: 0.5 },
+    })
+    await atomService.update({
+      table: 'article',
+      where: { id: articles[1].id },
+      data: { isSpam: null, spamScore: 0.2, decision: 'review', pHam: 0.02 },
+    })
+    await atomService.update({
+      table: 'article',
+      where: { id: articles[2].id },
+      data: { isSpam: null, spamScore: 0.2, decision: 'review', pHam: 0.03 },
+    })
+
+    const { query } = await channelService.findTopicChannelArticles(channel.id)
+    const results = await query
+    const resultIds = results.map((article) => article.id)
+
+    expect(resultIds).not.toContain(articles[0].id)
+    expect(resultIds).not.toContain(articles[1].id)
+    expect(resultIds).toContain(articles[2].id)
   })
 
   describe('datetimeRange filtering', () => {

--- a/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
+++ b/src/connectors/__test__/channelService/findTopicChannelArticles.test.ts
@@ -1,10 +1,6 @@
 import type { Connections, Article, TopicChannel } from '#definitions/index.js'
 
-import {
-  FEATURE_FLAG,
-  FEATURE_NAME,
-  USER_STATE,
-} from '#common/enums/index.js'
+import { FEATURE_FLAG, FEATURE_NAME, USER_STATE } from '#common/enums/index.js'
 import { AtomService } from '../../atomService.js'
 import { CampaignService } from '../../campaignService.js'
 import { ChannelService } from '../../channel/channelService.js'

--- a/src/connectors/__test__/systemService.test.ts
+++ b/src/connectors/__test__/systemService.test.ts
@@ -380,6 +380,26 @@ test('get topic channel spam threshold', async () => {
   expect(threshold).toBe(0.8)
 })
 
+test('get discovery spam threshold', async () => {
+  await systemService.setFeatureFlag({
+    name: FEATURE_NAME.spam_detection,
+    flag: FEATURE_FLAG.on,
+    value: 0.94,
+  })
+  await systemService.setFeatureFlag({
+    name: FEATURE_NAME.discovery_spam_filter,
+    flag: FEATURE_FLAG.on,
+    value: 0.6,
+  })
+  expect(await systemService.getDiscoverySpamThreshold()).toBe(0.6)
+
+  await systemService.setFeatureFlag({
+    name: FEATURE_NAME.discovery_spam_filter,
+    flag: FEATURE_FLAG.off,
+  })
+  expect(await systemService.getDiscoverySpamThreshold()).toBe(0.94)
+})
+
 test('get discovery probation days', async () => {
   // flag off (seed default): null, discovery feeds stay unchanged
   expect(await systemService.getDiscoveryProbationDays()).toBeNull()

--- a/src/connectors/recommendationService.ts
+++ b/src/connectors/recommendationService.ts
@@ -351,7 +351,7 @@ export class RecommendationService {
     const { id: targetTypeId } = await this.systemService.baseFindEntityTypeId(
       'article'
     )
-    const spamThreshold = await this.systemService.getSpamThreshold()
+    const spamThreshold = await this.systemService.getDiscoverySpamThreshold()
     // dark-launched discovery probation: `null` while flag is off (zero diff)
     const probationDays = await this.systemService.getDiscoveryProbationDays()
     const startDate = new Date()
@@ -1053,7 +1053,7 @@ export class RecommendationService {
       ? RECOMMENDATION_TOP_PERCENTILE_CHANNEL_AUTHOR
       : RECOMMENDATION_TOP_PERCENTILE
     const decayFactor = RECOMMENDATION_DECAY_FACTOR
-    const spamThreshold = await this.systemService.getSpamThreshold()
+    const spamThreshold = await this.systemService.getDiscoverySpamThreshold()
     const dateColumn = channelId ? 'channel_article_created_at' : 'created_at'
     let articlesQuery
     if (channelId) {
@@ -1253,7 +1253,7 @@ export class RecommendationService {
       : RECOMMENDATION_DECAY_DAYS
     const percentile = RECOMMENDATION_TOP_PERCENTILE_CHANNEL_TAG
     const decayFactor = RECOMMENDATION_DECAY_FACTOR
-    const spamThreshold = await this.systemService.getSpamThreshold()
+    const spamThreshold = await this.systemService.getDiscoverySpamThreshold()
     const dateColumn = channelId ? 'channel_article_created_at' : 'created_at'
     let articlesQuery
     if (channelId) {

--- a/src/connectors/systemService.ts
+++ b/src/connectors/systemService.ts
@@ -168,6 +168,37 @@ export class SystemService extends BaseService<BaseDBSchema> {
   }
 
   /**
+   * Get the public discovery spam threshold from `feature_flag` table.
+   * Falls back to the global spam threshold so discovery feeds stay compatible
+   * when the dedicated flag is missing or off.
+   */
+  public getDiscoverySpamThreshold = async (): Promise<number | null> => {
+    const cache = new Cache(
+      CACHE_PREFIX.DISCOVERY_SPAM_THRESHOLD,
+      this.connections.objectCacheRedis
+    )
+    const value = (await cache.getObject({
+      keys: { id: 'discovery_spam_threshold' },
+      getter: this._getDiscoverySpamThreshold,
+      expire: isTest ? CACHE_TTL.INSTANT : CACHE_TTL.SHORT,
+    })) as number | null
+    return value
+  }
+  private _getDiscoverySpamThreshold = async (): Promise<number | null> => {
+    const threshold = await this.models.findFirst({
+      table: 'feature_flag',
+      where: {
+        name: FEATURE_NAME.discovery_spam_filter,
+        flag: FEATURE_FLAG.on,
+      },
+    })
+    if (threshold?.value) {
+      return threshold.value
+    }
+    return this._getSpamThreshold()
+  }
+
+  /**
    * Get the topic-channel-only spam threshold from `feature_flag` table.
    */
   public getTopicChannelSpamThreshold = async (): Promise<number | null> => {

--- a/src/definitions/schema.d.ts
+++ b/src/definitions/schema.d.ts
@@ -1894,6 +1894,7 @@ export type GQLFeatureName =
   | 'article_channel'
   | 'circle_interact'
   | 'circle_management'
+  | 'discovery_spam_filter'
   | 'discovery_probation'
   | 'fingerprint'
   | 'hottest_moment_feed'

--- a/src/queries/article/relatedArticles.ts
+++ b/src/queries/article/relatedArticles.ts
@@ -11,7 +11,8 @@ const resolver: GQLArticleResolvers['relatedArticles'] = async (
 ) => {
   // return 3 recommendations by default
   const { take, skip } = fromConnectionArgs(input, { defaultTake: 3 })
-  const spamThreshold = (await systemService.getSpamThreshold()) ?? undefined
+  const spamThreshold =
+    (await systemService.getDiscoverySpamThreshold()) ?? undefined
 
   // buffer for archived article and random draw
   const buffer = 7

--- a/src/queries/article/tag/articles.ts
+++ b/src/queries/article/tag/articles.ts
@@ -8,7 +8,8 @@ const resolver: GQLTagResolvers['articles'] = async (
   { dataSources: { tagService, systemService } }
 ) => {
   const { sortBy } = input
-  const spamThreshold = (await systemService.getSpamThreshold()) ?? undefined
+  const spamThreshold =
+    (await systemService.getDiscoverySpamThreshold()) ?? undefined
   // dark-launched discovery probation: `undefined` while flag is off (zero diff)
   const probationDays =
     (await systemService.getDiscoveryProbationDays()) ?? undefined

--- a/src/queries/article/tag/moments.ts
+++ b/src/queries/article/tag/moments.ts
@@ -7,7 +7,8 @@ const resolver: GQLTagResolvers['moments'] = async (
   { input },
   { dataSources: { tagService, systemService } }
 ) => {
-  const spamThreshold = (await systemService.getSpamThreshold()) ?? undefined
+  const spamThreshold =
+    (await systemService.getDiscoverySpamThreshold()) ?? undefined
   const query = tagService.findMoments({ id, spamThreshold })
 
   return connectionFromQuery({

--- a/src/queries/article/tag/numMoments.ts
+++ b/src/queries/article/tag/numMoments.ts
@@ -5,7 +5,8 @@ const resolver: GQLTagResolvers['numMoments'] = async (
   _,
   { dataSources: { tagService, systemService } }
 ) => {
-  const spamThreshold = (await systemService.getSpamThreshold()) ?? undefined
+  const spamThreshold =
+    (await systemService.getDiscoverySpamThreshold()) ?? undefined
   return tagService.countMoments({ id, spamThreshold })
 }
 

--- a/src/queries/user/recommendation/newest.ts
+++ b/src/queries/user/recommendation/newest.ts
@@ -32,7 +32,7 @@ export const newest: GQLRecommendationResolvers['newest'] = async (
     }
   }
 
-  const spamThreshold = await systemService.getSpamThreshold()
+  const spamThreshold = await systemService.getDiscoverySpamThreshold()
   // dark-launched discovery probation: `null` while flag is off (zero diff)
   const probationDays = await systemService.getDiscoveryProbationDays()
   const query = articleService.findNewestArticles({

--- a/src/types/__test__/1/article/oss.test.ts
+++ b/src/types/__test__/1/article/oss.test.ts
@@ -13,10 +13,12 @@ beforeAll(async () => {
   connections = await genConnections()
   atomService = new AtomService(connections)
   channelService = new ChannelService(connections)
-}, 30000)
+}, 60000)
 
 afterAll(async () => {
-  await closeConnections(connections)
+  if (connections) {
+    await closeConnections(connections)
+  }
 })
 
 describe('query oss articles', () => {

--- a/src/types/__test__/2/recommendation/articles.test.ts
+++ b/src/types/__test__/2/recommendation/articles.test.ts
@@ -12,6 +12,8 @@ import {
   TRANSACTION_STATE,
   DEFAULT_TAKE_PER_PAGE,
   USER_STATE,
+  FEATURE_FLAG,
+  FEATURE_NAME,
 } from '#common/enums/index.js'
 import {
   AtomService,
@@ -345,6 +347,59 @@ describe('user recommendations', () => {
     await knex('user_restriction')
       .where({ userId: '1', type: 'articleNewest' })
       .delete()
+  })
+
+  test('newest uses discovery spam threshold instead of global threshold', async () => {
+    await systemService.setFeatureFlag({
+      name: FEATURE_NAME.spam_detection,
+      flag: FEATURE_FLAG.on,
+      value: 0.94,
+    })
+    await systemService.setFeatureFlag({
+      name: FEATURE_NAME.discovery_spam_filter,
+      flag: FEATURE_FLAG.on,
+      value: 0.6,
+    })
+
+    const [article] = await articleService.findNewestArticles({
+      excludeChannelArticles: true,
+      excludeExclusiveCampaignArticles: true,
+    })
+    const original = await atomService.findUnique({
+      table: 'article',
+      where: { id: article.id },
+    })
+    await atomService.update({
+      table: 'article',
+      where: { id: article.id },
+      data: { isSpam: null, spamScore: 0.7, decision: null, pHam: null },
+    })
+
+    const server = await testClient({
+      isAuth: true,
+      connections,
+    })
+    const { data, errors } = await server.executeOperation({
+      query: GET_VIEWER_RECOMMENDATION('newest'),
+      variables: { first: 20 },
+    })
+    expect(errors).toBeUndefined()
+
+    const ids = data.viewer.recommendation.newest.edges.map(
+      ({ node }: { node: { id: GlobalId } }) => fromGlobalId(node.id).id
+    )
+    expect(ids).not.toContain(article.id)
+
+    await atomService.update({
+      table: 'article',
+      where: { id: article.id },
+      data: {
+        isSpam: original?.isSpam,
+        spamScore: original?.spamScore,
+        decision: original?.decision,
+        pHam: original?.pHam,
+      },
+    })
   })
 
   test('newest respects maxTake limit for regular users', async () => {

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -688,6 +688,7 @@ export default /* GraphQL */ `
     circle_management
     circle_interact
     spam_detection
+    discovery_spam_filter
     topic_channel_spam_filter
     article_channel
     hottest_moment_feed


### PR DESCRIPTION
## Summary
- Promote PR #4948 from develop to production.
- Adds discovery_spam_filter for public discovery surfaces with threshold 0.6.
- Keeps global spam_detection threshold unchanged for moderation actions.

## Staging verification
- Develop deploy succeeded: https://github.com/thematters/matters-server/actions/runs/29342952654
- Staging GraphQL smoke test passed at https://server.matters.icu/graphql.
- Staging feature flags show discovery_spam_filter enabled with value 0.6.
- Production feature flags do not yet include discovery_spam_filter before this promotion.

## Production scope
- Production deploy will run after this PR is merged into master.
- Production migration is expected to add discovery_spam_filter default 0.6.
